### PR TITLE
[FIX] Genre 도메인 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/Genre.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Genre.java
@@ -1,0 +1,26 @@
+package org.websoso.WSSServer.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Genre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long genreId;
+
+    @Column(columnDefinition = "varchar(5)", nullable = false)
+    private String genreName;
+
+    @Column(columnDefinition = "text", nullable = false)
+    private String genreBadge;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/Genre.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Genre.java
@@ -25,7 +25,7 @@ public class Genre {
     private String genreName;
 
     @Column(columnDefinition = "text", nullable = false)
-    private String genreBadge;
+    private String genreImage;
 
     @OneToMany(mappedBy = "genre")
     private List<NovelGenre> novelGenres = new ArrayList<>();

--- a/src/main/java/org/websoso/WSSServer/domain/Genre.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Genre.java
@@ -5,6 +5,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,4 +26,7 @@ public class Genre {
 
     @Column(columnDefinition = "text", nullable = false)
     private String genreBadge;
+
+    @OneToMany(mappedBy = "genre")
+    private List<NovelGenre> novelGenres = new ArrayList<>();
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Novel.java
@@ -34,9 +34,6 @@ public class Novel {
     @Column(nullable = false)
     private String author;
 
-    @Column(nullable = false)
-    private String genre;
-
     @Column(columnDefinition = "text", nullable = false)
     private String novelImage;
 

--- a/src/main/java/org/websoso/WSSServer/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Novel.java
@@ -61,4 +61,7 @@ public class Novel {
 
     @OneToMany(mappedBy = "novel")
     private List<Platform> platforms = new ArrayList<>();
+
+    @OneToMany(mappedBy = "novel")
+    private List<NovelGenre> novelGenres = new ArrayList<>();
 }

--- a/src/main/java/org/websoso/WSSServer/domain/NovelGenre.java
+++ b/src/main/java/org/websoso/WSSServer/domain/NovelGenre.java
@@ -6,10 +6,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NovelGenre {
 
     @Id

--- a/src/main/java/org/websoso/WSSServer/domain/NovelGenre.java
+++ b/src/main/java/org/websoso/WSSServer/domain/NovelGenre.java
@@ -1,0 +1,26 @@
+package org.websoso.WSSServer.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class NovelGenre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long novelGenreId;
+
+    @ManyToOne
+    @JoinColumn(name = "novel_id")
+    private Novel novel;
+
+    @ManyToOne
+    @JoinColumn(name = "genre_id")
+    private Genre genre;
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#34 -> dev
- close #34 

## Key Changes
<!-- 최대한 자세히 -->
- genreName, genreBadge를 가진 Genre 도메인을 만들었습니다.
- 기존에 Genre에 있던 `String genre`는 삭제하였습니다.
- NovelGenre를 통하여 다대다 관계를 각각 일대다로 풀어줬습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 해당 관계가 맞는지 검토 부탁드립니다!
- genreBadge가 좋을지, genreImage가 좋을지... 변수 이름 추천받습니다.

## References
<!-- 참고한 자료-->
