### PR TITLE
[FEAT] 닉네임 중복 확인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	//spring data jpa
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	// spring boot bean validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	//lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -1,27 +1,19 @@
 package org.websoso.WSSServer.controller;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.OK;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.dto.User.NicknameValidation;
-import org.websoso.WSSServer.exception.common.ErrorResult;
-import org.websoso.WSSServer.exception.user.UserErrorCode;
-import org.websoso.WSSServer.exception.user.exception.InvalidNicknameException;
 import org.websoso.WSSServer.service.UserService;
 import org.websoso.WSSServer.validation.NicknameConstraint;
 
-@Slf4j
 @RestController
 @RequestMapping("/users")
 @Validated
@@ -43,13 +35,5 @@ public class UserController {
         return ResponseEntity
                 .status(OK)
                 .body(nicknameValidation);
-    }
-
-    @ResponseStatus(BAD_REQUEST)
-    @ExceptionHandler(InvalidNicknameException.class)
-    public ErrorResult InvalidNicknameExceptionHandler(InvalidNicknameException e) {
-        log.error("[InvalidNicknameException] exception ", e);
-        UserErrorCode userErrorCode = e.getUserErrorCode();
-        return new ErrorResult(userErrorCode.getCode(), userErrorCode.getDescription());
     }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -1,19 +1,30 @@
 package org.websoso.WSSServer.controller;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.OK;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.dto.User.NicknameValidation;
+import org.websoso.WSSServer.exception.common.ErrorResult;
+import org.websoso.WSSServer.exception.user.UserErrorCode;
+import org.websoso.WSSServer.exception.user.exception.InvalidNicknameException;
 import org.websoso.WSSServer.service.UserService;
+import org.websoso.WSSServer.validation.NicknameConstraint;
 
+@Slf4j
 @RestController
 @RequestMapping("/users")
