### PR TITLE
[FEAT] 작품 정보 조회 API(기본) 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig {
     private final String[] permitAllPaths = {
             "/users/login",
             "/users/nickname/check",
-            "/actuator/health"
+            "/actuator/health",
+            "/novels/{novelId}"
     };
 
     @Bean

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.novel.NovelGetResponse1;
 import org.websoso.WSSServer.service.NovelService;
 import org.websoso.WSSServer.service.UserService;
@@ -24,12 +23,14 @@ public class NovelController {
 
     @GetMapping("/{novelId}")
     public ResponseEntity<NovelGetResponse1> getNovelInfo1(Principal principal, @PathVariable Long novelId) {
-        User user = null;
-        if (principal != null) {
-            user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        if (principal == null) {
+            return ResponseEntity
+                    .status(OK)
+                    .body(novelService.getNovelInfo1(null, novelId));
         }
         return ResponseEntity
                 .status(OK)
-                .body(novelService.getNovelInfo1(user, novelId));
+                .body(novelService.getNovelInfo1(userService.getUserOrException(Long.valueOf(principal.getName())),
+                        novelId));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -24,7 +24,10 @@ public class NovelController {
 
     @GetMapping("/{novelId}")
     public ResponseEntity<NovelGetResponse> getNovelInfo1(Principal principal, @PathVariable Long novelId) {
-        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        User user = null;
+        if(principal != null){
+            user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        }
         return ResponseEntity
                 .status(OK)
                 .body(novelService.getNovelInfo1(user, novelId));

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -21,6 +21,7 @@ public class NovelController {
     private final NovelService novelService;
     private final UserService userService;
 
+    // TODO 이름 변경(작품 정보 조회 뷰에서 상단, 기본정보를 제공하는 부분)
     @GetMapping("/{novelId}")
     public ResponseEntity<NovelGetResponse1> getNovelInfo1(Principal principal, @PathVariable Long novelId) {
         if (principal == null) {

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -1,5 +1,7 @@
 package org.websoso.WSSServer.controller;
 
+import static org.springframework.http.HttpStatus.OK;
+
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,8 +14,6 @@ import org.websoso.WSSServer.dto.novel.NovelGetResponse;
 import org.websoso.WSSServer.service.NovelService;
 import org.websoso.WSSServer.service.UserService;
 
-import static org.springframework.http.HttpStatus.OK;
-
 @RestController
 @RequestMapping("/novels")
 @RequiredArgsConstructor
@@ -23,7 +23,7 @@ public class NovelController {
     private final UserService userService;
 
     @GetMapping("/{novelId}")
-    public ResponseEntity<NovelGetResponse> getNovelInfo1(Principal principal, @PathVariable Long novelId){
+    public ResponseEntity<NovelGetResponse> getNovelInfo1(Principal principal, @PathVariable Long novelId) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
                 .status(OK)

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -1,0 +1,32 @@
+package org.websoso.WSSServer.controller;
+
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.dto.novel.NovelGetResponse;
+import org.websoso.WSSServer.service.NovelService;
+import org.websoso.WSSServer.service.UserService;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequestMapping("/novels")
+@RequiredArgsConstructor
+public class NovelController {
+
+    private final NovelService novelService;
+    private final UserService userService;
+
+    @GetMapping("/{novelId}")
+    public ResponseEntity<NovelGetResponse> getNovelInfo1(Principal principal, @PathVariable Long novelId){
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(OK)
+                .body(novelService.getNovelInfo1(user, novelId));
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -25,7 +25,7 @@ public class NovelController {
     @GetMapping("/{novelId}")
     public ResponseEntity<NovelGetResponse1> getNovelInfo1(Principal principal, @PathVariable Long novelId) {
         User user = null;
-        if(principal != null){
+        if (principal != null) {
             user = userService.getUserOrException(Long.valueOf(principal.getName()));
         }
         return ResponseEntity

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
-import org.websoso.WSSServer.dto.novel.NovelGetResponse;
+import org.websoso.WSSServer.dto.novel.NovelGetResponse1;
 import org.websoso.WSSServer.service.NovelService;
 import org.websoso.WSSServer.service.UserService;
 
@@ -23,7 +23,7 @@ public class NovelController {
     private final UserService userService;
 
     @GetMapping("/{novelId}")
-    public ResponseEntity<NovelGetResponse> getNovelInfo1(Principal principal, @PathVariable Long novelId) {
+    public ResponseEntity<NovelGetResponse1> getNovelInfo1(Principal principal, @PathVariable Long novelId) {
         User user = null;
         if(principal != null){
             user = userService.getUserOrException(Long.valueOf(principal.getName()));

--- a/src/main/java/org/websoso/WSSServer/domain/common/ReadStatus.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/ReadStatus.java
@@ -1,5 +1,13 @@
 package org.websoso.WSSServer.domain.common;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum ReadStatus {
-    WATCHING, WATCHED, QUIT
+    WATCHING("보는 중"),
+    WATCHED("봤어요"),
+    QUIT("하차");
+    private final String name;
 }

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse.java
@@ -28,7 +28,7 @@ public record NovelGetResponse(
     public static NovelGetResponse of(Novel novel, UserNovel userNovel, NovelStatistics novelStatistics,
                                       String novelGenres, String novelGenreImage) {
         return new NovelGetResponse(
-                novel.getNovelId(),
+                userNovel != null ? userNovel.getUserNovelId() : null,
                 novel.getTitle(),
                 novel.getNovelImage(),
                 novelGenres,
@@ -47,7 +47,7 @@ public record NovelGetResponse(
                 userNovel != null && userNovel.getEndDate() != null ? userNovel.getEndDate()
                         .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko")))
                         : null,
-                userNovel != null ? userNovel.getIsInterest().equals(Flag.Y) : null
+                userNovel != null ? userNovel.getIsInterest().equals(Flag.Y) : false
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse.java
@@ -47,7 +47,7 @@ public record NovelGetResponse(
                 userNovel != null && userNovel.getEndDate() != null ? userNovel.getEndDate()
                         .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko")))
                         : null,
-                userNovel != null ? userNovel.getIsInterest().equals(Flag.Y) : false
+                userNovel != null && userNovel.getIsInterest().equals(Flag.Y)
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse.java
@@ -25,13 +25,14 @@ public record NovelGetResponse(
         String endDate,
         Boolean isUserNovelInterest
 ) {
-    public static NovelGetResponse of(Novel novel, UserNovel userNovel, NovelStatistics novelStatistics) {
+    public static NovelGetResponse of(Novel novel, UserNovel userNovel, NovelStatistics novelStatistics,
+                                      String novelGenres, String novelGenreImage) {
         return new NovelGetResponse(
                 novel.getNovelId(),
                 novel.getTitle(),
                 novel.getNovelImage(),
-                novel.getGenre(),
-                "genre badge",  //TODO 장르 도메인 만들기
+                novelGenres,
+                novelGenreImage,
                 novel.getIsCompleted().equals(Flag.Y),
                 novel.getAuthor(),
                 novelStatistics.getInterestCount(),

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse.java
@@ -39,12 +39,15 @@ public record NovelGetResponse(
                 novel.getNovelRatingSum() / novel.getNovelRatingCount(),
                 novel.getNovelRatingCount(),
                 novelStatistics.getNovelFeedCount(),
-                userNovel.getUserNovelRating(),
-                userNovel.getStatus().getName(),
-                userNovel.getStartDate()
-                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko"))),
-                userNovel.getEndDate().toString(),
-                userNovel.getIsInterest().equals(Flag.Y)
+                userNovel != null ? userNovel.getUserNovelRating() : null,
+                userNovel != null ? userNovel.getStatus().getName() : null,
+                userNovel != null && userNovel.getStartDate() != null ? userNovel.getStartDate()
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko")))
+                        : null,
+                userNovel != null && userNovel.getEndDate() != null ? userNovel.getEndDate()
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko")))
+                        : null,
+                userNovel != null ? userNovel.getIsInterest().equals(Flag.Y) : null
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse.java
@@ -1,0 +1,49 @@
+package org.websoso.WSSServer.dto.novel;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.NovelStatistics;
+import org.websoso.WSSServer.domain.UserNovel;
+import org.websoso.WSSServer.domain.common.Flag;
+
+public record NovelGetResponse(
+        Long userNovelId,
+        String novelTitle,
+        String novelImage,
+        String novelGenres,
+        String novelGenreImage,
+        Boolean isNovelCompleted,
+        String author,
+        Integer interestCount,
+        Float novelRating,
+        Integer novelRatingCount,
+        Integer feedCount,
+        Float userNovelRating,
+        String readStatus,
+        String startDate,
+        String endDate,
+        Boolean isUserNovelInterest
+) {
+    public static NovelGetResponse of(Novel novel, UserNovel userNovel, NovelStatistics novelStatistics) {
+        return new NovelGetResponse(
+                novel.getNovelId(),
+                novel.getTitle(),
+                novel.getNovelImage(),
+                novel.getGenre(),
+                "genre badge",  //TODO 장르 도메인 만들기
+                novel.getIsCompleted().equals(Flag.Y),
+                novel.getAuthor(),
+                novelStatistics.getInterestCount(),
+                novel.getNovelRatingSum() / novel.getNovelRatingCount(),
+                novel.getNovelRatingCount(),
+                novelStatistics.getNovelFeedCount(),
+                userNovel.getUserNovelRating(),
+                userNovel.getStatus().getName(),
+                userNovel.getStartDate()
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko"))),
+                userNovel.getEndDate().toString(),
+                userNovel.getIsInterest().equals(Flag.Y)
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse.java
@@ -36,7 +36,7 @@ public record NovelGetResponse(
                 novel.getIsCompleted().equals(Flag.Y),
                 novel.getAuthor(),
                 novelStatistics.getInterestCount(),
-                novel.getNovelRatingSum() / novel.getNovelRatingCount(),
+                novel.getNovelRatingCount() > 0 ? novel.getNovelRatingSum() / novel.getNovelRatingCount() : 0,
                 novel.getNovelRatingCount(),
                 novelStatistics.getNovelFeedCount(),
                 userNovel != null ? userNovel.getUserNovelRating() : null,

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse1.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse1.java
@@ -7,6 +7,7 @@ import org.websoso.WSSServer.domain.NovelStatistics;
 import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.domain.common.Flag;
 
+// TODO 이름 변경(작품 정보 조회 뷰에서 상단, 기본정보를 제공하는 부분)
 public record NovelGetResponse1(
         Long userNovelId,
         String novelTitle,

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse1.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse1.java
@@ -28,6 +28,8 @@ public record NovelGetResponse1(
 ) {
     public static NovelGetResponse1 of(Novel novel, UserNovel userNovel, NovelStatistics novelStatistics,
                                        String novelGenres, String novelGenreImage) {
+        Float novelRating = novel.getNovelRatingCount() > 0 ?
+                Math.round((novel.getNovelRatingSum() / novel.getNovelRatingCount()) * 10) / 10.0f : 0;
         if (userNovel == null) {
             return new NovelGetResponse1(
                     null,
@@ -38,7 +40,7 @@ public record NovelGetResponse1(
                     novel.getIsCompleted().equals(Flag.Y),
                     novel.getAuthor(),
                     novelStatistics.getInterestCount(),
-                    novel.getNovelRatingCount() > 0 ? novel.getNovelRatingSum() / novel.getNovelRatingCount() : 0,
+                    novelRating,
                     novel.getNovelRatingCount(),
                     novelStatistics.getNovelFeedCount(),
                     null,
@@ -57,7 +59,7 @@ public record NovelGetResponse1(
                 novel.getIsCompleted().equals(Flag.Y),
                 novel.getAuthor(),
                 novelStatistics.getInterestCount(),
-                novel.getNovelRatingCount() > 0 ? novel.getNovelRatingSum() / novel.getNovelRatingCount() : 0,
+                novelRating,
                 novel.getNovelRatingCount(),
                 novelStatistics.getNovelFeedCount(),
                 userNovel.getUserNovelRating(),

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse1.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse1.java
@@ -7,7 +7,7 @@ import org.websoso.WSSServer.domain.NovelStatistics;
 import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.domain.common.Flag;
 
-public record NovelGetResponse(
+public record NovelGetResponse1(
         Long userNovelId,
         String novelTitle,
         String novelImage,
@@ -25,9 +25,9 @@ public record NovelGetResponse(
         String endDate,
         Boolean isUserNovelInterest
 ) {
-    public static NovelGetResponse of(Novel novel, UserNovel userNovel, NovelStatistics novelStatistics,
-                                      String novelGenres, String novelGenreImage) {
-        return new NovelGetResponse(
+    public static NovelGetResponse1 of(Novel novel, UserNovel userNovel, NovelStatistics novelStatistics,
+                                       String novelGenres, String novelGenreImage) {
+        return new NovelGetResponse1(
                 userNovel != null ? userNovel.getUserNovelId() : null,
                 novel.getTitle(),
                 novel.getNovelImage(),

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse1.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse1.java
@@ -27,27 +27,48 @@ public record NovelGetResponse1(
 ) {
     public static NovelGetResponse1 of(Novel novel, UserNovel userNovel, NovelStatistics novelStatistics,
                                        String novelGenres, String novelGenreImage) {
-        return new NovelGetResponse1(
-                userNovel != null ? userNovel.getUserNovelId() : null,
-                novel.getTitle(),
-                novel.getNovelImage(),
-                novelGenres,
-                novelGenreImage,
-                novel.getIsCompleted().equals(Flag.Y),
-                novel.getAuthor(),
-                novelStatistics.getInterestCount(),
-                novel.getNovelRatingCount() > 0 ? novel.getNovelRatingSum() / novel.getNovelRatingCount() : 0,
-                novel.getNovelRatingCount(),
-                novelStatistics.getNovelFeedCount(),
-                userNovel != null ? userNovel.getUserNovelRating() : null,
-                userNovel != null ? userNovel.getStatus().getName() : null,
-                userNovel != null && userNovel.getStartDate() != null ? userNovel.getStartDate()
-                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko")))
-                        : null,
-                userNovel != null && userNovel.getEndDate() != null ? userNovel.getEndDate()
-                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko")))
-                        : null,
-                userNovel != null && userNovel.getIsInterest().equals(Flag.Y)
-        );
+        if (userNovel == null) {
+            return new NovelGetResponse1(
+                    null,
+                    novel.getTitle(),
+                    novel.getNovelImage(),
+                    novelGenres,
+                    novelGenreImage,
+                    novel.getIsCompleted().equals(Flag.Y),
+                    novel.getAuthor(),
+                    novelStatistics.getInterestCount(),
+                    novel.getNovelRatingCount() > 0 ? novel.getNovelRatingSum() / novel.getNovelRatingCount() : 0,
+                    novel.getNovelRatingCount(),
+                    novelStatistics.getNovelFeedCount(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    false
+            );
+        } else {
+            return new NovelGetResponse1(
+                    userNovel.getUserNovelId(),
+                    novel.getTitle(),
+                    novel.getNovelImage(),
+                    novelGenres,
+                    novelGenreImage,
+                    novel.getIsCompleted().equals(Flag.Y),
+                    novel.getAuthor(),
+                    novelStatistics.getInterestCount(),
+                    novel.getNovelRatingCount() > 0 ? novel.getNovelRatingSum() / novel.getNovelRatingCount() : 0,
+                    novel.getNovelRatingCount(),
+                    novelStatistics.getNovelFeedCount(),
+                    userNovel.getUserNovelRating(),
+                    userNovel.getStatus().getName(),
+                    userNovel.getStartDate() != null ? userNovel.getStartDate()
+                            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko")))
+                            : null,
+                    userNovel.getEndDate() != null ? userNovel.getEndDate()
+                            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko")))
+                            : null,
+                    userNovel.getIsInterest().equals(Flag.Y)
+            );
+        }
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse1.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse1.java
@@ -43,7 +43,7 @@ public record NovelGetResponse1(
                     novelRating,
                     novel.getNovelRatingCount(),
                     novelStatistics.getNovelFeedCount(),
-                    null,
+                    0f,
                     null,
                     null,
                     null,

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse1.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponse1.java
@@ -46,29 +46,28 @@ public record NovelGetResponse1(
                     null,
                     false
             );
-        } else {
-            return new NovelGetResponse1(
-                    userNovel.getUserNovelId(),
-                    novel.getTitle(),
-                    novel.getNovelImage(),
-                    novelGenres,
-                    novelGenreImage,
-                    novel.getIsCompleted().equals(Flag.Y),
-                    novel.getAuthor(),
-                    novelStatistics.getInterestCount(),
-                    novel.getNovelRatingCount() > 0 ? novel.getNovelRatingSum() / novel.getNovelRatingCount() : 0,
-                    novel.getNovelRatingCount(),
-                    novelStatistics.getNovelFeedCount(),
-                    userNovel.getUserNovelRating(),
-                    userNovel.getStatus().getName(),
-                    userNovel.getStartDate() != null ? userNovel.getStartDate()
-                            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko")))
-                            : null,
-                    userNovel.getEndDate() != null ? userNovel.getEndDate()
-                            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko")))
-                            : null,
-                    userNovel.getIsInterest().equals(Flag.Y)
-            );
         }
+        return new NovelGetResponse1(
+                userNovel.getUserNovelId(),
+                novel.getTitle(),
+                novel.getNovelImage(),
+                novelGenres,
+                novelGenreImage,
+                novel.getIsCompleted().equals(Flag.Y),
+                novel.getAuthor(),
+                novelStatistics.getInterestCount(),
+                novel.getNovelRatingCount() > 0 ? novel.getNovelRatingSum() / novel.getNovelRatingCount() : 0,
+                novel.getNovelRatingCount(),
+                novelStatistics.getNovelFeedCount(),
+                userNovel.getUserNovelRating(),
+                userNovel.getStatus().getName(),
+                userNovel.getStartDate() != null ? userNovel.getStartDate()
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko")))
+                        : null,
+                userNovel.getEndDate() != null ? userNovel.getEndDate()
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd").withLocale(Locale.forLanguageTag("ko")))
+                        : null,
+                userNovel.getIsInterest().equals(Flag.Y)
+        );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
@@ -6,7 +6,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.websoso.WSSServer.domain.NovelStatistics;
 import org.websoso.WSSServer.exception.category.CategoryErrorCode;
 import org.websoso.WSSServer.exception.category.exception.InvalidCategoryException;
 import org.websoso.WSSServer.exception.common.ErrorResult;
@@ -80,7 +79,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(InvalidNovelException.class)
-    public ResponseEntity<ErrorResult> InvalidNovelExceptionHandler(InvalidNovelException e){
+    public ResponseEntity<ErrorResult> InvalidNovelExceptionHandler(InvalidNovelException e) {
         log.error("[InvalidNovelException] exception ", e);
         NovelErrorCode novelErrorCode = e.getNovelErrorCode();
         return ResponseEntity
@@ -89,7 +88,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(InvalidNovelStatisticsException.class)
-    public ResponseEntity<ErrorResult> InvalidNovelStatisticsExceptionHandler(InvalidNovelStatisticsException e){
+    public ResponseEntity<ErrorResult> InvalidNovelStatisticsExceptionHandler(InvalidNovelStatisticsException e) {
         log.error("[InvalidNovelStatisticsException] exception", e);
         NovelStatisticsErrorCode novelStatisticsErrorCode = e.getNovelStatisticsErrorCode();
         return ResponseEntity

--- a/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
@@ -6,11 +6,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.websoso.WSSServer.domain.NovelStatistics;
 import org.websoso.WSSServer.exception.category.CategoryErrorCode;
 import org.websoso.WSSServer.exception.category.exception.InvalidCategoryException;
 import org.websoso.WSSServer.exception.common.ErrorResult;
 import org.websoso.WSSServer.exception.feed.FeedErrorCode;
 import org.websoso.WSSServer.exception.feed.exception.InvalidFeedException;
+import org.websoso.WSSServer.exception.novel.NovelErrorCode;
+import org.websoso.WSSServer.exception.novel.exception.InvalidNovelException;
+import org.websoso.WSSServer.exception.novelStatistics.NovelStatisticsErrorCode;
+import org.websoso.WSSServer.exception.novelStatistics.exception.InvalidNovelStatisticsException;
 import org.websoso.WSSServer.exception.user.UserErrorCode;
 import org.websoso.WSSServer.exception.user.exception.InvalidAuthorizedException;
 import org.websoso.WSSServer.exception.user.exception.InvalidNicknameException;
@@ -72,6 +77,24 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(feedErrorCode.getStatusCode())
                 .body(new ErrorResult(feedErrorCode.getCode(), feedErrorCode.getDescription()));
+    }
+
+    @ExceptionHandler(InvalidNovelException.class)
+    public ResponseEntity<ErrorResult> InvalidNovelExceptionHandler(InvalidNovelException e){
+        log.error("[InvalidNovelException] exception ", e);
+        NovelErrorCode novelErrorCode = e.getNovelErrorCode();
+        return ResponseEntity
+                .status(novelErrorCode.getStatusCode())
+                .body(new ErrorResult(novelErrorCode.getCode(), novelErrorCode.getDescription()));
+    }
+
+    @ExceptionHandler(InvalidNovelStatisticsException.class)
+    public ResponseEntity<ErrorResult> InvalidNovelStatisticsExceptionHandler(InvalidNovelStatisticsException e){
+        log.error("[InvalidNovelStatisticsException] exception", e);
+        NovelStatisticsErrorCode novelStatisticsErrorCode = e.getNovelStatisticsErrorCode();
+        return ResponseEntity
+                .status(novelStatisticsErrorCode.getStatusCode())
+                .body(new ErrorResult(novelStatisticsErrorCode.getCode(), novelStatisticsErrorCode.getDescription()));
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/exception/novel/NovelErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/novel/NovelErrorCode.java
@@ -1,0 +1,17 @@
+package org.websoso.WSSServer.exception.novel;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.websoso.WSSServer.exception.common.IErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum NovelErrorCode implements IErrorCode {
+
+    NOVEL_NOT_FOUND("NOVEL-001", "해당 ID를 가진 작품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String description;
+    private final HttpStatus statusCode;
+}

--- a/src/main/java/org/websoso/WSSServer/exception/novel/NovelErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/novel/NovelErrorCode.java
@@ -1,5 +1,7 @@
 package org.websoso.WSSServer.exception.novel;
 
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -9,7 +11,7 @@ import org.websoso.WSSServer.exception.common.IErrorCode;
 @AllArgsConstructor
 public enum NovelErrorCode implements IErrorCode {
 
-    NOVEL_NOT_FOUND("NOVEL-001", "해당 ID를 가진 작품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    NOVEL_NOT_FOUND("NOVEL-001", "해당 ID를 가진 작품을 찾을 수 없습니다.", NOT_FOUND);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/exception/novel/exception/InvalidNovelException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/novel/exception/InvalidNovelException.java
@@ -1,0 +1,17 @@
+package org.websoso.WSSServer.exception.novel.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.websoso.WSSServer.exception.novel.NovelErrorCode;
+
+@Getter
+@AllArgsConstructor
+public class InvalidNovelException extends RuntimeException {
+
+    public InvalidNovelException(NovelErrorCode novelErrorCode, String message) {
+        super(message);
+        this.novelErrorCode = novelErrorCode;
+    }
+
+    private NovelErrorCode novelErrorCode;
+}

--- a/src/main/java/org/websoso/WSSServer/exception/novelStatistics/NovelStatisticsErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/novelStatistics/NovelStatisticsErrorCode.java
@@ -1,0 +1,17 @@
+package org.websoso.WSSServer.exception.novelStatistics;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.websoso.WSSServer.exception.common.IErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum NovelStatisticsErrorCode implements IErrorCode {
+
+    NOVEL_STATISTICS_NOT_FOUND("NOVELSTATISTICS-001", "해당 작품의 통계를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String description;
+    private final HttpStatus statusCode;
+}

--- a/src/main/java/org/websoso/WSSServer/exception/novelStatistics/NovelStatisticsErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/novelStatistics/NovelStatisticsErrorCode.java
@@ -9,7 +9,7 @@ import org.websoso.WSSServer.exception.common.IErrorCode;
 @AllArgsConstructor
 public enum NovelStatisticsErrorCode implements IErrorCode {
 
-    NOVEL_STATISTICS_NOT_FOUND("NOVELSTATISTICS-001", "해당 작품의 통계를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    NOVEL_STATISTICS_NOT_FOUND("NOVEL_STATISTICS-001", "해당 작품의 통계를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/exception/novelStatistics/exception/InvalidNovelStatisticsException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/novelStatistics/exception/InvalidNovelStatisticsException.java
@@ -8,7 +8,7 @@ import org.websoso.WSSServer.exception.novelStatistics.NovelStatisticsErrorCode;
 @AllArgsConstructor
 public class InvalidNovelStatisticsException extends RuntimeException {
 
-    public InvalidNovelStatisticsException(NovelStatisticsErrorCode novelStatisticsErrorCode, String message){
+    public InvalidNovelStatisticsException(NovelStatisticsErrorCode novelStatisticsErrorCode, String message) {
         super(message);
         this.novelStatisticsErrorCode = novelStatisticsErrorCode;
     }

--- a/src/main/java/org/websoso/WSSServer/exception/novelStatistics/exception/InvalidNovelStatisticsException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/novelStatistics/exception/InvalidNovelStatisticsException.java
@@ -1,0 +1,17 @@
+package org.websoso.WSSServer.exception.novelStatistics.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.websoso.WSSServer.exception.novelStatistics.NovelStatisticsErrorCode;
+
+@Getter
+@AllArgsConstructor
+public class InvalidNovelStatisticsException extends RuntimeException {
+
+    public InvalidNovelStatisticsException(NovelStatisticsErrorCode novelStatisticsErrorCode, String message){
+        super(message);
+        this.novelStatisticsErrorCode = novelStatisticsErrorCode;
+    }
+
+    private NovelStatisticsErrorCode novelStatisticsErrorCode;
+}

--- a/src/main/java/org/websoso/WSSServer/repository/NovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelRepository.java
@@ -1,6 +1,5 @@
 package org.websoso.WSSServer.repository;
 
-import jakarta.persistence.EntityNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Novel;

--- a/src/main/java/org/websoso/WSSServer/repository/NovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelRepository.java
@@ -1,0 +1,15 @@
+package org.websoso.WSSServer.repository;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.Novel;
+
+@Repository
+public interface NovelRepository extends JpaRepository<Novel, Long> {
+    default Novel findByNovelIdOrThrow(Long novelId){
+        return findById(novelId).orElseThrow(
+                () -> new EntityNotFoundException("존재하지 않는 작품입니다.")
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/repository/NovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelRepository.java
@@ -7,9 +7,4 @@ import org.websoso.WSSServer.domain.Novel;
 
 @Repository
 public interface NovelRepository extends JpaRepository<Novel, Long> {
-    default Novel findByNovelIdOrThrow(Long novelId){
-        return findById(novelId).orElseThrow(
-                () -> new EntityNotFoundException("존재하지 않는 작품입니다.")
-        );
-    }
 }

--- a/src/main/java/org/websoso/WSSServer/repository/NovelStatisticsRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelStatisticsRepository.java
@@ -1,8 +1,6 @@
 package org.websoso.WSSServer.repository;
 
-import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
-import javax.swing.text.html.Option;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Novel;

--- a/src/main/java/org/websoso/WSSServer/repository/NovelStatisticsRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelStatisticsRepository.java
@@ -1,0 +1,18 @@
+package org.websoso.WSSServer.repository;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Optional;
+import javax.swing.text.html.Option;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.NovelStatistics;
+
+@Repository
+public interface NovelStatisticsRepository extends JpaRepository<NovelStatistics, Long> {
+    Optional<NovelStatistics> findByNovel(Novel novel);
+
+    default NovelStatistics findByNovelOrThrow(Novel novel) {
+        return findByNovel(novel).orElseThrow(() -> new EntityNotFoundException(""));
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/repository/NovelStatisticsRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelStatisticsRepository.java
@@ -12,7 +12,4 @@ import org.websoso.WSSServer.domain.NovelStatistics;
 public interface NovelStatisticsRepository extends JpaRepository<NovelStatistics, Long> {
     Optional<NovelStatistics> findByNovel(Novel novel);
 
-    default NovelStatistics findByNovelOrThrow(Novel novel) {
-        return findByNovel(novel).orElseThrow(() -> new EntityNotFoundException(""));
-    }
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
@@ -1,7 +1,5 @@
 package org.websoso.WSSServer.repository;
 
-import jakarta.persistence.EntityNotFoundException;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
@@ -13,7 +13,4 @@ import org.websoso.WSSServer.domain.UserNovel;
 public interface UserNovelRepository extends JpaRepository<UserNovel, Long> {
     Optional<UserNovel> findByNovelAndUser(Novel novel, User user);
 
-    default UserNovel findUserNovelByNovelAndUserOrThrow(Novel novel, User user) {
-        return findByNovelAndUser(novel, user).orElseThrow(() -> new EntityNotFoundException(""));
-    }
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
@@ -1,0 +1,19 @@
+package org.websoso.WSSServer.repository;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserNovel;
+
+@Repository
+public interface UserNovelRepository extends JpaRepository<UserNovel, Long> {
+    Optional<UserNovel> findByNovelAndUser(Novel novel, User user);
+
+    default UserNovel findUserNovelByNovelAndUserOrThrow(Novel novel, User user) {
+        return findByNovelAndUser(novel, user).orElseThrow(() -> new EntityNotFoundException(""));
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -1,7 +1,6 @@
 package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.exception.novel.NovelErrorCode.NOVEL_NOT_FOUND;
-import static org.websoso.WSSServer.exception.novelStatistics.NovelStatisticsErrorCode.NOVEL_STATISTICS_NOT_FOUND;
 
 import java.util.List;
 import java.util.Random;
@@ -10,30 +9,26 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.NovelGenre;
-import org.websoso.WSSServer.domain.NovelStatistics;
 import org.websoso.WSSServer.domain.User;
-import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.dto.novel.NovelGetResponse1;
 import org.websoso.WSSServer.exception.novel.exception.InvalidNovelException;
-import org.websoso.WSSServer.exception.novelStatistics.exception.InvalidNovelStatisticsException;
 import org.websoso.WSSServer.repository.NovelRepository;
-import org.websoso.WSSServer.repository.NovelStatisticsRepository;
-import org.websoso.WSSServer.repository.UserNovelRepository;
 
 @Service
 @RequiredArgsConstructor
 public class NovelService {
+
     private final NovelRepository novelRepository;
-    private final UserNovelRepository userNovelRepository;
-    private final NovelStatisticsRepository novelStatisticsRepository;
+    private final NovelStatisticsService novelStatisticsService;
+    private final UserNovelService userNovelService;
 
     public NovelGetResponse1 getNovelInfo1(User user, Long novelId) {
         Novel novel = getNovelOrException(novelId);
         List<NovelGenre> novelGenres = novel.getNovelGenres();
         return NovelGetResponse1.of(
                 novel,
-                getUserNovelOrNull(user, novel),
-                getNovelStatisticsOrException(novel),
+                userNovelService.getUserNovelOrNull(user, novel),
+                novelStatisticsService.getNovelStatisticsOrException(novel),
                 getNovelGenreNames(novelGenres),
                 getRandomNovelGenreImage(novelGenres)
         );
@@ -43,19 +38,6 @@ public class NovelService {
         return novelRepository.findById(novelId)
                 .orElseThrow(() -> new InvalidNovelException(NOVEL_NOT_FOUND,
                         "novel with the given id is not found"));
-    }
-
-    private NovelStatistics getNovelStatisticsOrException(Novel novel) {
-        return novelStatisticsRepository.findByNovel(novel).orElseThrow(
-                () -> new InvalidNovelStatisticsException(NOVEL_STATISTICS_NOT_FOUND,
-                        "novel statistics with the given novel is not found"));
-    }
-
-    private UserNovel getUserNovelOrNull(User user, Novel novel) {
-        if (user == null) {
-            return null;
-        }
-        return userNovelRepository.findByNovelAndUser(novel, user).orElse(null);
     }
 
     private String getNovelGenreNames(List<NovelGenre> novelGenres) {

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -56,7 +56,7 @@ public class NovelService {
 
     private String getNovelGenreNames(List<NovelGenre> novelGenres) {
         return novelGenres.stream().map(novelGenre -> novelGenre.getGenre().getGenreName())
-                .collect(Collectors.joining(", "));
+                .collect(Collectors.joining("/"));
     }
 
     private String getRandomNovelGenreImage(List<NovelGenre> novelGenres) {

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -11,6 +11,10 @@ import org.websoso.WSSServer.domain.NovelStatistics;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.dto.novel.NovelGetResponse;
+import org.websoso.WSSServer.exception.novel.NovelErrorCode;
+import org.websoso.WSSServer.exception.novel.exception.InvalidNovelException;
+import org.websoso.WSSServer.exception.novelStatistics.NovelStatisticsErrorCode;
+import org.websoso.WSSServer.exception.novelStatistics.exception.InvalidNovelStatisticsException;
 import org.websoso.WSSServer.repository.NovelRepository;
 import org.websoso.WSSServer.repository.NovelStatisticsRepository;
 import org.websoso.WSSServer.repository.UserNovelRepository;
@@ -23,14 +27,29 @@ public class NovelService {
     private final NovelStatisticsRepository novelStatisticsRepository;
 
     public NovelGetResponse getNovelInfo1(User user, Long novelId) {
-        Novel novel = novelRepository.findByNovelIdOrThrow(novelId);
-        UserNovel userNovel = userNovelRepository.findUserNovelByNovelAndUserOrThrow(novel, user);
-        // TODO 유저노벨 없는 경우 처리하는 코드 추가
-        NovelStatistics novelStatistics = novelStatisticsRepository.findByNovelOrThrow(novel);
+        Novel novel = getNovelOrException(novelId);
+        NovelStatistics novelStatistics = getNovelStatisticsOrException(novel);
+        UserNovel userNovel = getUserNovelOrNull(user, novel);
         List<NovelGenre> novelGenres = novel.getNovelGenres();
         String novelGenreNames = getNovelGenreNames(novelGenres);
         String randomNovelGenreImage = getRandomNovelGenreImage(novelGenres);
         return NovelGetResponse.of(novel, userNovel, novelStatistics, novelGenreNames, randomNovelGenreImage);
+    }
+
+    private Novel getNovelOrException(Long novelId) {
+        return novelRepository.findById(novelId).orElseThrow(
+                () -> new InvalidNovelException(NovelErrorCode.NOVEL_NOT_FOUND,
+                        "novel with the given id is not found"));
+    }
+
+    private NovelStatistics getNovelStatisticsOrException(Novel novel) {
+        return novelStatisticsRepository.findByNovel(novel).orElseThrow(
+                () -> new InvalidNovelStatisticsException(NovelStatisticsErrorCode.NOVEL_STATISTICS_NOT_FOUND,
+                        "novel statistics with the given novel is not found"));
+    }
+
+    private UserNovel getUserNovelOrNull(User user, Novel novel) {
+        return userNovelRepository.findByNovelAndUser(novel, user).orElse(null);
     }
 
     private String getNovelGenreNames(List<NovelGenre> novelGenres) {
@@ -42,4 +61,5 @@ public class NovelService {
         Random random = new Random();
         return novelGenres.get(random.nextInt(novelGenres.size())).getGenre().getGenreImage();
     }
+
 }

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -1,12 +1,12 @@
 package org.websoso.WSSServer.service;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.NovelGenre;
 import org.websoso.WSSServer.domain.NovelStatistics;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserNovel;
@@ -22,10 +22,24 @@ public class NovelService {
     private final UserNovelRepository userNovelRepository;
     private final NovelStatisticsRepository novelStatisticsRepository;
 
-    public NovelGetResponse getNovelInfo1(User user, Long novelId){
+    public NovelGetResponse getNovelInfo1(User user, Long novelId) {
         Novel novel = novelRepository.findByNovelIdOrThrow(novelId);
         UserNovel userNovel = userNovelRepository.findUserNovelByNovelAndUserOrThrow(novel, user);
+        // TODO 유저노벨 없는 경우 처리하는 코드 추가
         NovelStatistics novelStatistics = novelStatisticsRepository.findByNovelOrThrow(novel);
-        return NovelGetResponse.of(novel, userNovel, novelStatistics);
+        List<NovelGenre> novelGenres = novel.getNovelGenres();
+        String novelGenreNames = getNovelGenreNames(novelGenres);
+        String randomNovelGenreImage = getRandomNovelGenreImage(novelGenres);
+        return NovelGetResponse.of(novel, userNovel, novelStatistics, novelGenreNames, randomNovelGenreImage);
+    }
+
+    private String getNovelGenreNames(List<NovelGenre> novelGenres) {
+        return novelGenres.stream().map(novelGenre -> novelGenre.getGenre().getGenreName())
+                .collect(Collectors.joining(", "));
+    }
+
+    private String getRandomNovelGenreImage(List<NovelGenre> novelGenres) {
+        Random random = new Random();
+        return novelGenres.get(random.nextInt(novelGenres.size())).getGenre().getGenreImage();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -52,6 +52,9 @@ public class NovelService {
     }
 
     private UserNovel getUserNovelOrNull(User user, Novel novel) {
+        if (user == null) {
+            return null;
+        }
         return userNovelRepository.findByNovelAndUser(novel, user).orElse(null);
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -28,12 +28,14 @@ public class NovelService {
 
     public NovelGetResponse1 getNovelInfo1(User user, Long novelId) {
         Novel novel = getNovelOrException(novelId);
-        NovelStatistics novelStatistics = getNovelStatisticsOrException(novel);
-        UserNovel userNovel = getUserNovelOrNull(user, novel);
         List<NovelGenre> novelGenres = novel.getNovelGenres();
-        String novelGenreNames = getNovelGenreNames(novelGenres);
-        String randomNovelGenreImage = getRandomNovelGenreImage(novelGenres);
-        return NovelGetResponse1.of(novel, userNovel, novelStatistics, novelGenreNames, randomNovelGenreImage);
+        return NovelGetResponse1.of(
+                novel,
+                getUserNovelOrNull(user, novel),
+                getNovelStatisticsOrException(novel),
+                getNovelGenreNames(novelGenres),
+                getRandomNovelGenreImage(novelGenres)
+        );
     }
 
     private Novel getNovelOrException(Long novelId) {

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -1,5 +1,8 @@
 package org.websoso.WSSServer.service;
 
+import static org.websoso.WSSServer.exception.novel.NovelErrorCode.NOVEL_NOT_FOUND;
+import static org.websoso.WSSServer.exception.novelStatistics.NovelStatisticsErrorCode.NOVEL_STATISTICS_NOT_FOUND;
+
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -11,9 +14,7 @@ import org.websoso.WSSServer.domain.NovelStatistics;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.dto.novel.NovelGetResponse1;
-import org.websoso.WSSServer.exception.novel.NovelErrorCode;
 import org.websoso.WSSServer.exception.novel.exception.InvalidNovelException;
-import org.websoso.WSSServer.exception.novelStatistics.NovelStatisticsErrorCode;
 import org.websoso.WSSServer.exception.novelStatistics.exception.InvalidNovelStatisticsException;
 import org.websoso.WSSServer.repository.NovelRepository;
 import org.websoso.WSSServer.repository.NovelStatisticsRepository;
@@ -39,14 +40,14 @@ public class NovelService {
     }
 
     private Novel getNovelOrException(Long novelId) {
-        return novelRepository.findById(novelId).orElseThrow(
-                () -> new InvalidNovelException(NovelErrorCode.NOVEL_NOT_FOUND,
+        return novelRepository.findById(novelId)
+                .orElseThrow(() -> new InvalidNovelException(NOVEL_NOT_FOUND,
                         "novel with the given id is not found"));
     }
 
     private NovelStatistics getNovelStatisticsOrException(Novel novel) {
         return novelStatisticsRepository.findByNovel(novel).orElseThrow(
-                () -> new InvalidNovelStatisticsException(NovelStatisticsErrorCode.NOVEL_STATISTICS_NOT_FOUND,
+                () -> new InvalidNovelStatisticsException(NOVEL_STATISTICS_NOT_FOUND,
                         "novel statistics with the given novel is not found"));
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -1,0 +1,31 @@
+package org.websoso.WSSServer.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.NovelStatistics;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserNovel;
+import org.websoso.WSSServer.dto.novel.NovelGetResponse;
+import org.websoso.WSSServer.repository.NovelRepository;
+import org.websoso.WSSServer.repository.NovelStatisticsRepository;
+import org.websoso.WSSServer.repository.UserNovelRepository;
+
+@Service
+@RequiredArgsConstructor
+public class NovelService {
+    private final NovelRepository novelRepository;
+    private final UserNovelRepository userNovelRepository;
+    private final NovelStatisticsRepository novelStatisticsRepository;
+
+    public NovelGetResponse getNovelInfo1(User user, Long novelId){
+        Novel novel = novelRepository.findByNovelIdOrThrow(novelId);
+        UserNovel userNovel = userNovelRepository.findUserNovelByNovelAndUserOrThrow(novel, user);
+        NovelStatistics novelStatistics = novelStatisticsRepository.findByNovelOrThrow(novel);
+        return NovelGetResponse.of(novel, userNovel, novelStatistics);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -10,7 +10,7 @@ import org.websoso.WSSServer.domain.NovelGenre;
 import org.websoso.WSSServer.domain.NovelStatistics;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserNovel;
-import org.websoso.WSSServer.dto.novel.NovelGetResponse;
+import org.websoso.WSSServer.dto.novel.NovelGetResponse1;
 import org.websoso.WSSServer.exception.novel.NovelErrorCode;
 import org.websoso.WSSServer.exception.novel.exception.InvalidNovelException;
 import org.websoso.WSSServer.exception.novelStatistics.NovelStatisticsErrorCode;
@@ -26,14 +26,14 @@ public class NovelService {
     private final UserNovelRepository userNovelRepository;
     private final NovelStatisticsRepository novelStatisticsRepository;
 
-    public NovelGetResponse getNovelInfo1(User user, Long novelId) {
+    public NovelGetResponse1 getNovelInfo1(User user, Long novelId) {
         Novel novel = getNovelOrException(novelId);
         NovelStatistics novelStatistics = getNovelStatisticsOrException(novel);
         UserNovel userNovel = getUserNovelOrNull(user, novel);
         List<NovelGenre> novelGenres = novel.getNovelGenres();
         String novelGenreNames = getNovelGenreNames(novelGenres);
         String randomNovelGenreImage = getRandomNovelGenreImage(novelGenres);
-        return NovelGetResponse.of(novel, userNovel, novelStatistics, novelGenreNames, randomNovelGenreImage);
+        return NovelGetResponse1.of(novel, userNovel, novelStatistics, novelGenreNames, randomNovelGenreImage);
     }
 
     private Novel getNovelOrException(Long novelId) {

--- a/src/main/java/org/websoso/WSSServer/service/NovelStatisticsService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelStatisticsService.java
@@ -1,0 +1,23 @@
+package org.websoso.WSSServer.service;
+
+import static org.websoso.WSSServer.exception.novelStatistics.NovelStatisticsErrorCode.NOVEL_STATISTICS_NOT_FOUND;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.NovelStatistics;
+import org.websoso.WSSServer.exception.novelStatistics.exception.InvalidNovelStatisticsException;
+import org.websoso.WSSServer.repository.NovelStatisticsRepository;
+
+@Service
+@RequiredArgsConstructor
+public class NovelStatisticsService {
+
+    private final NovelStatisticsRepository novelStatisticsRepository;
+
+    protected NovelStatistics getNovelStatisticsOrException(Novel novel) {
+        return novelStatisticsRepository.findByNovel(novel).orElseThrow(
+                () -> new InvalidNovelStatisticsException(NOVEL_STATISTICS_NOT_FOUND,
+                        "novel statistics with the given novel is not found"));
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -1,0 +1,23 @@
+package org.websoso.WSSServer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserNovel;
+import org.websoso.WSSServer.repository.UserNovelRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UserNovelService {
+
+    private final UserNovelRepository userNovelRepository;
+
+    protected UserNovel getUserNovelOrNull(User user, Novel novel) {
+        if (user == null) {
+            return null;
+        }
+        return userNovelRepository.findByNovelAndUser(novel, user).orElse(null);
+    }
+
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#20 -> dev
- close #20 

## Key Changes
<!-- 최대한 자세히 -->
- 로그인하지 않은 경우에도 작품 정보를 조회할 수 있도록 하였습니다.
- 작품 장르의 경우, 장르 테이블의 `genreName`들이 `,`(콤마)로 이어지고, `genreImage`의 경우 자신의 장르 중 랜덤하게 한 장르를 골라 뱃지 이미지를 전달하도록 하였습니다.
- 유저노벨, 즉 서재에 등록되지 않은 작품이라면(+ 로그인하지 않은 사용자라면) 관련 사항에 관해서는 null 값을 전달하도록 하였습니다. 다만 `isUserNovelInterest`의 경우에는 api 명세서에 따라 로그인하지 않은 경우나 서재에 등록되지 않은 경우에 `false`를 전달하게 되며, 작품 별점은 0.0을 전달하게 됩니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 현재 dto(`NovelGetResponse`)에 `userNovel`이 null값인지 확인하는 절차가 여러줄에 걸쳐 있는데, 그냥 if문으로 한번에 처리하는게 나을까요?
- 현재 `getNovelInfo1`, `NovelGetResponse1`과 같은 함수명, 클래스명들은 작품정보조회 api 개발이 완료되면 각각의 세부 기능에 따라 한번에 이름을 다시 지을 예정입니다!

## References
<!-- 참고한 자료-->
