### PR TITLE
[FEAT] 소소피드 작성 API의 소소피드 작성과 연관된 소설 통계 엔티티의 소설 피드 수 로직 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/NovelStatistics.java
+++ b/src/main/java/org/websoso/WSSServer/domain/NovelStatistics.java
@@ -9,11 +9,17 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import java.util.Optional;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import org.websoso.WSSServer.exception.novelStatistics.exception.InvalidNovelStatisticsException;
 
+@DynamicInsert
+@DynamicUpdate
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -57,6 +63,15 @@ public class NovelStatistics {
     @OneToOne
     @JoinColumn(name = "novel_id", nullable = false)
     private Novel novel;
+
+    @Builder
+    public NovelStatistics(Novel novel) {
+        this.novel = novel;
+    }
+
+    public void increaseNovelFeedCount() {
+        this.novelFeedCount = Optional.ofNullable(this.novelFeedCount).orElse(0) + 1;
+    }
 
     public void decreaseNovelFeedCount() {
         if (this.novelFeedCount <= 0) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -26,12 +26,18 @@ public class FeedService {
 
     @Transactional
     public void createFeed(User user, FeedCreateRequest request) {
+        Long linkedNovelId = request.novelId();
+
         Feed feed = Feed.builder()
                 .feedContent(request.feedContent())
                 .isSpoiler(request.isSpoiler() ? Y : N)
-                .novelId(request.novelId())
+                .novelId(linkedNovelId)
                 .user(user)
                 .build();
+
+        if (linkedNovelId != null) {
+            novelStatisticsService.increaseNovelFeedCount(linkedNovelId);
+        }
 
         feedRepository.save(feed);
         categoryService.createCategory(feed, request.relevantCategories());

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -26,17 +26,15 @@ public class FeedService {
 
     @Transactional
     public void createFeed(User user, FeedCreateRequest request) {
-        Long linkedNovelId = request.novelId();
-
         Feed feed = Feed.builder()
                 .feedContent(request.feedContent())
                 .isSpoiler(request.isSpoiler() ? Y : N)
-                .novelId(linkedNovelId)
+                .novelId(request.novelId())
                 .user(user)
                 .build();
 
-        if (linkedNovelId != null) {
-            novelStatisticsService.increaseNovelFeedCount(linkedNovelId);
+        if (request.novelId() != null) {
+            novelStatisticsService.increaseNovelFeedCount(request.novelId());
         }
 
         feedRepository.save(feed);
@@ -52,7 +50,7 @@ public class FeedService {
         feed.updateFeed(request.feedContent(), request.isSpoiler() ? Y : N, request.novelId());
         categoryService.updateCategory(feed, request.relevantCategories());
     }
-  
+
     @Transactional
     public void deleteFeed(User user, Long feedId) {
         Feed feed = getFeedOrException(feedId);

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -34,7 +34,7 @@ public class NovelService {
         );
     }
 
-    private Novel getNovelOrException(Long novelId) {
+    public Novel getNovelOrException(Long novelId) {
         return novelRepository.findById(novelId)
                 .orElseThrow(() -> new InvalidNovelException(NOVEL_NOT_FOUND,
                         "novel with the given id is not found"));

--- a/src/main/java/org/websoso/WSSServer/service/NovelStatisticsService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelStatisticsService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.NovelStatistics;
 import org.websoso.WSSServer.exception.novelStatistics.exception.InvalidNovelStatisticsException;
-import org.websoso.WSSServer.repository.NovelRepository;
 import org.websoso.WSSServer.repository.NovelStatisticsRepository;
 
 @Service
@@ -16,7 +15,7 @@ import org.websoso.WSSServer.repository.NovelStatisticsRepository;
 public class NovelStatisticsService {
 
     private final NovelStatisticsRepository novelStatisticsRepository;
-    private final NovelRepository novelRepository; // 나경이거 머지 되면 수정
+    private final NovelService novelService;
 
     @Transactional
     public void increaseNovelFeedCount(Long novelId) {
@@ -28,7 +27,7 @@ public class NovelStatisticsService {
 
     @Transactional
     public NovelStatistics createNovelStatistics(Long novelId) {
-        Novel novel = novelRepository.findById(novelId).get(); // 나경이거 머지 되면 수정
+        Novel novel = novelService.getNovelOrException(novelId);
 
         return novelStatisticsRepository.save(
                 NovelStatistics.builder()
@@ -51,5 +50,5 @@ public class NovelStatisticsService {
                 () -> new InvalidNovelStatisticsException(NOVEL_STATISTICS_NOT_FOUND,
                         "novel statistics with the given novel is not found"));
     }
-  
+
 }

--- a/src/main/java/org/websoso/WSSServer/service/NovelStatisticsService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelStatisticsService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.NovelStatistics;
 import org.websoso.WSSServer.exception.novelStatistics.exception.InvalidNovelStatisticsException;
+import org.websoso.WSSServer.repository.NovelRepository;
 import org.websoso.WSSServer.repository.NovelStatisticsRepository;
 
 @Service
@@ -15,6 +16,26 @@ import org.websoso.WSSServer.repository.NovelStatisticsRepository;
 public class NovelStatisticsService {
 
     private final NovelStatisticsRepository novelStatisticsRepository;
+    private final NovelRepository novelRepository; // 나경이거 머지 되면 수정
+
+    @Transactional
+    public void increaseNovelFeedCount(Long novelId) {
+        NovelStatistics novelStatistics = novelStatisticsRepository.findByNovelId(novelId)
+                .orElseGet(() -> createNovelStatistics(novelId));
+
+        novelStatistics.increaseNovelFeedCount();
+    }
+
+    @Transactional
+    public NovelStatistics createNovelStatistics(Long novelId) {
+        Novel novel = novelRepository.findById(novelId).get(); // 나경이거 머지 되면 수정
+
+        return novelStatisticsRepository.save(
+                NovelStatistics.builder()
+                        .novel(novel)
+                        .build()
+        );
+    }
 
     @Transactional
     public void decreaseNovelFeedCount(Long novelId) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#35 -> dev
- close #35

## Key Changes
<!-- 최대한 자세히 -->
### 소소피드 작성 API의 피드 작성 시에 피드에 연결된 작품이 있다면 `novelStatistics` 엔티티의 소설 피드 수를 증가시키는 로직을 추가 구현했습니다.

- _novel_statistics_ 테이블에 해당 작품의 `novelId`와 **연결된 값이 없다면 생성한 뒤,** `novelFeedCount` 값을 1로 증가 시킵니다.
- _novel_statistics_ 테이블에 해당 작품의 `novelId`와 **연결된 값이 있다면** `novelFeedCount`만 1 증가 시킵니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X
## References
<!-- 참고한 자료-->
X