### PR TITLE
[FIX] Genre 도메인 내 genreName 글자 수 제한 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/Genre.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Genre.java
@@ -21,7 +21,7 @@ public class Genre {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long genreId;
 
-    @Column(columnDefinition = "varchar(5)", nullable = false)
+    @Column(columnDefinition = "varchar(4)", nullable = false)
     private String genreName;
 
     @Column(columnDefinition = "text", nullable = false)


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/ #37 -> dev
- close #37 

## Key Changes
<!-- 최대한 자세히 -->
- "라이트노벨"을 "라노벨"로 표기함에 따라 최대 글자수 장르가 "미스터리"로 바뀌었습니다. 따라서 `genreName` 글자 수 제한 을 5->4로 수정하였습니다!

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
