### PR TITLE
[FIX] Novel의 genre 글자수 제한 삭제

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Novel.java
@@ -34,7 +34,7 @@ public class Novel {
     @Column(nullable = false)
     private String author;
 
-    @Column(columnDefinition = "varchar(5)", nullable = false)
+    @Column(nullable = false)
     private String genre;
 
     @Column(columnDefinition = "text", nullable = false)


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#21 -> dev
- close #21 

## Key Changes
<!-- 최대한 자세히 -->
- 작품의 장르에 두가지 이상의 장르가 들어갈 수 있어 장르에 대한 글자수 제한을 삭제하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
