### PR TITLE
[FEAT] Entity 설계

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,23 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	//spring boot starter
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	//spring actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	//spring data jpa
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	//lombok
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	//mysql
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	//spring boot starter for testing
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/org/websoso/WSSServer/config/JpaAuditingConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package org.websoso.WSSServer.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -1,0 +1,11 @@
+package org.websoso.WSSServer.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+}

--- a/src/main/java/org/websoso/WSSServer/domain/AttractivePoint.java
+++ b/src/main/java/org/websoso/WSSServer/domain/AttractivePoint.java
@@ -1,0 +1,57 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.websoso.WSSServer.domain.common.Flag;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AttractivePoint {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long attractivePointId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag universe;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag vibe;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag material;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag characters;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag relationship;
+
+    @OneToOne
+    @JoinColumn(name = "user_novel_id", nullable = false)
+    private UserNovel userNovel;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/Avatar.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Avatar.java
@@ -1,7 +1,9 @@
 package org.websoso.WSSServer.domain;
 
+import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -29,6 +31,6 @@ public class Avatar {
     @Column(columnDefinition = "varchar(100)", nullable = false)
     private String avatarImage;
 
-    @OneToMany(mappedBy = "avatar")
+    @OneToMany(mappedBy = "avatar", cascade = ALL)
     private List<AvatarLine> avatarLine = new ArrayList<>();
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Avatar.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Avatar.java
@@ -1,0 +1,34 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Avatar {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Byte avatarId;
+
+    @Column(columnDefinition = "varchar(10)", nullable = false)
+    private String avatarName;
+
+    @Column(columnDefinition = "varchar(100)", nullable = false)
+    private String avatarImage;
+
+    @OneToMany(mappedBy = "avatar")
+    private List<AvatarLine> avatarLine = new ArrayList<>();
+}

--- a/src/main/java/org/websoso/WSSServer/domain/AvatarLine.java
+++ b/src/main/java/org/websoso/WSSServer/domain/AvatarLine.java
@@ -1,0 +1,31 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AvatarLine {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Byte avatarLineId;
+
+    @Column(columnDefinition = "varchar(50)", nullable = false)
+    private String avatarLine;
+
+    @ManyToOne
+    @JoinColumn(name = "avatar_id", nullable = false)
+    private Avatar avatar;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/BasicProfile.java
+++ b/src/main/java/org/websoso/WSSServer/domain/BasicProfile.java
@@ -1,0 +1,31 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BasicProfile {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Byte basicProfileId;
+
+    @Column(columnDefinition = "varchar(10)", nullable = false)
+    private String basicProfileName;
+
+    @Column(columnDefinition = "varchar(50)", nullable = false)
+    private String basicProfileLine;
+
+    @Column(columnDefinition = "varchar(100)", nullable = false)
+    private String basicProfileImage;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/Block.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Block.java
@@ -1,0 +1,28 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Block {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long blockId;
+
+    @Column(nullable = false)
+    private Long blockingId;
+
+    @Column(nullable = false)
+    private Long blockedId;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/Category.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Category.java
@@ -1,0 +1,82 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.websoso.WSSServer.domain.common.Flag;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long categoryId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isRf;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isRo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isFa;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isMf;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isDr;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isLn;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isWu;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isMy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isBl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isEtc;
+
+    @OneToOne
+    @JoinColumn(name = "feed_id", nullable = false)
+    private Feed feed;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/Comment.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Comment.java
@@ -1,0 +1,44 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.websoso.WSSServer.domain.common.BaseEntity;
+import org.websoso.WSSServer.domain.common.Flag;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long commentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isHidden;
+
+    @Column(columnDefinition = "varchar(100)", nullable = false)
+    private String commentContent;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @ManyToOne
+    @JoinColumn(name = "feed_id", nullable = false)
+    private Feed feed;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -1,0 +1,72 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.websoso.WSSServer.domain.common.BaseEntity;
+import org.websoso.WSSServer.domain.common.Flag;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Feed extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long feedId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isHidden;
+
+    @Column(columnDefinition = "varchar(2000)")
+    private String feedContent;
+
+    @Column
+    private Long novelId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isSpoiler;
+
+    @Column(columnDefinition = "int default 0", nullable = false)
+    private Integer likeCount;
+
+    @Column(columnDefinition = "int default 0", nullable = false)
+    private Integer commentCount;
+
+    @Column(columnDefinition = "varchar(1000) default ''", nullable = false)
+    private String likeUsers;
+
+    @OneToOne(mappedBy = "feed", cascade = ALL)
+    private PopularFeed popularFeed;
+
+    @OneToOne(mappedBy = "feed", cascade = ALL)
+    private Category category;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToMany(mappedBy = "feed")
+    private List<Comment> comments = new ArrayList<>();
+}

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -3,6 +3,7 @@ package org.websoso.WSSServer.domain;
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -37,7 +38,7 @@ public class Feed extends BaseEntity {
     @ColumnDefault("'N'")
     private Flag isHidden;
 
-    @Column(columnDefinition = "varchar(2000)")
+    @Column(columnDefinition = "varchar(2000)", nullable = false)
     private String feedContent;
 
     @Column
@@ -67,6 +68,6 @@ public class Feed extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @OneToMany(mappedBy = "feed")
+    @OneToMany(mappedBy = "feed", cascade = ALL)
     private List<Comment> comments = new ArrayList<>();
 }

--- a/src/main/java/org/websoso/WSSServer/domain/GenrePreference.java
+++ b/src/main/java/org/websoso/WSSServer/domain/GenrePreference.java
@@ -1,0 +1,77 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.websoso.WSSServer.domain.common.Flag;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GenrePreference {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long genrePreferenceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag romance;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag romanceFantasy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag fantasy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag modernFantasy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag wuxia;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag boysLove;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag lightNovel;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag mystery;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag drama;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/Keyword.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Keyword.java
@@ -1,0 +1,32 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.websoso.WSSServer.domain.common.KeywordCategory;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Keyword {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long keywordId;
+
+    @Column(nullable = false)
+    private KeywordCategory categoryName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private KeywordCategory keywordName;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/Keyword.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Keyword.java
@@ -28,5 +28,5 @@ public class Keyword {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private KeywordCategory keywordName;
+    private String keywordName;
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Keyword.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Keyword.java
@@ -21,7 +21,7 @@ public class Keyword {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(nullable = false)
-    private Long keywordId;
+    private Integer keywordId;
 
     @Column(nullable = false)
     private KeywordCategory categoryName;

--- a/src/main/java/org/websoso/WSSServer/domain/Notice.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Notice.java
@@ -1,0 +1,32 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.websoso.WSSServer.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long noticeId;
+
+    @Column(columnDefinition = "varchar(200)", nullable = false)
+    private String noticeTitle;
+
+    @Column(columnDefinition = "varchar(2000)", nullable = false)
+    private String noticeContent;
+
+    @Column
+    private Long userId;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Novel.java
@@ -1,0 +1,64 @@
+package org.websoso.WSSServer.domain;
+
+
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.websoso.WSSServer.domain.common.Flag;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Novel {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long novelId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String author;
+
+    @Column(columnDefinition = "varchar(5)", nullable = false)
+    private String genre;
+
+    @Column(columnDefinition = "text", nullable = false)
+    private String novelImage;
+
+    @Column(columnDefinition = "text", nullable = false)
+    private String novelDescription;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Flag isCompleted;
+
+    @Column(columnDefinition = "int default 0", nullable = false)
+    private Long novelRatingCount;
+
+    @Column(columnDefinition = "float default 0.0", nullable = false)
+    private Float novelRatingSum;
+
+    @OneToOne(mappedBy = "novel", cascade = ALL)
+    private NovelStatistics novelStatistics;
+
+    @OneToMany(mappedBy = "novel")
+    private List<UserNovel> userNovels = new ArrayList<>();
+
+    @OneToMany(mappedBy = "novel")
+    private List<Platform> platforms = new ArrayList<>();
+}

--- a/src/main/java/org/websoso/WSSServer/domain/NovelKeywords.java
+++ b/src/main/java/org/websoso/WSSServer/domain/NovelKeywords.java
@@ -1,0 +1,31 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NovelKeywords {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long novelKeywordId;
+
+    @Column(nullable = false)
+    private Long novelId;
+
+    @Column(nullable = false)
+    private Integer keywordId;
+
+    @Column
+    private Long userId;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/NovelStatistics.java
+++ b/src/main/java/org/websoso/WSSServer/domain/NovelStatistics.java
@@ -1,0 +1,58 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NovelStatistics {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long novelStatisticsId;
+
+    @Column(columnDefinition = "int default 0", nullable = false)
+    private Integer novelFeedCount;
+
+    @Column(columnDefinition = "int default 0", nullable = false)
+    private Integer watchingCount;
+
+    @Column(columnDefinition = "int default 0", nullable = false)
+    private Integer interestCount;
+
+    @Column(columnDefinition = "int default 0", nullable = false)
+    private Integer watchedCount;
+
+    @Column(columnDefinition = "int default 0", nullable = false)
+    private Integer quitCount;
+
+    @Column(columnDefinition = "int default 0", nullable = false)
+    private Integer universeCount;
+
+    @Column(columnDefinition = "int default 0", nullable = false)
+    private Integer vibeCount;
+
+    @Column(columnDefinition = "int default 0", nullable = false)
+    private Integer materialCount;
+
+    @Column(columnDefinition = "int default 0", nullable = false)
+    private Integer charactersCount;
+
+    @Column(columnDefinition = "int default 0", nullable = false)
+    private Integer relationshipCount;
+
+    @OneToOne
+    @JoinColumn(name = "novel_id", nullable = false)
+    private Novel novel;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/Platform.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Platform.java
@@ -1,0 +1,33 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Platform {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long platformId;
+
+    @Column(columnDefinition = "varchar(10)", nullable = false)
+    private String platformName;
+
+    @Column(nullable = false)
+    private String platformUrl;
+
+    @ManyToOne
+    @JoinColumn(name = "novel_id", nullable = false)
+    private Novel novel;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/PopularFeed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/PopularFeed.java
@@ -1,0 +1,28 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PopularFeed {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long popularFeedId;
+
+    @OneToOne
+    @JoinColumn(name = "feed_id", nullable = false)
+    private Feed feed;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/RecentUserNovel.java
+++ b/src/main/java/org/websoso/WSSServer/domain/RecentUserNovel.java
@@ -1,0 +1,26 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.websoso.WSSServer.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecentUserNovel extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long recentUserNovelId;
+
+    @Column(nullable = false)
+    private Long novelId;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/ReportedComment.java
+++ b/src/main/java/org/websoso/WSSServer/domain/ReportedComment.java
@@ -1,0 +1,31 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportedComment {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long reportedCommentId;
+
+    @Column(nullable = false)
+    private Long commentId;
+
+    @Column(columnDefinition = "tinyint default 0", nullable = false)
+    private Byte spoilerCount;
+
+    @Column(columnDefinition = "tinyint default 0", nullable = false)
+    private Byte impertinenceCount;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/ReportedFeed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/ReportedFeed.java
@@ -1,0 +1,31 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportedFeed {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long reportedFeedId;
+
+    @Column(nullable = false)
+    private Long feedId;
+
+    @Column(columnDefinition = "tinyint default 0", nullable = false)
+    private Byte spoilerCount;
+
+    @Column(columnDefinition = "tinyint default 0", nullable = false)
+    private Byte impertinenceCount;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -1,0 +1,71 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.CascadeType.ALL;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import java.time.Year;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.websoso.WSSServer.domain.common.Flag;
+import org.websoso.WSSServer.domain.common.Gender;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(unique = true, columnDefinition = "varchar(10)", nullable = false)
+    private String nickname;
+    //TODO 일부 특수문자 제외, 앞뒤 공백 불가능
+
+    @Column(columnDefinition = "varchar(60) default '안녕하세요'", nullable = false)
+    private String intro;
+
+    @Column(columnDefinition = "varchar(320)", nullable = false)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Gender gender;
+
+    @Column(nullable = false)
+    private Year birth;
+    //TODO 유효성 체크
+
+    @Column(columnDefinition = "tinyint default 1", nullable = false)
+    private Byte avatarId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'Y'")
+    private Flag isProfilePublic;
+
+    @OneToOne(mappedBy = "user", cascade = ALL)
+    private GenrePreference genrePreference;
+
+    @OneToOne(mappedBy = "user", cascade = ALL)
+    private UserStatistics userStatistics;
+
+    @OneToMany(mappedBy = "user")
+    private List<Feed> feeds = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<UserNovel> userNovels = new ArrayList<>();
+}

--- a/src/main/java/org/websoso/WSSServer/domain/UserNovel.java
+++ b/src/main/java/org/websoso/WSSServer/domain/UserNovel.java
@@ -1,0 +1,62 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.websoso.WSSServer.domain.common.BaseEntity;
+import org.websoso.WSSServer.domain.common.Flag;
+import org.websoso.WSSServer.domain.common.ReadStatus;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserNovel extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long userNovelId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'N'")
+    private Flag isInterest;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReadStatus status;
+
+    @Column(nullable = false, columnDefinition = "float default 0.0")
+    private Float userNovelRating;
+
+    @Column
+    private LocalDate startDate;
+
+    @Column
+    private LocalDate endDate;
+
+    @OneToOne(mappedBy = "userNovel", cascade = ALL)
+    private AttractivePoint attractivePoint;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "novel_id", nullable = false)
+    private Novel novel;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/UserNovel.java
+++ b/src/main/java/org/websoso/WSSServer/domain/UserNovel.java
@@ -37,7 +37,7 @@ public class UserNovel extends BaseEntity {
     private Flag isInterest;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column
     private ReadStatus status;
 
     @Column(nullable = false, columnDefinition = "float default 0.0")

--- a/src/main/java/org/websoso/WSSServer/domain/UserStatistics.java
+++ b/src/main/java/org/websoso/WSSServer/domain/UserStatistics.java
@@ -1,0 +1,94 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserStatistics {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long userStatisticsId;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private Integer watchingNovelCount;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private Integer interestNovelCount;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private Integer watchedNovelCount;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private Integer quitNovelCount;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private Integer roNovelNovelCount;
+
+    @Column(nullable = false, columnDefinition = "float default 0.0")
+    private Float roNovelRatingSum;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private Integer rfNovelNovelCount;
+
+    @Column(nullable = false, columnDefinition = "float default 0.0")
+    private Float rfNovelRatingSum;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private Integer blNovelNovelCount;
+
+    @Column(nullable = false, columnDefinition = "float default 0.0")
+    private Float blNovelRatingSum;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private Integer faNovelNovelCount;
+
+    @Column(nullable = false, columnDefinition = "float default 0.0")
+    private Float faNovelRatingSum;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private Integer mfNovelNovelCount;
+
+    @Column(nullable = false, columnDefinition = "float default 0.0")
+    private Float mfNovelRatingSum;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private Integer wuNovelNovelCount;
+
+    @Column(nullable = false, columnDefinition = "float default 0.0")
+    private Float wuNovelRatingSum;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private Integer lnNovelNovelCount;
+
+    @Column(nullable = false, columnDefinition = "float default 0.0")
+    private Float lnNovelRatingSum;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private Integer drNovelNovelCount;
+
+    @Column(nullable = false, columnDefinition = "float default 0.0")
+    private Float drNovelRatingSum;
+
+    @Column(nullable = false, columnDefinition = "int default 0")
+    private Integer myNovelNovelCount;
+
+    @Column(nullable = false, columnDefinition = "float default 0.0")
+    private Float myNovelRatingSum;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/common/BaseEntity.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/BaseEntity.java
@@ -1,0 +1,43 @@
+package org.websoso.WSSServer.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false)
+    protected String createdDate;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected String modifiedDate;
+
+    @PrePersist
+    public void onPrePersist() {
+        String formattedDateTime = LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd a hh:mm").withLocale(Locale.forLanguageTag("ko")));
+
+        this.createdDate = formattedDateTime;
+        this.modifiedDate = formattedDateTime;
+    }
+
+    @PreUpdate
+    public void onPreUpdate() {
+        this.modifiedDate = LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd a hh:mm").withLocale(Locale.forLanguageTag("ko")));
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/domain/common/Flag.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/Flag.java
@@ -1,0 +1,6 @@
+package org.websoso.WSSServer.domain.common;
+
+
+public enum Flag {
+    Y, N
+}

--- a/src/main/java/org/websoso/WSSServer/domain/common/Gender.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/Gender.java
@@ -1,0 +1,5 @@
+package org.websoso.WSSServer.domain.common;
+
+public enum Gender {
+    M, F
+}

--- a/src/main/java/org/websoso/WSSServer/domain/common/KeywordCategory.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/KeywordCategory.java
@@ -1,0 +1,8 @@
+package org.websoso.WSSServer.domain.common;
+
+import lombok.Getter;
+
+@Getter
+public enum KeywordCategory {
+    WORLDVIEW, MATERIAL, CHARACTER, RELATIONSHIP, VIBE
+}

--- a/src/main/java/org/websoso/WSSServer/domain/common/ReadStatus.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/ReadStatus.java
@@ -1,0 +1,5 @@
+package org.websoso.WSSServer.domain.common;
+
+public enum ReadStatus {
+    WATCHING, WATCHED, QUIT
+}

--- a/src/main/java/org/websoso/WSSServer/repository/UserRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package org.websoso.WSSServer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -1,0 +1,10 @@
+package org.websoso.WSSServer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#1 -> dev
- close #1 

## Key Changes
<!-- 최대한 자세히 -->
- 기존 ERD에서 `CHAR(1)`로 사용하기로 했던 필드들을 `ENUM`으로 설정했습니다. 여러 부분에서 같은 의미로 사용되는 flag들에 대해 굳이 String으로 처리하기보다는 type-safe하고 가독성이 좋은 ENUM을 사용하는 것이 낫다고 판단했습니다..! 또 ENUM은 불변 객체로 캐싱하여 사용할 수 있어서 메모리를 절약하고 성능 면에서 이점이 있다고 판단했습니다.
- package 컨벤션 명시를 위해 User 도메인의 controller, service, repository의 간단한 틀 넣어놨습니다.
- `CASCADE` 옵션의 경우 `완전 개인 소유`인 경우에만 적용했습니다. (레퍼런스 참고 바람, ex. User - UserStatistics)

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 연결된 Issue 내용과 다르게 health check 위해서 actuator 추가했습니다. actuator 관련 도움됐던 링크 레퍼런스에 추가해뒀습니다. 최소한의 보안대책을 반영한 yaml도 노션에 업로드해두었습니다.
- ERD에서 정해진 것과 살짝 달라진 부분이 있는데 확인 바랍니다. (`CHAR(1) -> Enum`)
- 신경 쓴다고 노력했는데, 빠진 필드나 데이터 타입, default value, nullable 여부 누락, 연관관계 매핑 등등 꼼꼼히 크로스 체크해주시면 감사하겠습니다.
- ENUM으로 사용, DDL이 날라갈 때 default value를 설정하는 방법을 몰라서 오래 헤멨는데, `@ColumnDefault`옵션을 통해 해결했습니다.
- 추후 ENUM에서 변경 사항 발생 시, persist할 수 있는 converter에 대해 알게 되어서 레퍼런스에 추가해뒀습니다. 우형 테크 블로그에서도 converter 적용한 내용 있어서 같이 추가해뒀습니다.


## References
<!-- 참고한 자료-->
- https://techblog.woowahan.com/9232/
- https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints.enabling
- https://www.inflearn.com/questions/681929/일대다-단방향은-무조건-피해야-하나요
- https://www.inflearn.com/questions/31969/cascade-옵션-질문
- https://www.baeldung.com/jpa-persisting-enums-in-jpa
- https://techblog.woowahan.com/2600/