### PR TITLE
[FIX] 닉네임 중복 시 응답 포맷 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -1,6 +1,5 @@
 package org.websoso.WSSServer.controller;
 
-import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.security.Principal;

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -32,15 +32,9 @@ public class UserController {
     public ResponseEntity<NicknameValidation> checkNicknameAvailability(
             @RequestParam("nickname")
             @NicknameConstraint String nickname) {
-        NicknameValidation nicknameValidation = userService.isNicknameAvailable(nickname);
-        if (nicknameValidation.isDuplicated()) {
-            return ResponseEntity
-                    .status(CONFLICT)
-                    .body(nicknameValidation);
-        }
         return ResponseEntity
                 .status(OK)
-                .body(nicknameValidation);
+                .body(userService.isNicknameAvailable(nickname));
     }
 
     @GetMapping("/email")

--- a/src/main/java/org/websoso/WSSServer/dto/User/NicknameValidation.java
+++ b/src/main/java/org/websoso/WSSServer/dto/User/NicknameValidation.java
@@ -1,6 +1,9 @@
 package org.websoso.WSSServer.dto.User;
 
-public record NicknameValidation(boolean isDuplicated) {
+public record NicknameValidation(
+        boolean isDuplicated
+) {
+
     public static NicknameValidation of(boolean isDuplicated) {
         return new NicknameValidation(isDuplicated);
     }

--- a/src/main/java/org/websoso/WSSServer/dto/User/NicknameValidation.java
+++ b/src/main/java/org/websoso/WSSServer/dto/User/NicknameValidation.java
@@ -1,10 +1,10 @@
 package org.websoso.WSSServer.dto.User;
 
 public record NicknameValidation(
-        boolean isDuplicated
+        boolean isValid
 ) {
 
-    public static NicknameValidation of(boolean isDuplicated) {
-        return new NicknameValidation(isDuplicated);
+    public static NicknameValidation of(boolean isValid) {
+        return new NicknameValidation(isValid);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/exception/user/UserErrorCode.java
+++ b/src/main/java/org/websoso/WSSServer/exception/user/UserErrorCode.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.exception.user;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
@@ -19,7 +20,8 @@ public enum UserErrorCode implements IErrorCode {
     INVALID_NICKNAME_LENGTH("USER-004", "닉네임의 길이가 2 ~ 10자가 아닙니다.", BAD_REQUEST),
     INVALID_NICKNAME_PATTERN("USER-005", "닉네임은 한글, 영문, 숫자, 특수문자(-, _)로만 이루어져아 합니다.", BAD_REQUEST),
     USER_NOT_FOUND("USER-006", "해당 ID를 가진 사용자를 찾을 수 없습니다.", NOT_FOUND),
-    INVALID_AUTHORIZED("USER-007", "사용자에게 권한이 없습니다.", FORBIDDEN);
+    INVALID_AUTHORIZED("USER-007", "사용자에게 권한이 없습니다.", FORBIDDEN),
+    DUPLICATED_NICKNAME("USER-008", "중복된 닉네임입니다.", CONFLICT);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/exception/user/exception/DuplicatedNicknameException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/user/exception/DuplicatedNicknameException.java
@@ -15,5 +15,3 @@ public class DuplicatedNicknameException extends RuntimeException {
 
     private UserErrorCode userErrorCode;
 }
-
-

--- a/src/main/java/org/websoso/WSSServer/exception/user/exception/DuplicatedNicknameException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/user/exception/DuplicatedNicknameException.java
@@ -1,0 +1,19 @@
+package org.websoso.WSSServer.exception.user.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.websoso.WSSServer.exception.user.UserErrorCode;
+
+@Getter
+@AllArgsConstructor
+public class DuplicatedNicknameException extends RuntimeException {
+
+    public DuplicatedNicknameException(UserErrorCode userErrorCode, String message) {
+        super(message);
+        this.userErrorCode = userErrorCode;
+    }
+
+    private UserErrorCode userErrorCode;
+}
+
+

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -29,7 +29,7 @@ public class UserService {
         if (userRepository.existsByNickname(nickname)) {
             throw new DuplicatedNicknameException(DUPLICATED_NICKNAME, "nickname is duplicated.");
         }
-        return NicknameValidation.of(false);
+        return NicknameValidation.of(true);
     }
 
     public LoginResponse login(Long userId) {

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.service;
 
+import static org.websoso.WSSServer.exception.user.UserErrorCode.DUPLICATED_NICKNAME;
 import static org.websoso.WSSServer.exception.user.UserErrorCode.USER_NOT_FOUND;
 
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.User.LoginResponse;
 import org.websoso.WSSServer.dto.User.NicknameValidation;
 import org.websoso.WSSServer.dto.user.EmailGetResponse;
+import org.websoso.WSSServer.exception.user.exception.DuplicatedNicknameException;
 import org.websoso.WSSServer.exception.user.exception.InvalidUserException;
 import org.websoso.WSSServer.repository.UserRepository;
 
@@ -24,8 +26,10 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public NicknameValidation isNicknameAvailable(String nickname) {
-        boolean isNicknameTaken = userRepository.existsByNickname(nickname);
-        return NicknameValidation.of(isNicknameTaken);
+        if (userRepository.existsByNickname(nickname)) {
+            throw new DuplicatedNicknameException(DUPLICATED_NICKNAME, "nickname is duplicated.");
+        }
+        return NicknameValidation.of(false);
     }
 
     public LoginResponse login(Long userId) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#54 -> dev
- close #54

## Key Changes
<!-- 최대한 자세히 -->
닉네임 중복인 경우에도 성공 케이스와 동일한 isDuplicated: true/false 포맷으로 응답을 내려주고 있어서,
실패 케이스로 분류하고 실패 응답 포맷으로 변경했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
닉네임 중복이 아닌 성공 케이스의 경우 isDuplicated는 항상 false라서 굳이 body에 뭔가를 내려주는게 조금 어색한 것 같습니다.