### PR TITLE
[FEAT] 소소피드 좋아요 API 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -50,4 +50,15 @@ public class FeedController {
                 .build();
     }
 
+    @PostMapping("/{feedId}/likes")
+    public ResponseEntity<Void> likeFeed(Principal principal,
+                                         @PathVariable("feedId") Long feedId) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        feedService.likeFeed(user, feedId);
+
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -102,12 +102,7 @@ public class Feed extends BaseEntity {
             throw new InvalidFeedException(ALREADY_LIKED, "already liked feed");
         }
 
-        if (this.likeUsers.isBlank()) {
-            this.likeUsers += likeUserId;
-        } else {
-            this.likeUsers += "," + likeUserId;
-        }
-
+        this.likeUsers += "{" + likeUserId + "}";
         this.likeCount++;
     }
 

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -97,7 +97,7 @@ public class Feed extends BaseEntity {
         }
     }
 
-    public void updateLikeUsers(String likeUserId) {
+    public void addLike(String likeUserId) {
         if (this.likeUsers.contains(likeUserId)) {
             throw new InvalidFeedException(ALREADY_LIKED, "already liked feed");
         }
@@ -107,6 +107,8 @@ public class Feed extends BaseEntity {
         } else {
             this.likeUsers += "," + likeUserId;
         }
+
+        this.likeCount++;
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -2,6 +2,7 @@ package org.websoso.WSSServer.domain;
 
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.GenerationType.IDENTITY;
+import static org.websoso.WSSServer.exception.feed.FeedErrorCode.ALREADY_LIKED;
 import static org.websoso.WSSServer.exception.user.UserErrorCode.INVALID_AUTHORIZED;
 
 import jakarta.persistence.Column;
@@ -24,6 +25,7 @@ import org.hibernate.annotations.DynamicInsert;
 import org.websoso.WSSServer.domain.common.Action;
 import org.websoso.WSSServer.domain.common.BaseEntity;
 import org.websoso.WSSServer.domain.common.Flag;
+import org.websoso.WSSServer.exception.feed.exception.InvalidFeedException;
 import org.websoso.WSSServer.exception.user.exception.InvalidAuthorizedException;
 
 @DynamicInsert
@@ -92,6 +94,18 @@ public class Feed extends BaseEntity {
         if (!this.user.equals(user)) {
             throw new InvalidAuthorizedException(INVALID_AUTHORIZED,
                     "only the author can " + action.getDescription() + " the feed");
+        }
+    }
+
+    public void updateLikeUsers(String likeUserId) {
+        if (this.likeUsers.contains(likeUserId)) {
+            throw new InvalidFeedException(ALREADY_LIKED, "already liked feed");
+        }
+
+        if (this.likeUsers.isBlank()) {
+            this.likeUsers += likeUserId;
+        } else {
+            this.likeUsers += "," + likeUserId;
         }
     }
 

--- a/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
@@ -48,10 +48,12 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(InvalidAuthorizedException.class)
-    public ErrorResult InvalidUserAuthorizedExceptionHandler(InvalidAuthorizedException e) {
+    public ResponseEntity<ErrorResult> InvalidUserAuthorizedExceptionHandler(InvalidAuthorizedException e) {
         log.error("[InvalidAuthorizedException] exception ", e);
         UserErrorCode userErrorCode = e.getUserErrorCode();
-        return new ErrorResult(userErrorCode.getCode(), userErrorCode.getDescription());
+        return ResponseEntity
+                .status(userErrorCode.getStatusCode())
+                .body(new ErrorResult(userErrorCode.getCode(), userErrorCode.getDescription()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.websoso.WSSServer.exception.category.CategoryErrorCode;
 import org.websoso.WSSServer.exception.category.exception.InvalidCategoryException;
 import org.websoso.WSSServer.exception.common.ErrorResult;
+import org.websoso.WSSServer.exception.feed.FeedErrorCode;
+import org.websoso.WSSServer.exception.feed.exception.InvalidFeedException;
 import org.websoso.WSSServer.exception.user.UserErrorCode;
 import org.websoso.WSSServer.exception.user.exception.InvalidAuthorizedException;
 import org.websoso.WSSServer.exception.user.exception.InvalidNicknameException;
@@ -59,6 +61,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(httpStatus)
                 .body(new ErrorResult(httpStatus.name(),
                         e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
+    }
+
+    @ExceptionHandler(InvalidFeedException.class)
+    public ResponseEntity<ErrorResult> InvalidFeedExceptionHandler(InvalidFeedException e) {
+        log.error("[InvalidFeedException] exception ", e);
+        FeedErrorCode feedErrorCode = e.getFeedErrorCode();
+        return ResponseEntity
+                .status(feedErrorCode.getStatusCode())
+                .body(new ErrorResult(feedErrorCode.getCode(), feedErrorCode.getDescription()));
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/exception/feed/FeedErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/feed/FeedErrorCode.java
@@ -1,15 +1,22 @@
 package org.websoso.WSSServer.exception.feed;
 
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 import org.websoso.WSSServer.exception.common.IErrorCode;
 
 @Getter
 @AllArgsConstructor
 public enum FeedErrorCode implements IErrorCode {
 
-    FEED_NOT_FOUND("FEED-001", "해당 ID를 가진 피드를 찾을 수 없습니다.");
+    FEED_NOT_FOUND("FEED-001", "해당 ID를 가진 피드를 찾을 수 없습니다.", NOT_FOUND),
+    ALREADY_LIKED("FEED-003", "이미 해당 피드에 좋아요를 눌렀습니다.", CONFLICT);
 
     private final String code;
     private final String description;
+    private final HttpStatus statusCode;
+
 }

--- a/src/main/java/org/websoso/WSSServer/exception/feed/exception/InvalidFeedException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/feed/exception/InvalidFeedException.java
@@ -1,0 +1,18 @@
+package org.websoso.WSSServer.exception.feed.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.websoso.WSSServer.exception.feed.FeedErrorCode;
+
+@Getter
+@AllArgsConstructor
+public class InvalidFeedException extends RuntimeException {
+
+    public InvalidFeedException(FeedErrorCode feedErrorCode, String message) {
+        super(message);
+        this.feedErrorCode = feedErrorCode;
+    }
+
+    private FeedErrorCode feedErrorCode;
+    
+}

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -46,4 +46,13 @@ public class FeedService {
         categoryService.updateCategory(feed, request.relevantCategories());
     }
 
+    public void likeFeed(User user, Long feedId) {
+        Feed feed = feedRepository.findById(feedId).orElseThrow(() ->
+                new InvalidFeedException(FEED_NOT_FOUND, "feed with the given id was not found"));
+
+        String likeUserId = String.valueOf(user.getUserId());
+
+        feed.updateLikeUsers(likeUserId);
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -51,7 +51,7 @@ public class FeedService {
 
         String likeUserId = String.valueOf(user.getUserId());
 
-        feed.updateLikeUsers(likeUserId);
+        feed.addLike(likeUserId);
     }
 
     private Feed getFeedOrException(Long feedId) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -37,22 +37,25 @@ public class FeedService {
 
     @Transactional
     public void updateFeed(User user, Long feedId, FeedUpdateRequest request) {
-        Feed feed = feedRepository.findById(feedId).orElseThrow(() ->
-                new InvalidFeedException(FEED_NOT_FOUND, "feed with the given id was not found"));
+        Feed feed = getFeedOrException(feedId);
 
         feed.validateUserAuthorization(user, UPDATE);
 
         feed.updateFeed(request.feedContent(), request.isSpoiler() ? Y : N, request.novelId());
         categoryService.updateCategory(feed, request.relevantCategories());
     }
-
+    
     public void likeFeed(User user, Long feedId) {
-        Feed feed = feedRepository.findById(feedId).orElseThrow(() ->
-                new InvalidFeedException(FEED_NOT_FOUND, "feed with the given id was not found"));
+        Feed feed = getFeedOrException(feedId);
 
         String likeUserId = String.valueOf(user.getUserId());
 
         feed.updateLikeUsers(likeUserId);
+    }
+
+    private Feed getFeedOrException(Long feedId) {
+        return feedRepository.findById(feedId).orElseThrow(() ->
+                new InvalidFeedException(FEED_NOT_FOUND, "feed with the given id was not found"));
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -44,7 +44,8 @@ public class FeedService {
         feed.updateFeed(request.feedContent(), request.isSpoiler() ? Y : N, request.novelId());
         categoryService.updateCategory(feed, request.relevantCategories());
     }
-    
+
+    @Transactional
     public void likeFeed(User user, Long feedId) {
         Feed feed = getFeedOrException(feedId);
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#29 -> dev
- close #29

## Key Changes
<!-- 최대한 자세히 -->
### 소소피드에 좋아요를 등록하는 API를 구현했습니다.

- 이미 좋아요를 등록한 소소피드라면 예외를 발생시킵니다.
- 특정 `Feed`의 좋아요 누른 유저들은 `likeUsers` 컬럼에 `userId`를 콤마(,)로 연결하여 저장합니다.

  특정 `Feed`에 좋아요 누른 유저가 한 명도 없을 때는 콤마 없이 저장하고, 한 명이라도 있을 때는 `,{userId}` 와 같이 연결하여 저장합니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X