### PR TITLE
[FEAT] 소소피드 수정 API 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -1,17 +1,21 @@
 package org.websoso.WSSServer.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
+import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 import org.websoso.WSSServer.service.FeedService;
 import org.websoso.WSSServer.service.UserService;
 
@@ -33,4 +37,17 @@ public class FeedController {
                 .status(CREATED)
                 .build();
     }
+
+    @PutMapping("/{feedId}")
+    public ResponseEntity<Void> updateFeed(Principal principal,
+                                           @PathVariable("feedId") Long feedId,
+                                           @Valid @RequestBody FeedUpdateRequest request) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        feedService.updateFeed(user, feedId, request);
+
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Category.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Category.java
@@ -15,10 +15,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.DynamicInsert;
 import org.websoso.WSSServer.domain.common.Flag;
 
-@DynamicInsert
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -84,8 +82,9 @@ public class Category {
     private Feed feed;
 
     @Builder
-    public Category(Flag isRf, Flag isRo, Flag isFa, Flag isMf, Flag isDr, Flag isLn, Flag isWu, Flag isMy, Flag isBl,
-                    Flag isEtc, Feed feed) {
+    public Category(Long categoryId, Flag isRf, Flag isRo, Flag isFa, Flag isMf, Flag isDr, Flag isLn, Flag isWu,
+                    Flag isMy, Flag isBl, Flag isEtc, Feed feed) {
+        this.categoryId = categoryId;
         this.isRf = isRf;
         this.isRo = isRo;
         this.isFa = isFa;
@@ -98,4 +97,5 @@ public class Category {
         this.isEtc = isEtc;
         this.feed = feed;
     }
+
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -2,6 +2,7 @@ package org.websoso.WSSServer.domain;
 
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.GenerationType.IDENTITY;
+import static org.websoso.WSSServer.exception.user.UserErrorCode.INVALID_AUTHORIZED;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,16 +18,16 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+import org.websoso.WSSServer.domain.common.Action;
 import org.websoso.WSSServer.domain.common.BaseEntity;
 import org.websoso.WSSServer.domain.common.Flag;
+import org.websoso.WSSServer.exception.user.exception.InvalidAuthorizedException;
 
 @DynamicInsert
 @Entity
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Feed extends BaseEntity {
 
@@ -86,4 +87,12 @@ public class Feed extends BaseEntity {
         this.isSpoiler = isSpoiler;
         this.novelId = novelId;
     }
+
+    public void validateUserAuthorization(User user, Action action) {
+        if (!this.user.equals(user)) {
+            throw new InvalidAuthorizedException(INVALID_AUTHORIZED,
+                    "only the author can " + action.getDescription() + " the feed");
+        }
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -80,4 +80,10 @@ public class Feed extends BaseEntity {
         this.novelId = novelId;
         this.user = user;
     }
+
+    public void updateFeed(String feedContent, Flag isSpoiler, Long novelId) {
+        this.feedContent = feedContent;
+        this.isSpoiler = isSpoiler;
+        this.novelId = novelId;
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/common/Action.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/Action.java
@@ -1,0 +1,14 @@
+package org.websoso.WSSServer.domain.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Action {
+    UPDATE("update"),
+    DELETE("delete");
+
+    private final String description;
+
+}

--- a/src/main/java/org/websoso/WSSServer/domain/common/CategoryName.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/CategoryName.java
@@ -1,8 +1,10 @@
 package org.websoso.WSSServer.domain.common;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public enum CategoryName {
     RF("romanceFantasy"),
     RO("romance"),
@@ -16,9 +18,5 @@ public enum CategoryName {
     ETC("etc");
 
     private final String value;
-
-    CategoryName(String value) {
-        this.value = value;
-    }
-
+    
 }

--- a/src/main/java/org/websoso/WSSServer/domain/common/CategoryName.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/CategoryName.java
@@ -1,0 +1,24 @@
+package org.websoso.WSSServer.domain.common;
+
+import lombok.Getter;
+
+@Getter
+public enum CategoryName {
+    RF("romanceFantasy"),
+    RO("romance"),
+    FA("fantasy"),
+    MF("modernFantasy"),
+    DR("drama"),
+    LN("lightNovel"),
+    WU("wuxia"),
+    MY("mystery"),
+    BL("BL"),
+    ETC("etc");
+
+    private final String value;
+
+    CategoryName(String value) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedUpdateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedUpdateRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
-public record FeedCreateRequest(
+public record FeedUpdateRequest(
         @NotNull(message = "카테고리는 null일 수 없습니다.")
         @NotEmpty(message = "카테고리는 1개 이상 선택해야 합니다.")
         List<String> relevantCategories,

--- a/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.websoso.WSSServer.exception.category.CategoryErrorCode;
 import org.websoso.WSSServer.exception.category.exception.InvalidCategoryException;
 import org.websoso.WSSServer.exception.common.ErrorResult;
 import org.websoso.WSSServer.exception.user.UserErrorCode;
+import org.websoso.WSSServer.exception.user.exception.InvalidAuthorizedException;
 import org.websoso.WSSServer.exception.user.exception.InvalidNicknameException;
 import org.websoso.WSSServer.exception.user.exception.InvalidUserException;
 
@@ -44,8 +45,15 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResult(categoryErrorCode.getCode(), categoryErrorCode.getDescription()));
     }
 
+    @ExceptionHandler(InvalidAuthorizedException.class)
+    public ErrorResult InvalidUserAuthorizedExceptionHandler(InvalidAuthorizedException e) {
+        log.error("[InvalidAuthorizedException] exception ", e);
+        UserErrorCode userErrorCode = e.getUserErrorCode();
+        return new ErrorResult(userErrorCode.getCode(), userErrorCode.getDescription());
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResult> InvalidFeedExceptionHandler(MethodArgumentNotValidException e) {
+    public ResponseEntity<ErrorResult> InvalidRequestBodyExceptionHandler(MethodArgumentNotValidException e) {
         log.error("[MethodArgumentNotValidException] exception ", e);
         HttpStatus httpStatus = HttpStatus.valueOf(e.getStatusCode().value());
         return ResponseEntity.status(httpStatus)

--- a/src/main/java/org/websoso/WSSServer/exception/category/CategoryErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/category/CategoryErrorCode.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.exception.category;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,7 +12,8 @@ import org.websoso.WSSServer.exception.common.IErrorCode;
 @Getter
 public enum CategoryErrorCode implements IErrorCode {
 
-    INVALID_CATEGORY_FORMAT("CATEGORY-001", "카테고리 형식이 잘못되었습니다.", BAD_REQUEST);
+    INVALID_CATEGORY_FORMAT("CATEGORY-001", "카테고리 형식이 잘못되었습니다.", BAD_REQUEST),
+    CATEGORY_NOT_FOUND("CATEGORY-002", "피드에 카테고리가 존재하지 않습니다.", NOT_FOUND);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/exception/feed/FeedErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/feed/FeedErrorCode.java
@@ -1,0 +1,15 @@
+package org.websoso.WSSServer.exception.feed;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.websoso.WSSServer.exception.common.IErrorCode;
+
+@Getter
+@AllArgsConstructor
+public enum FeedErrorCode implements IErrorCode {
+
+    FEED_NOT_FOUND("FEED-001", "해당 ID를 가진 피드를 찾을 수 없습니다.");
+
+    private final String code;
+    private final String description;
+}

--- a/src/main/java/org/websoso/WSSServer/exception/feed/exeption/InvalidFeedException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/feed/exeption/InvalidFeedException.java
@@ -1,0 +1,17 @@
+package org.websoso.WSSServer.exception.feed.exeption;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.websoso.WSSServer.exception.feed.FeedErrorCode;
+
+@Getter
+@AllArgsConstructor
+public class InvalidFeedException extends RuntimeException {
+
+    public InvalidFeedException(FeedErrorCode feedErrorCode, String message) {
+        super(message);
+        this.feedErrorCode = feedErrorCode;
+    }
+
+    private FeedErrorCode feedErrorCode;
+}

--- a/src/main/java/org/websoso/WSSServer/exception/user/UserErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/user/UserErrorCode.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.exception.user;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.AllArgsConstructor;
@@ -17,7 +18,8 @@ public enum UserErrorCode implements IErrorCode {
     INVALID_NICKNAME_START_OR_END_WITH_BLANK("USER-003", "닉네임은 공백으로 시작하거나 끝날 수 없습니다.", BAD_REQUEST),
     INVALID_NICKNAME_LENGTH("USER-004", "닉네임의 길이가 2 ~ 10자가 아닙니다.", BAD_REQUEST),
     INVALID_NICKNAME_PATTERN("USER-005", "닉네임은 한글, 영문, 숫자, 특수문자(-, _)로만 이루어져아 합니다.", BAD_REQUEST),
-    USER_NOT_FOUND("USER-006", "해당 ID를 가진 사용자를 찾을 수 없습니다.", NOT_FOUND);
+    USER_NOT_FOUND("USER-006", "해당 ID를 가진 사용자를 찾을 수 없습니다.", NOT_FOUND),
+    INVALID_AUTHORIZED("USER-007", "사용자에게 권한이 없습니다.", FORBIDDEN);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/exception/user/exception/InvalidAuthorizedException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/user/exception/InvalidAuthorizedException.java
@@ -1,0 +1,18 @@
+package org.websoso.WSSServer.exception.user.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.websoso.WSSServer.exception.user.UserErrorCode;
+
+@Getter
+@AllArgsConstructor
+public class InvalidAuthorizedException extends RuntimeException {
+
+    public InvalidAuthorizedException(UserErrorCode userErrorCode, String message) {
+        super(message);
+        this.userErrorCode = userErrorCode;
+    }
+
+    private UserErrorCode userErrorCode;
+}
+

--- a/src/main/java/org/websoso/WSSServer/repository/CategoryRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/CategoryRepository.java
@@ -1,9 +1,13 @@
 package org.websoso.WSSServer.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Category;
+import org.websoso.WSSServer.domain.Feed;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    Optional<Category> findByFeed(Feed feed);
 }

--- a/src/main/java/org/websoso/WSSServer/service/CategoryService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CategoryService.java
@@ -1,8 +1,21 @@
 package org.websoso.WSSServer.service;
 
+import static org.websoso.WSSServer.domain.common.CategoryName.BL;
+import static org.websoso.WSSServer.domain.common.CategoryName.DR;
+import static org.websoso.WSSServer.domain.common.CategoryName.ETC;
+import static org.websoso.WSSServer.domain.common.CategoryName.FA;
+import static org.websoso.WSSServer.domain.common.CategoryName.LN;
+import static org.websoso.WSSServer.domain.common.CategoryName.MF;
+import static org.websoso.WSSServer.domain.common.CategoryName.MY;
+import static org.websoso.WSSServer.domain.common.CategoryName.RF;
+import static org.websoso.WSSServer.domain.common.CategoryName.RO;
+import static org.websoso.WSSServer.domain.common.CategoryName.WU;
+import static org.websoso.WSSServer.domain.common.Flag.N;
 import static org.websoso.WSSServer.domain.common.Flag.Y;
+import static org.websoso.WSSServer.exception.category.CategoryErrorCode.CATEGORY_NOT_FOUND;
 import static org.websoso.WSSServer.exception.category.CategoryErrorCode.INVALID_CATEGORY_FORMAT;
 
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Category;
 import org.websoso.WSSServer.domain.Category.CategoryBuilder;
 import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.common.CategoryName;
+import org.websoso.WSSServer.domain.common.Flag;
 import org.websoso.WSSServer.exception.category.exception.InvalidCategoryException;
 import org.websoso.WSSServer.repository.CategoryRepository;
 
@@ -24,26 +39,53 @@ public class CategoryService {
         CategoryBuilder builder = Category.builder()
                 .feed(feed);
 
-        for (String category : relevantCategories) {
-            setCategory(builder, category);
-        }
+        Category category = setCategory(builder, relevantCategories);
 
-        Category category = builder.build();
         categoryRepository.save(category);
     }
 
-    private void setCategory(CategoryBuilder builder, String category) {
-        switch (category) {
-            case "romanceFantasy" -> builder.isRf(Y);
-            case "romance" -> builder.isRo(Y);
-            case "fantasy" -> builder.isFa(Y);
-            case "modernFantasy" -> builder.isMf(Y);
-            case "drama" -> builder.isDr(Y);
-            case "lightNovel" -> builder.isLn(Y);
-            case "wuxia" -> builder.isWu(Y);
-            case "mystery" -> builder.isMy(Y);
-            case "BL" -> builder.isBl(Y);
-            default -> throw new InvalidCategoryException(INVALID_CATEGORY_FORMAT, "invalid category format");
+    @Transactional
+    public void updateCategory(Feed feed, List<String> relevantCategories) {
+        Long categoryId = categoryRepository.findByFeed(feed).orElseThrow(() ->
+                        new InvalidCategoryException(CATEGORY_NOT_FOUND, "Category for the given feed was not found"))
+                .getCategoryId();
+
+        CategoryBuilder builder = Category.builder()
+                .categoryId(categoryId)
+                .feed(feed);
+
+        Category category = setCategory(builder, relevantCategories);
+
+        categoryRepository.save(category);
+    }
+
+    private Category setCategory(CategoryBuilder builder, List<String> relevantCategories) {
+        validateCategory(relevantCategories);
+
+        return builder
+                .isRf(getCategoryFlag(relevantCategories, RF))
+                .isRo(getCategoryFlag(relevantCategories, RO))
+                .isFa(getCategoryFlag(relevantCategories, FA))
+                .isMf(getCategoryFlag(relevantCategories, MF))
+                .isDr(getCategoryFlag(relevantCategories, DR))
+                .isLn(getCategoryFlag(relevantCategories, LN))
+                .isWu(getCategoryFlag(relevantCategories, WU))
+                .isMy(getCategoryFlag(relevantCategories, MY))
+                .isBl(getCategoryFlag(relevantCategories, BL))
+                .isEtc(getCategoryFlag(relevantCategories, ETC))
+                .build();
+    }
+
+    private void validateCategory(List<String> relevantCategories) {
+        List<String> categoryNames = Arrays.stream(CategoryName.values()).map(CategoryName::getValue).toList();
+
+        if (!categoryNames.containsAll(relevantCategories)) {
+            throw new InvalidCategoryException(INVALID_CATEGORY_FORMAT, "invalid category format");
         }
     }
+
+    private Flag getCategoryFlag(List<String> relevantCategories, CategoryName categoryName) {
+        return relevantCategories.contains(categoryName.getValue()) ? Y : N;
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -1,9 +1,9 @@
 package org.websoso.WSSServer.service;
 
+import static org.websoso.WSSServer.domain.common.Action.UPDATE;
 import static org.websoso.WSSServer.domain.common.Flag.N;
 import static org.websoso.WSSServer.domain.common.Flag.Y;
 import static org.websoso.WSSServer.exception.feed.FeedErrorCode.FEED_NOT_FOUND;
-import static org.websoso.WSSServer.exception.user.UserErrorCode.INVALID_AUTHORIZED;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,7 +13,6 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 import org.websoso.WSSServer.exception.feed.exeption.InvalidFeedException;
-import org.websoso.WSSServer.exception.user.exception.InvalidAuthorizedException;
 import org.websoso.WSSServer.repository.FeedRepository;
 
 @Service
@@ -41,10 +40,7 @@ public class FeedService {
         Feed feed = feedRepository.findById(feedId).orElseThrow(() ->
                 new InvalidFeedException(FEED_NOT_FOUND, "feed with the given id was not found"));
 
-        if (feed.getUser() != user) {
-            throw new InvalidAuthorizedException(INVALID_AUTHORIZED,
-                    "only the author can update the feed");
-        }
+        feed.validateUserAuthorization(user, UPDATE);
 
         feed.updateFeed(request.feedContent(), request.isSpoiler() ? Y : N, request.novelId());
         categoryService.updateCategory(feed, request.relevantCategories());

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -2,6 +2,8 @@ package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.domain.common.Flag.N;
 import static org.websoso.WSSServer.domain.common.Flag.Y;
+import static org.websoso.WSSServer.exception.feed.FeedErrorCode.FEED_NOT_FOUND;
+import static org.websoso.WSSServer.exception.user.UserErrorCode.INVALID_AUTHORIZED;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,6 +11,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
+import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
+import org.websoso.WSSServer.exception.feed.exeption.InvalidFeedException;
+import org.websoso.WSSServer.exception.user.exception.InvalidAuthorizedException;
 import org.websoso.WSSServer.repository.FeedRepository;
 
 @Service
@@ -29,6 +34,20 @@ public class FeedService {
 
         feedRepository.save(feed);
         categoryService.createCategory(feed, request.relevantCategories());
+    }
+
+    @Transactional
+    public void updateFeed(User user, Long feedId, FeedUpdateRequest request) {
+        Feed feed = feedRepository.findById(feedId).orElseThrow(() ->
+                new InvalidFeedException(FEED_NOT_FOUND, "feed with the given id was not found"));
+
+        if (feed.getUser() != user) {
+            throw new InvalidAuthorizedException(INVALID_AUTHORIZED,
+                    "only the author can update the feed");
+        }
+
+        feed.updateFeed(request.feedContent(), request.isSpoiler() ? Y : N, request.novelId());
+        categoryService.updateCategory(feed, request.relevantCategories());
     }
 
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#18 -> dev
- close #18

## Key Changes
<!-- 최대한 자세히 -->
### 소소피드 수정 API를 구현했습니다.

- 수정(Update) 구현 방식인 Setter방식과 Builder 방식 중 `Feed` 엔티티는 **Setter 방식**, `Category` 엔티티는 **Builder 방식**을 택했습니다.
일반적으로 Setter + 더티체킹을 이용하여 Update 하지만, Category 엔티티는 Request로 받은 카테고리들의 컬럼을 `Flag.Y`로, 나머지는 `Flag.N`으로 변경해주어야 하기 때문에, Builder 로 덮어씌우는 Update 방식이 적합하다고 판단했습니다.
- 카테고리 명 Enum 클래스(CategoryName)를 만들어 카테고리 이름들을 상수로 관리하도록 구현했습니다.
- CategoryService 내에서 수정(Update) 코드를 작성하다 보니 생성(Create) 코드와 중복되는 부분이 있어, 메서드로 분리하여 생성 코드의 리팩토링을 진행했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
X
