### PR TITLE
[FEAT] 공지사항 조회/생성/수정/삭제 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/NoticeController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NoticeController.java
@@ -2,11 +2,13 @@ package org.websoso.WSSServer.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.OK;
 
 import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.notice.NoticeEditRequest;
 import org.websoso.WSSServer.dto.notice.NoticePostRequest;
+import org.websoso.WSSServer.dto.notice.NoticesGetResponse;
 import org.websoso.WSSServer.service.NoticeService;
 import org.websoso.WSSServer.service.UserService;
 
@@ -46,5 +49,13 @@ public class NoticeController {
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();
+    }
+
+    @GetMapping
+    public ResponseEntity<NoticesGetResponse> getNotices(Principal principal) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(OK)
+                .body(noticeService.getNotices(user));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/NoticeController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NoticeController.java
@@ -2,14 +2,17 @@ package org.websoso.WSSServer.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.notice.NoticePostRequest;
 import org.websoso.WSSServer.service.NoticeService;
+import org.websoso.WSSServer.service.UserService;
 
 @RestController
 @RequestMapping("/notices")
@@ -17,10 +20,13 @@ import org.websoso.WSSServer.service.NoticeService;
 public class NoticeController {
 
     private final NoticeService noticeService;
+    private final UserService userService;
 
     @PostMapping
-    public ResponseEntity<Void> createNotice(@RequestBody NoticePostRequest noticePostRequest) {
-        noticeService.createNotice(noticePostRequest);
+    public ResponseEntity<Void> createNotice(Principal principal,
+                                             @RequestBody NoticePostRequest noticePostRequest) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        noticeService.createNotice(user, noticePostRequest);
         return ResponseEntity
                 .status(CREATED)
                 .build();

--- a/src/main/java/org/websoso/WSSServer/controller/NoticeController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NoticeController.java
@@ -1,0 +1,28 @@
+package org.websoso.WSSServer.controller;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.websoso.WSSServer.dto.notice.NoticePostRequest;
+import org.websoso.WSSServer.service.NoticeService;
+
+@RestController
+@RequestMapping("/notices")
+@RequiredArgsConstructor
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @PostMapping
+    public ResponseEntity<Void> createNotice(@RequestBody NoticePostRequest noticePostRequest) {
+        noticeService.createNotice(noticePostRequest);
+        return ResponseEntity
+                .status(CREATED)
+                .build();
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/controller/NoticeController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NoticeController.java
@@ -2,6 +2,7 @@ package org.websoso.WSSServer.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
+import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +25,7 @@ public class NoticeController {
 
     @PostMapping
     public ResponseEntity<Void> createNotice(Principal principal,
-                                             @RequestBody NoticePostRequest noticePostRequest) {
+                                             @Valid @RequestBody NoticePostRequest noticePostRequest) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         noticeService.createNotice(user, noticePostRequest);
         return ResponseEntity

--- a/src/main/java/org/websoso/WSSServer/controller/NoticeController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NoticeController.java
@@ -1,16 +1,20 @@
 package org.websoso.WSSServer.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.dto.notice.NoticeEditRequest;
 import org.websoso.WSSServer.dto.notice.NoticePostRequest;
 import org.websoso.WSSServer.service.NoticeService;
 import org.websoso.WSSServer.service.UserService;
@@ -30,6 +34,17 @@ public class NoticeController {
         noticeService.createNotice(user, noticePostRequest);
         return ResponseEntity
                 .status(CREATED)
+                .build();
+    }
+
+    @PutMapping("/{noticeId}")
+    public ResponseEntity<Void> editNotice(Principal principal,
+                                           @PathVariable("noticeId") Long noticeId,
+                                           @Valid @RequestBody NoticeEditRequest noticeEditRequest) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        noticeService.editNotice(user, noticeId, noticeEditRequest);
+        return ResponseEntity
+                .status(NO_CONTENT)
                 .build();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/NoticeController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NoticeController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -57,5 +58,15 @@ public class NoticeController {
         return ResponseEntity
                 .status(OK)
                 .body(noticeService.getNotices(user));
+    }
+
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity<Void> deleteNotice(Principal principal,
+                                             @PathVariable("noticeId") Long noticeId) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        noticeService.deleteNotice(user, noticeId);
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Notice.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Notice.java
@@ -37,4 +37,10 @@ public class Notice extends BaseEntity {
         this.noticeContent = noticeContent;
         this.userId = userId;
     }
+
+    public void updateNotice(String noticeTitle, String noticeContent, Long userId) {
+        this.noticeTitle = noticeTitle;
+        this.noticeContent = noticeContent;
+        this.userId = userId;
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Notice.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Notice.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.websoso.WSSServer.domain.common.BaseEntity;
@@ -29,4 +30,11 @@ public class Notice extends BaseEntity {
 
     @Column
     private Long userId;
+
+    @Builder
+    private Notice(String noticeTitle, String noticeContent, Long userId) {
+        this.noticeTitle = noticeTitle;
+        this.noticeContent = noticeContent;
+        this.userId = userId;
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.websoso.WSSServer.domain.common.Flag;
 import org.websoso.WSSServer.domain.common.Gender;
+import org.websoso.WSSServer.domain.common.Role;
 
 @Entity
 @Getter
@@ -56,6 +57,11 @@ public class User {
     @Column(nullable = false)
     @ColumnDefault("'Y'")
     private Flag isProfilePublic;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'USER'")
+    private Role role;
 
     @OneToOne(mappedBy = "user", cascade = ALL)
     private GenrePreference genrePreference;

--- a/src/main/java/org/websoso/WSSServer/domain/common/Role.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/Role.java
@@ -1,0 +1,5 @@
+package org.websoso.WSSServer.domain.common;
+
+public enum Role {
+    ADMIN, USER
+}

--- a/src/main/java/org/websoso/WSSServer/dto/notice/NoticeEditRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notice/NoticeEditRequest.java
@@ -1,0 +1,20 @@
+package org.websoso.WSSServer.dto.notice;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.websoso.WSSServer.validation.UserIdConstraint;
+
+public record NoticeEditRequest(
+
+        @NotBlank(message = "공지 제목은 비어 있거나, 공백일 수 없습니다.")
+        @Size(max = 200, message = "공지 제목은 200자를 초과할 수 없습니다.")
+        String noticeTitle,
+
+        @NotBlank(message = "공지 내용은 비어 있거나, 공백일 수 없습니다.")
+        @Size(max = 2000, message = "공지 내용은 2000자를 초과할 수 없습니다.")
+        String noticeContent,
+
+        @UserIdConstraint
+        Long userId
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/dto/notice/NoticeGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notice/NoticeGetResponse.java
@@ -1,0 +1,8 @@
+package org.websoso.WSSServer.dto.notice;
+
+public record NoticeGetResponse(
+        String noticeTitle,
+        String noticeContent,
+        String createdDate
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/dto/notice/NoticeGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notice/NoticeGetResponse.java
@@ -1,8 +1,27 @@
 package org.websoso.WSSServer.dto.notice;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.websoso.WSSServer.domain.Notice;
+
 public record NoticeGetResponse(
         String noticeTitle,
         String noticeContent,
         String createdDate
 ) {
+
+    public static NoticeGetResponse from(Notice notice) {
+        return new NoticeGetResponse(
+                notice.getNoticeTitle(),
+                notice.getNoticeContent(),
+                formatDateString(notice.getCreatedDate())
+        );
+    }
+
+    private static String formatDateString(String dateTime) {
+        DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd a hh:mm");
+        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        LocalDateTime date = LocalDateTime.parse(dateTime, inputFormatter);
+        return date.format(outputFormatter);
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/notice/NoticePostRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notice/NoticePostRequest.java
@@ -1,8 +1,18 @@
 package org.websoso.WSSServer.dto.notice;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record NoticePostRequest(
+
+        @NotBlank(message = "공지 제목은 비어 있거나, 공백일 수 없습니다.")
+        @Size(max = 200, message = "공지 제목은 200자를 초과할 수 없습니다.")
         String noticeTitle,
+
+        @NotBlank(message = "공지 내용은 비어 있거나, 공백일 수 없습니다.")
+        @Size(max = 2000, message = "공지 내용은 2000자를 초과할 수 없습니다.")
         String noticeContent,
+
         Long userId
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/notice/NoticePostRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notice/NoticePostRequest.java
@@ -1,0 +1,8 @@
+package org.websoso.WSSServer.dto.notice;
+
+public record NoticePostRequest(
+        String noticeTitle,
+        String noticeContent,
+        Long userId
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/dto/notice/NoticePostRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notice/NoticePostRequest.java
@@ -2,6 +2,7 @@ package org.websoso.WSSServer.dto.notice;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.websoso.WSSServer.validation.UserIdConstraint;
 
 public record NoticePostRequest(
 
@@ -13,6 +14,7 @@ public record NoticePostRequest(
         @Size(max = 2000, message = "공지 내용은 2000자를 초과할 수 없습니다.")
         String noticeContent,
 
+        @UserIdConstraint
         Long userId
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/notice/NoticesGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notice/NoticesGetResponse.java
@@ -9,13 +9,9 @@ public record NoticesGetResponse(
 ) {
 
     public static NoticesGetResponse of(List<Notice> notices) {
-        List<NoticeGetResponse> noticeGetResponses = notices.stream()
-                .map(notice -> new NoticeGetResponse(
-                        notice.getNoticeTitle(),
-                        notice.getNoticeContent(),
-                        notice.getCreatedDate()
-                ))
+        List<NoticeGetResponse> noticeList = notices.stream()
+                .map(NoticeGetResponse::from)
                 .collect(Collectors.toList());
-        return new NoticesGetResponse(noticeGetResponses);
+        return new NoticesGetResponse(noticeList);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/notice/NoticesGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notice/NoticesGetResponse.java
@@ -1,0 +1,21 @@
+package org.websoso.WSSServer.dto.notice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.websoso.WSSServer.domain.Notice;
+
+public record NoticesGetResponse(
+        List<NoticeGetResponse> notices
+) {
+
+    public static NoticesGetResponse of(List<Notice> notices) {
+        List<NoticeGetResponse> noticeGetResponses = notices.stream()
+                .map(notice -> new NoticeGetResponse(
+                        notice.getNoticeTitle(),
+                        notice.getNoticeContent(),
+                        notice.getCreatedDate()
+                ))
+                .collect(Collectors.toList());
+        return new NoticesGetResponse(noticeGetResponses);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.websoso.WSSServer.exception.feed.FeedErrorCode;
 import org.websoso.WSSServer.exception.feed.exception.InvalidFeedException;
 import org.websoso.WSSServer.exception.notice.NoticeErrorCode;
 import org.websoso.WSSServer.exception.notice.exception.ForbiddenNoticeCreationException;
+import org.websoso.WSSServer.exception.notice.exception.NoticeNotFoundException;
 import org.websoso.WSSServer.exception.user.UserErrorCode;
 import org.websoso.WSSServer.exception.user.exception.InvalidAuthorizedException;
 import org.websoso.WSSServer.exception.user.exception.InvalidNicknameException;
@@ -79,6 +80,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ForbiddenNoticeCreationException.class)
     public ResponseEntity<ErrorResult> ForbiddenNoticeCreationExceptionHandler(ForbiddenNoticeCreationException e) {
         log.error("[ForbiddenNoticeCreationException] exception ", e);
+        NoticeErrorCode noticeErrorCode = e.getNoticeErrorCode();
+        return ResponseEntity
+                .status(noticeErrorCode.getStatusCode())
+                .body(new ErrorResult(noticeErrorCode.getCode(), noticeErrorCode.getDescription()));
+    }
+
+    @ExceptionHandler(NoticeNotFoundException.class)
+    public ResponseEntity<ErrorResult> NoticeNotFoundExceptionHandler(NoticeNotFoundException e) {
+        log.error("[NoticeNotFoundException] exception ", e);
         NoticeErrorCode noticeErrorCode = e.getNoticeErrorCode();
         return ResponseEntity
                 .status(noticeErrorCode.getStatusCode())

--- a/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
@@ -11,6 +11,8 @@ import org.websoso.WSSServer.exception.category.exception.InvalidCategoryExcepti
 import org.websoso.WSSServer.exception.common.ErrorResult;
 import org.websoso.WSSServer.exception.feed.FeedErrorCode;
 import org.websoso.WSSServer.exception.feed.exception.InvalidFeedException;
+import org.websoso.WSSServer.exception.notice.NoticeErrorCode;
+import org.websoso.WSSServer.exception.notice.exception.ForbiddenNoticeCreationException;
 import org.websoso.WSSServer.exception.user.UserErrorCode;
 import org.websoso.WSSServer.exception.user.exception.InvalidAuthorizedException;
 import org.websoso.WSSServer.exception.user.exception.InvalidNicknameException;
@@ -74,4 +76,12 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResult(feedErrorCode.getCode(), feedErrorCode.getDescription()));
     }
 
+    @ExceptionHandler(ForbiddenNoticeCreationException.class)
+    public ResponseEntity<ErrorResult> ForbiddenNoticeCreationExceptionHandler(ForbiddenNoticeCreationException e) {
+        log.error("[ForbiddenNoticeCreationException] exception ", e);
+        NoticeErrorCode noticeErrorCode = e.getNoticeErrorCode();
+        return ResponseEntity
+                .status(noticeErrorCode.getStatusCode())
+                .body(new ErrorResult(noticeErrorCode.getCode(), noticeErrorCode.getDescription()));
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/websoso/WSSServer/exception/GlobalExceptionHandler.java
@@ -12,7 +12,7 @@ import org.websoso.WSSServer.exception.common.ErrorResult;
 import org.websoso.WSSServer.exception.feed.FeedErrorCode;
 import org.websoso.WSSServer.exception.feed.exception.InvalidFeedException;
 import org.websoso.WSSServer.exception.notice.NoticeErrorCode;
-import org.websoso.WSSServer.exception.notice.exception.ForbiddenNoticeCreationException;
+import org.websoso.WSSServer.exception.notice.exception.ForbiddenNoticeManipulationException;
 import org.websoso.WSSServer.exception.notice.exception.NoticeNotFoundException;
 import org.websoso.WSSServer.exception.user.UserErrorCode;
 import org.websoso.WSSServer.exception.user.exception.InvalidAuthorizedException;
@@ -77,9 +77,9 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResult(feedErrorCode.getCode(), feedErrorCode.getDescription()));
     }
 
-    @ExceptionHandler(ForbiddenNoticeCreationException.class)
-    public ResponseEntity<ErrorResult> ForbiddenNoticeCreationExceptionHandler(ForbiddenNoticeCreationException e) {
-        log.error("[ForbiddenNoticeCreationException] exception ", e);
+    @ExceptionHandler(ForbiddenNoticeManipulationException.class)
+    public ResponseEntity<ErrorResult> ForbiddenNoticeManipulationExceptionHandler(ForbiddenNoticeManipulationException e) {
+        log.error("[ForbiddenNoticeManipulationException] exception ", e);
         NoticeErrorCode noticeErrorCode = e.getNoticeErrorCode();
         return ResponseEntity
                 .status(noticeErrorCode.getStatusCode())

--- a/src/main/java/org/websoso/WSSServer/exception/notice/NoticeErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/notice/NoticeErrorCode.java
@@ -12,7 +12,7 @@ import org.websoso.WSSServer.exception.common.IErrorCode;
 @Getter
 public enum NoticeErrorCode implements IErrorCode {
 
-    NOTICE_FORBIDDEN("NOTICE-001", "관리자가 아닌 계정은 공지사항을 작성 혹은 수정할 수 없습니다.", FORBIDDEN),
+    NOTICE_FORBIDDEN("NOTICE-001", "관리자가 아닌 계정은 공지사항을 작성 혹은 수정 혹은 삭제할 수 없습니다.", FORBIDDEN),
     NOTICE_NOT_FOUND("NOTICE-002", "해당 ID를 가진 공지사항을 찾을 수 없습니다.", NOT_FOUND);
 
     private final String code;

--- a/src/main/java/org/websoso/WSSServer/exception/notice/NoticeErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/notice/NoticeErrorCode.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.exception.notice;
 
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,7 +12,8 @@ import org.websoso.WSSServer.exception.common.IErrorCode;
 @Getter
 public enum NoticeErrorCode implements IErrorCode {
 
-    NOTICE_FORBIDDEN("NOTICE-001", "관리자가 아닌 계정은 공지사항을 작성할 수 없습니다.", FORBIDDEN);
+    NOTICE_FORBIDDEN("NOTICE-001", "관리자가 아닌 계정은 공지사항을 작성 혹은 수정할 수 없습니다.", FORBIDDEN),
+    NOTICE_NOT_FOUND("NOTICE-002", "해당 ID를 가진 공지사항을 찾을 수 없습니다.", NOT_FOUND);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/exception/notice/NoticeErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/notice/NoticeErrorCode.java
@@ -1,0 +1,19 @@
+package org.websoso.WSSServer.exception.notice;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.websoso.WSSServer.exception.common.IErrorCode;
+
+@AllArgsConstructor
+@Getter
+public enum NoticeErrorCode implements IErrorCode {
+
+    NOTICE_FORBIDDEN("NOTICE-001", "관리자가 아닌 계정은 공지사항을 작성할 수 없습니다.", FORBIDDEN);
+
+    private final String code;
+    private final String description;
+    private final HttpStatus statusCode;
+}

--- a/src/main/java/org/websoso/WSSServer/exception/notice/exception/ForbiddenNoticeCreationException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/notice/exception/ForbiddenNoticeCreationException.java
@@ -1,0 +1,17 @@
+package org.websoso.WSSServer.exception.notice.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.websoso.WSSServer.exception.notice.NoticeErrorCode;
+
+@Getter
+@AllArgsConstructor
+public class ForbiddenNoticeCreationException extends RuntimeException {
+
+    public ForbiddenNoticeCreationException(NoticeErrorCode noticeErrorCode, String message) {
+        super(message);
+        this.noticeErrorCode = noticeErrorCode;
+    }
+
+    private NoticeErrorCode noticeErrorCode;
+}

--- a/src/main/java/org/websoso/WSSServer/exception/notice/exception/ForbiddenNoticeManipulationException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/notice/exception/ForbiddenNoticeManipulationException.java
@@ -6,9 +6,9 @@ import org.websoso.WSSServer.exception.notice.NoticeErrorCode;
 
 @Getter
 @AllArgsConstructor
-public class ForbiddenNoticeCreationException extends RuntimeException {
+public class ForbiddenNoticeManipulationException extends RuntimeException {
 
-    public ForbiddenNoticeCreationException(NoticeErrorCode noticeErrorCode, String message) {
+    public ForbiddenNoticeManipulationException(NoticeErrorCode noticeErrorCode, String message) {
         super(message);
         this.noticeErrorCode = noticeErrorCode;
     }

--- a/src/main/java/org/websoso/WSSServer/exception/notice/exception/NoticeNotFoundException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/notice/exception/NoticeNotFoundException.java
@@ -1,0 +1,17 @@
+package org.websoso.WSSServer.exception.notice.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.websoso.WSSServer.exception.notice.NoticeErrorCode;
+
+@Getter
+@AllArgsConstructor
+public class NoticeNotFoundException extends RuntimeException {
+
+    public NoticeNotFoundException(NoticeErrorCode noticeErrorCode, String message) {
+        super(message);
+        this.noticeErrorCode = noticeErrorCode;
+    }
+
+    private NoticeErrorCode noticeErrorCode;
+}

--- a/src/main/java/org/websoso/WSSServer/repository/NoticeRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NoticeRepository.java
@@ -2,11 +2,13 @@ package org.websoso.WSSServer.repository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Notice;
 
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
+    @Query(value = "SELECT n FROM Notice n WHERE n.userId = ?1 OR n.userId = 0")
     List<Notice> findByUserId(Long userId);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/NoticeRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NoticeRepository.java
@@ -1,0 +1,10 @@
+package org.websoso.WSSServer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.Notice;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+}

--- a/src/main/java/org/websoso/WSSServer/repository/NoticeRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NoticeRepository.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Notice;
@@ -7,4 +8,5 @@ import org.websoso.WSSServer.domain.Notice;
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
+    List<Notice> findByUserId(Long userId);
 }

--- a/src/main/java/org/websoso/WSSServer/service/NoticeService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NoticeService.java
@@ -60,4 +60,11 @@ public class NoticeService {
         List<Notice> notices = noticeRepository.findByUserId(user.getUserId());
         return NoticesGetResponse.of(notices);
     }
+
+    @Transactional
+    public void deleteNotice(User user, Long noticeId) {
+        validateAuthorization(user);
+        Notice notice = getNoticeOrException(noticeId);
+        noticeRepository.delete(notice);
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/service/NoticeService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NoticeService.java
@@ -14,7 +14,7 @@ import org.websoso.WSSServer.domain.common.Role;
 import org.websoso.WSSServer.dto.notice.NoticeEditRequest;
 import org.websoso.WSSServer.dto.notice.NoticePostRequest;
 import org.websoso.WSSServer.dto.notice.NoticesGetResponse;
-import org.websoso.WSSServer.exception.notice.exception.ForbiddenNoticeCreationException;
+import org.websoso.WSSServer.exception.notice.exception.ForbiddenNoticeManipulationException;
 import org.websoso.WSSServer.exception.notice.exception.NoticeNotFoundException;
 import org.websoso.WSSServer.repository.NoticeRepository;
 
@@ -46,7 +46,7 @@ public class NoticeService {
 
     private static void validateAuthorization(User user) {
         if (user.getRole() != ADMIN_ROLE) {
-            throw new ForbiddenNoticeCreationException(NOTICE_FORBIDDEN,
+            throw new ForbiddenNoticeManipulationException(NOTICE_FORBIDDEN,
                     "user who tried to create or modify or delete the notice is not ADMIN");
         }
     }

--- a/src/main/java/org/websoso/WSSServer/service/NoticeService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NoticeService.java
@@ -44,7 +44,8 @@ public class NoticeService {
 
     private static void validateAuthorization(User user) {
         if (user.getRole() != ADMIN_ROLE) {
-            throw new ForbiddenNoticeCreationException(NOTICE_FORBIDDEN, "user is not ADMIN");
+            throw new ForbiddenNoticeCreationException(NOTICE_FORBIDDEN,
+                    "user who tried to create or modify the notice is not ADMIN");
         }
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/NoticeService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NoticeService.java
@@ -23,13 +23,17 @@ public class NoticeService {
 
     @Transactional
     public void createNotice(User user, NoticePostRequest noticePostRequest) {
-        if (user.getRole() != ADMIN_ROLE) {
-            throw new ForbiddenNoticeCreationException(NOTICE_FORBIDDEN, "user is not ADMIN");
-        }
+        validateAuthorization(user);
         noticeRepository.save(Notice.builder()
                 .noticeTitle(noticePostRequest.noticeTitle())
                 .noticeContent(noticePostRequest.noticeContent())
                 .userId(noticePostRequest.userId())
                 .build());
+    }
+
+    private static void validateAuthorization(User user) {
+        if (user.getRole() != ADMIN_ROLE) {
+            throw new ForbiddenNoticeCreationException(NOTICE_FORBIDDEN, "user is not ADMIN");
+        }
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/NoticeService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NoticeService.java
@@ -2,6 +2,7 @@ package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.domain.common.Role.ADMIN;
 import static org.websoso.WSSServer.exception.notice.NoticeErrorCode.NOTICE_FORBIDDEN;
+import static org.websoso.WSSServer.exception.notice.NoticeErrorCode.NOTICE_NOT_FOUND;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,8 +10,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Notice;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.common.Role;
+import org.websoso.WSSServer.dto.notice.NoticeEditRequest;
 import org.websoso.WSSServer.dto.notice.NoticePostRequest;
 import org.websoso.WSSServer.exception.notice.exception.ForbiddenNoticeCreationException;
+import org.websoso.WSSServer.exception.notice.exception.NoticeNotFoundException;
 import org.websoso.WSSServer.repository.NoticeRepository;
 
 @Service
@@ -31,9 +34,22 @@ public class NoticeService {
                 .build());
     }
 
+    @Transactional
+    public void editNotice(User user, Long noticeId, NoticeEditRequest noticeEditRequest) {
+        validateAuthorization(user);
+        Notice notice = getNoticeOrException(noticeId);
+        notice.updateNotice(noticeEditRequest.noticeTitle(), noticeEditRequest.noticeContent(),
+                noticeEditRequest.userId());
+    }
+
     private static void validateAuthorization(User user) {
         if (user.getRole() != ADMIN_ROLE) {
             throw new ForbiddenNoticeCreationException(NOTICE_FORBIDDEN, "user is not ADMIN");
         }
+    }
+
+    private Notice getNoticeOrException(Long noticeId) {
+        return noticeRepository.findById(noticeId).orElseThrow(() ->
+                new NoticeNotFoundException(NOTICE_NOT_FOUND, "notice with given noticeId was not found"));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/NoticeService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NoticeService.java
@@ -1,0 +1,25 @@
+package org.websoso.WSSServer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.domain.Notice;
+import org.websoso.WSSServer.dto.notice.NoticePostRequest;
+import org.websoso.WSSServer.repository.NoticeRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    public void createNotice(NoticePostRequest noticePostRequest) {
+        noticeRepository.save(Notice.builder()
+                .noticeTitle(noticePostRequest.noticeTitle())
+                .noticeContent(noticePostRequest.noticeContent())
+                .userId(noticePostRequest.userId())
+                .build());
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/service/NoticeService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NoticeService.java
@@ -47,7 +47,7 @@ public class NoticeService {
     private static void validateAuthorization(User user) {
         if (user.getRole() != ADMIN_ROLE) {
             throw new ForbiddenNoticeCreationException(NOTICE_FORBIDDEN,
-                    "user who tried to create or modify the notice is not ADMIN");
+                    "user who tried to create or modify or delete the notice is not ADMIN");
         }
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/NoticeService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NoticeService.java
@@ -1,10 +1,16 @@
 package org.websoso.WSSServer.service;
 
+import static org.websoso.WSSServer.domain.common.Role.ADMIN;
+import static org.websoso.WSSServer.exception.notice.NoticeErrorCode.NOTICE_FORBIDDEN;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Notice;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.common.Role;
 import org.websoso.WSSServer.dto.notice.NoticePostRequest;
+import org.websoso.WSSServer.exception.notice.exception.ForbiddenNoticeCreationException;
 import org.websoso.WSSServer.repository.NoticeRepository;
 
 @Service
@@ -13,9 +19,13 @@ import org.websoso.WSSServer.repository.NoticeRepository;
 public class NoticeService {
 
     private final NoticeRepository noticeRepository;
+    private static final Role ADMIN_ROLE = ADMIN;
 
     @Transactional
-    public void createNotice(NoticePostRequest noticePostRequest) {
+    public void createNotice(User user, NoticePostRequest noticePostRequest) {
+        if (user.getRole() != ADMIN_ROLE) {
+            throw new ForbiddenNoticeCreationException(NOTICE_FORBIDDEN, "user is not ADMIN");
+        }
         noticeRepository.save(Notice.builder()
                 .noticeTitle(noticePostRequest.noticeTitle())
                 .noticeContent(noticePostRequest.noticeContent())

--- a/src/main/java/org/websoso/WSSServer/service/NoticeService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NoticeService.java
@@ -51,11 +51,6 @@ public class NoticeService {
         }
     }
 
-    private Notice getNoticeOrException(Long noticeId) {
-        return noticeRepository.findById(noticeId).orElseThrow(() ->
-                new NoticeNotFoundException(NOTICE_NOT_FOUND, "notice with given noticeId was not found"));
-    }
-
     public NoticesGetResponse getNotices(User user) {
         List<Notice> notices = noticeRepository.findByUserId(user.getUserId());
         return NoticesGetResponse.of(notices);
@@ -66,5 +61,10 @@ public class NoticeService {
         validateAuthorization(user);
         Notice notice = getNoticeOrException(noticeId);
         noticeRepository.delete(notice);
+    }
+
+    private Notice getNoticeOrException(Long noticeId) {
+        return noticeRepository.findById(noticeId).orElseThrow(() ->
+                new NoticeNotFoundException(NOTICE_NOT_FOUND, "notice with given noticeId was not found"));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/NoticeService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NoticeService.java
@@ -4,6 +4,7 @@ import static org.websoso.WSSServer.domain.common.Role.ADMIN;
 import static org.websoso.WSSServer.exception.notice.NoticeErrorCode.NOTICE_FORBIDDEN;
 import static org.websoso.WSSServer.exception.notice.NoticeErrorCode.NOTICE_NOT_FOUND;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +13,7 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.common.Role;
 import org.websoso.WSSServer.dto.notice.NoticeEditRequest;
 import org.websoso.WSSServer.dto.notice.NoticePostRequest;
+import org.websoso.WSSServer.dto.notice.NoticesGetResponse;
 import org.websoso.WSSServer.exception.notice.exception.ForbiddenNoticeCreationException;
 import org.websoso.WSSServer.exception.notice.exception.NoticeNotFoundException;
 import org.websoso.WSSServer.repository.NoticeRepository;
@@ -52,5 +54,10 @@ public class NoticeService {
     private Notice getNoticeOrException(Long noticeId) {
         return noticeRepository.findById(noticeId).orElseThrow(() ->
                 new NoticeNotFoundException(NOTICE_NOT_FOUND, "notice with given noticeId was not found"));
+    }
+
+    public NoticesGetResponse getNotices(User user) {
+        List<Notice> notices = noticeRepository.findByUserId(user.getUserId());
+        return NoticesGetResponse.of(notices);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/validation/UserIdConstraint.java
+++ b/src/main/java/org/websoso/WSSServer/validation/UserIdConstraint.java
@@ -1,0 +1,23 @@
+package org.websoso.WSSServer.validation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = UserIdValidator.class)
+@Target({FIELD})
+@Retention(RUNTIME)
+public @interface UserIdConstraint {
+
+    String message() default "invalid userId.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/websoso/WSSServer/validation/UserIdValidator.java
+++ b/src/main/java/org/websoso/WSSServer/validation/UserIdValidator.java
@@ -1,0 +1,34 @@
+package org.websoso.WSSServer.validation;
+
+import static org.websoso.WSSServer.exception.user.UserErrorCode.USER_NOT_FOUND;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.stereotype.Component;
+import org.websoso.WSSServer.exception.user.exception.InvalidUserException;
+import org.websoso.WSSServer.repository.UserRepository;
+
+@Component
+public class UserIdValidator implements ConstraintValidator<UserIdConstraint, Long> {
+
+    private final UserRepository userRepository;
+
+    public UserIdValidator(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public void initialize(UserIdConstraint userId) {
+    }
+
+    @Override
+    public boolean isValid(Long userId, ConstraintValidatorContext constraintValidatorContext) {
+        if (userId == 0) {
+            return true;
+        }
+        userRepository.findById(userId).orElseThrow(() ->
+                new InvalidUserException(USER_NOT_FOUND, "user with the given id was not found"));
+
+        return true;
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/validation/UserIdValidator.java
+++ b/src/main/java/org/websoso/WSSServer/validation/UserIdValidator.java
@@ -4,18 +4,16 @@ import static org.websoso.WSSServer.exception.user.UserErrorCode.USER_NOT_FOUND;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.websoso.WSSServer.exception.user.exception.InvalidUserException;
 import org.websoso.WSSServer.repository.UserRepository;
 
 @Component
+@AllArgsConstructor
 public class UserIdValidator implements ConstraintValidator<UserIdConstraint, Long> {
 
     private final UserRepository userRepository;
-
-    public UserIdValidator(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
 
     @Override
     public void initialize(UserIdConstraint userId) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#41 -> dev
- close #41

## Key Changes
<!-- 최대한 자세히 -->
- `User Entity`
  - 공지사항 생성, 수정, 삭제의 경우 일반 사용자가 아닌 `관리자`만 가능하도록 인가 처리를 해야 하므로 `Role` 컬럼 추가했습니다. 추후 Spring Security 사용하여 개선할 예정입니다.
- `API`
  - `관리자(ADMIN)`이 아닌 사용자가 생성, 수정, 삭제 시도 시 `ForbiddenNoticeManipulationException`을 터뜨리도록 했습니다. 클라이언트에게 반환할 응답(`code`, `description`)은 `NOTICE_FORBIDDEN`에 정의되어 있습니다.
  - `requestBody`에 담겨 오는 `userId` 유효성 검사가 spring boot validation으로는 불가능해서 custom annotation을 만들었습니다. (`UserIdConstraint`, `UserIdValidator`)
  - json으로 내려줘야할 포맷과 달라서 `NoticeGetResponse`에서 `createdDate` 포맷팅했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- CRUD를 한 PR에 하려니 양이 좀 많네요.. 죄송합니다.
- `GlobalExceptionHandler`에서 conflict 나서 수정했습니다.
- `BaseEntity`에서 String으로 관리하는게 좀 별로인 것 같습니다. `LocalDateTime`으로 저장하고 필요할 때마다 원하는 형식으로 바꿔서 쓰는 것이 더 낫지 않을까요?
