### PR TITLE
[FIX] 서버 상태 체크 API가 인증 인가를 거치는 오류 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
 
     private final String[] permitAllPaths = {
             "/users/login",
-            "/users/nickname/check"
+            "/users/nickname/check",
+            "/actuator/health"
     };
 
     @Bean


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#16 -> dev
- close #16

## Key Changes
<!-- 최대한 자세히 -->
직전에 dev에 merge된 작업에서 사용자의 인증/인가 과정이 추가되었는데, CD 작업에서 사용되는 서버 상태 체크 API가 인증 인가를 거치게 되어, CD가 정상적으로 작동하지 않는 현상이 발생했습니다.

Spring Security 설정 파일 인증 인가 예외 경로에 서버 상태 체크 API 경로를 추가하여, 오류를 해결하고자 합니다.

아래는 로컬환경에서 사용자 토큰 없이 테스트 해본 화면입니다!

<img width="687" alt="image" src="https://github.com/Team-WSS/WSS-Server/assets/109871579/c29188e8-203b-4422-af55-77401ab52f76">

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