+@Validated
 @RequiredArgsConstructor
 public class UserController {
 
@@ -21,7 +32,8 @@ public class UserController {
 
     @GetMapping("/nickname/check")
     public ResponseEntity<NicknameValidation> checkNicknameAvailability(
-            @RequestParam("nickname") String nickname) {
+            @RequestParam("nickname")
+            @NicknameConstraint String nickname) {
         NicknameValidation nicknameValidation = userService.isNicknameAvailable(nickname);
         if (nicknameValidation.isDuplicated()) {
             return ResponseEntity
@@ -31,5 +43,13 @@ public class UserController {
         return ResponseEntity
                 .status(OK)
                 .body(nicknameValidation);
+    }
+
+    @ResponseStatus(BAD_REQUEST)
+    @ExceptionHandler(InvalidNicknameException.class)
+    public ErrorResult InvalidNicknameExceptionHandler(InvalidNicknameException e) {
+        log.error("[InvalidNicknameException] exception ", e);
+        UserErrorCode userErrorCode = e.getUserErrorCode();
+        return new ErrorResult(userErrorCode.getCode(), userErrorCode.getDescription());
     }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -1,11 +1,35 @@
 package org.websoso.WSSServer.controller;
 
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.OK;
+
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.websoso.WSSServer.dto.User.NicknameValidation;
+import org.websoso.WSSServer.service.UserService;
 
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/nickname/check")
+    public ResponseEntity<NicknameValidation> checkNicknameAvailability(
+            @RequestParam("nickname") String nickname) {
+        NicknameValidation nicknameValidation = userService.isNicknameAvailable(nickname);
+        if (nicknameValidation.isDuplicated()) {
+            return ResponseEntity
+                    .status(CONFLICT)
+                    .body(nicknameValidation);
+        }
+        return ResponseEntity
+                .status(OK)
+                .body(nicknameValidation);
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/User/NicknameValidation.java
+++ b/src/main/java/org/websoso/WSSServer/dto/User/NicknameValidation.java
@@ -1,0 +1,7 @@
+package org.websoso.WSSServer.dto.User;
+
+public record NicknameValidation(boolean isDuplicated) {
+    public static NicknameValidation of(boolean isDuplicated) {
+        return new NicknameValidation(isDuplicated);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package org.websoso.WSSServer.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.websoso.WSSServer.exception.user.UserErrorCode;
+import org.websoso.WSSServer.exception.common.ErrorResult;
+import org.websoso.WSSServer.exception.user.exception.InvalidNicknameException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ResponseStatus(BAD_REQUEST)
+    @ExceptionHandler(InvalidNicknameException.class)
+    public ErrorResult InvalidNicknameExceptionHandler(InvalidNicknameException e) {
+        log.error("[InvalidNicknameException] exception ", e);
+        UserErrorCode userErrorCode = e.getUserErrorCode();
+        return new ErrorResult(userErrorCode.getCode(), userErrorCode.getDescription());
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/exception/common/ErrorResult.java
+++ b/src/main/java/org/websoso/WSSServer/exception/common/ErrorResult.java
@@ -1,0 +1,12 @@
+package org.websoso.WSSServer.exception.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResult {
+
+    private String code;
+    private String message;
+}

--- a/src/main/java/org/websoso/WSSServer/exception/common/IErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/common/IErrorCode.java
@@ -1,0 +1,8 @@
+package org.websoso.WSSServer.exception.common;
+
+public interface IErrorCode {
+    
+    String getCode();
+
+    String getDescription();
+}

--- a/src/main/java/org/websoso/WSSServer/exception/user/UserErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/user/UserErrorCode.java
@@ -1,0 +1,19 @@
+package org.websoso.WSSServer.exception.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.websoso.WSSServer.exception.common.IErrorCode;
+
+@AllArgsConstructor
+@Getter
+public enum UserErrorCode implements IErrorCode {
+
+    INVALID_NICKNAME_NULL("USER-001", "닉네임은 null일 수 없습니다."),
+    INVALID_NICKNAME_BLANK("USER-002", "닉네임은 빈칸일 수 없습니다."),
+    INVALID_NICKNAME_START_OR_END_WITH_BLANK("USER-003", "닉네임은 공백으로 시작하거나 끝날 수 없습니다."),
+    INVALID_NICKNAME_LENGTH("USER-004", "닉네임의 길이가 2 ~ 10자가 아닙니다."),
+    INVALID_NICKNAME_PATTERN("USER-005", "닉네임은 한글, 영문, 숫자로만 이루어져아 합니다.");
+
+    private final String code;
+    private final String description;
+}

--- a/src/main/java/org/websoso/WSSServer/exception/user/exception/InvalidNicknameException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/user/exception/InvalidNicknameException.java
@@ -1,0 +1,18 @@
+package org.websoso.WSSServer.exception.user.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.websoso.WSSServer.exception.user.UserErrorCode;
+
+@Getter
+@AllArgsConstructor
+public class InvalidNicknameException extends RuntimeException {
+
+    public InvalidNicknameException(UserErrorCode userErrorCode, String message) {
+        super(message);
+        this.userErrorCode = userErrorCode;
+    }
+
+    private UserErrorCode userErrorCode;
+}
+

--- a/src/main/java/org/websoso/WSSServer/repository/UserRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserRepository.java
@@ -6,4 +6,6 @@ import org.websoso.WSSServer.domain.User;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -2,15 +2,18 @@ package org.websoso.WSSServer.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.dto.User.NicknameValidation;
 import org.websoso.WSSServer.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserService {
 
     private final UserRepository userRepository;
 
+    @Transactional(readOnly = true)
     public NicknameValidation isNicknameAvailable(String nickname) {
         boolean isNicknameTaken = userRepository.existsByNickname(nickname);
         return NicknameValidation.of(isNicknameTaken);

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -2,9 +2,17 @@ package org.websoso.WSSServer.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.websoso.WSSServer.dto.User.NicknameValidation;
+import org.websoso.WSSServer.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
+    private final UserRepository userRepository;
+
+    public NicknameValidation isNicknameAvailable(String nickname) {
+        boolean isNicknameTaken = userRepository.existsByNickname(nickname);
+        return NicknameValidation.of(isNicknameTaken);
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/validation/NicknameConstraint.java
+++ b/src/main/java/org/websoso/WSSServer/validation/NicknameConstraint.java
@@ -1,0 +1,23 @@
+package org.websoso.WSSServer.validation;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = NicknameValidator.class)
+@Target({PARAMETER})
+@Retention(RUNTIME)
+public @interface NicknameConstraint {
+
+    String message() default "invalid nickname";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
+++ b/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
@@ -1,0 +1,42 @@
+package org.websoso.WSSServer.validation;
+
+import static org.websoso.WSSServer.exception.user.UserErrorCode.INVALID_NICKNAME_BLANK;
+import static org.websoso.WSSServer.exception.user.UserErrorCode.INVALID_NICKNAME_LENGTH;
+import static org.websoso.WSSServer.exception.user.UserErrorCode.INVALID_NICKNAME_NULL;
+import static org.websoso.WSSServer.exception.user.UserErrorCode.INVALID_NICKNAME_PATTERN;
+import static org.websoso.WSSServer.exception.user.UserErrorCode.INVALID_NICKNAME_START_OR_END_WITH_BLANK;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.stereotype.Component;
+import org.websoso.WSSServer.exception.user.exception.InvalidNicknameException;
+
+@Component
+public class NicknameValidator implements ConstraintValidator<NicknameConstraint, String> {
+
+    @Override
+    public void initialize(NicknameConstraint nickname) {
+    }
+
+    @Override
+    public boolean isValid(String nickname, ConstraintValidatorContext constraintValidatorContext) {
+        if (nickname == null) {
+            throw new InvalidNicknameException(INVALID_NICKNAME_NULL, "nickname cannot be null");
+        }
+        if (nickname.isBlank()) {
+            throw new InvalidNicknameException(INVALID_NICKNAME_BLANK, "nickname cannot be blank");
+        }
+        if (!(nickname.length() >= 2 && nickname.length() <= 10)) {
+            throw new InvalidNicknameException(INVALID_NICKNAME_LENGTH, "nickname must be 2 to 10 characters long");
+        }
+        if (!nickname.matches("^\\s*[가-힣a-zA-Z0-9]*\\s*$")) {
+            throw new InvalidNicknameException(INVALID_NICKNAME_PATTERN,
+                    "nickname should be written in Korean, English, and numbers");
+        }
+        if (nickname.startsWith(" ") || nickname.endsWith(" ")) {
+            throw new InvalidNicknameException(INVALID_NICKNAME_START_OR_END_WITH_BLANK,
+                    "nickname cannot start or end with whitespace");
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
+++ b/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
@@ -31,7 +31,7 @@ public class NicknameValidator implements ConstraintValidator<NicknameConstraint
         if (!(nickname.length() >= 2 && nickname.length() <= 10)) {
             throw new InvalidNicknameException(INVALID_NICKNAME_LENGTH, "nickname must be 2 to 10 characters long");
         }
-        if (!nickname.matches(NICKNAME_REGEX)) {
+        if (!isMatches(nickname)) {
             throw new InvalidNicknameException(INVALID_NICKNAME_PATTERN,
                     "nickname should be written in Korean, English, and numbers");
         }
@@ -40,5 +40,9 @@ public class NicknameValidator implements ConstraintValidator<NicknameConstraint
                     "nickname cannot start or end with whitespace");
         }
         return true;
+    }
+
+    private static boolean isMatches(String nickname) {
+        return nickname.matches(NICKNAME_REGEX);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
+++ b/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
@@ -14,6 +14,8 @@ import org.websoso.WSSServer.exception.user.exception.InvalidNicknameException;
 @Component
 public class NicknameValidator implements ConstraintValidator<NicknameConstraint, String> {
 
+    private static final String NICKNAME_REGEX = "^\\s*[가-힣a-zA-Z0-9]*\\s*$";
+
     @Override
     public void initialize(NicknameConstraint nickname) {
     }
@@ -29,7 +31,7 @@ public class NicknameValidator implements ConstraintValidator<NicknameConstraint
         if (!(nickname.length() >= 2 && nickname.length() <= 10)) {
             throw new InvalidNicknameException(INVALID_NICKNAME_LENGTH, "nickname must be 2 to 10 characters long");
         }
-        if (!nickname.matches("^\\s*[가-힣a-zA-Z0-9]*\\s*$")) {
+        if (!nickname.matches(NICKNAME_REGEX)) {
             throw new InvalidNicknameException(INVALID_NICKNAME_PATTERN,
                     "nickname should be written in Korean, English, and numbers");
         }

--- a/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
+++ b/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
@@ -8,13 +8,14 @@ import static org.websoso.WSSServer.exception.user.UserErrorCode.INVALID_NICKNAM
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 import org.websoso.WSSServer.exception.user.exception.InvalidNicknameException;
 
 @Component
 public class NicknameValidator implements ConstraintValidator<NicknameConstraint, String> {
 
-    private static final String NICKNAME_REGEX = "^\\s*[가-힣a-zA-Z0-9]*\\s*$";
+    private static final Pattern NICKNAME_REGEX = Pattern.compile("^\\s*[가-힣a-zA-Z0-9]*\\s*$");
 
     @Override
     public void initialize(NicknameConstraint nickname) {
@@ -43,6 +44,6 @@ public class NicknameValidator implements ConstraintValidator<NicknameConstraint
     }
 
     private static boolean isMatches(String nickname) {
-        return nickname.matches(NICKNAME_REGEX);
+        return NICKNAME_REGEX.matcher(nickname).matches();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
+++ b/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
@@ -29,16 +29,16 @@ public class NicknameValidator implements ConstraintValidator<NicknameConstraint
         if (nickname.isBlank()) {
             throw new InvalidNicknameException(INVALID_NICKNAME_BLANK, "nickname cannot be blank");
         }
+        if (nickname.startsWith(" ") || nickname.endsWith(" ")) {
+            throw new InvalidNicknameException(INVALID_NICKNAME_START_OR_END_WITH_BLANK,
+                    "nickname cannot start or end with whitespace");
+        }
         if (!(nickname.length() >= 2 && nickname.length() <= 10)) {
             throw new InvalidNicknameException(INVALID_NICKNAME_LENGTH, "nickname must be 2 to 10 characters long");
         }
         if (!isMatches(nickname)) {
             throw new InvalidNicknameException(INVALID_NICKNAME_PATTERN,
                     "nickname should be written in Korean, English, and numbers");
-        }
-        if (nickname.startsWith(" ") || nickname.endsWith(" ")) {
-            throw new InvalidNicknameException(INVALID_NICKNAME_START_OR_END_WITH_BLANK,
-                    "nickname cannot start or end with whitespace");
         }
         return true;
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#3 -> dev
- close #3

## Key Changes
<!-- 최대한 자세히 -->
- `DTO`를 `NicknameValidation`으로 네이밍했습니다. 네이밍에 고민이 많았는데, 김영한 님 답변 참고했습니다. -> `ref1`
- `RequestParam`으로 받는 `nickname`에 대해 DB에 조회하여 존재한다면(중복) `409 Conflict`를, 존재하지 않는다면 `200 OK`를 내려줍니다.
- `RequestParam`으로 받는 값에 대해 유효성 검사를 위해 `@Validated`를 사용했습니다. -> `ref2`
- `nickname` 유효성 검사 조건이 까다로워서 `Spring Boot Validation`만으로는 어려워, custom으로 annotation과 validator를 만들어서 해결했습니다. -> `ref3`
  - 유효성 검사의 주요 로직은 `validator`에서 유효성 검사하여 `invalid한 값`일 때 custom exception인 `InvalidNicknameException`을 터뜨리고 `GlobalExceptionHandler`에서 전역으로 잡아서 처리하는 방식입니다. 
  - 프로젝트 전반에서 사용할 전역 에러 처리나 공통 오류 코드, 공통 에러 응답 등 custom하게 구현했습니다. -> 리뷰 시 확인 바랍니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- Effective Java 스터디를 하고 있는데, 공부한 내용을 써먹을 곳이 있어서 적용해봤습니다. -> 정규표현식 관련 로직 처리 시 static으로 사용하여 캐싱 -> `ref4`
- 프로젝트 전반에서 사용할 전역 에러 처리나 공통 오류 코드, 공통 에러 응답 등 custom하게 구현했습니다. -> 조언이나 피드백 바랍니다.
- 디스코드에 유효성 검사 관련해서 TL님께 질문 남겨놨는데, 요구사항 수정되면 코드 수정도 있게 될 것 같습니다.


## References
<!-- 참고한 자료-->
- `ref1`: https://www.inflearn.com/questions/89727/요청받는-객체의-이름도-dto로-네이밍-해야할까요
- `ref2`: https://www.baeldung.com/spring-validate-requestparam-pathvariable
- `ref3`: https://www.baeldung.com/spring-mvc-custom-validator
- `ref4`:  
  - https://ryumodrn.tistory.com/55
  - https://wooki99.notion.site/Item-6-96e8ad1291ad46fdae546fa3e135a46c?pvs=4