### PR TITLE
[FEAT] 프로필(아바타) 목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/AvatarController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AvatarController.java
@@ -1,0 +1,32 @@
+package org.websoso.WSSServer.controller;
+
+import static org.springframework.http.HttpStatus.OK;
+
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.dto.avatar.AvatarsGetResponse;
+import org.websoso.WSSServer.service.AvatarService;
+import org.websoso.WSSServer.service.UserService;
+
+@RequestMapping("/avatars")
+@RestController
+@RequiredArgsConstructor
+public class AvatarController {
+
+    private final AvatarService avatarService;
+    private final UserService userService;
+
+
+    @GetMapping
+    public ResponseEntity<AvatarsGetResponse> getAvatarList(Principal principal) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(OK)
+                .body(avatarService.getAvatarList(user));
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/avatar/AvatarGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/avatar/AvatarGetResponse.java
@@ -1,0 +1,29 @@
+package org.websoso.WSSServer.dto.avatar;
+
+import java.util.List;
+import java.util.Random;
+import org.websoso.WSSServer.domain.Avatar;
+import org.websoso.WSSServer.domain.AvatarLine;
+import org.websoso.WSSServer.domain.User;
+
+public record AvatarGetResponse(
+        Byte avatarId,
+        String avatarName,
+        String avatarLine,
+        String avatarImage,
+        Boolean isRepresentative
+) {
+
+    public static AvatarGetResponse of(Avatar avatar, List<AvatarLine> avatarLines, User user) {
+        int avatarLineSize = avatarLines.size();
+        int randomNumber = new Random().nextInt(avatarLineSize);
+        Byte representativeAvatarId = user.getAvatarId();
+        return new AvatarGetResponse(
+                avatar.getAvatarId(),
+                avatar.getAvatarName(),
+                avatarLines.get(randomNumber).getAvatarLine(),
+                avatar.getAvatarImage(),
+                avatar.getAvatarId().equals(representativeAvatarId)
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/avatar/AvatarGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/avatar/AvatarGetResponse.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Random;
 import org.websoso.WSSServer.domain.Avatar;
 import org.websoso.WSSServer.domain.AvatarLine;
-import org.websoso.WSSServer.domain.User;
 
 public record AvatarGetResponse(
         Byte avatarId,
@@ -13,11 +12,9 @@ public record AvatarGetResponse(
         String avatarImage,
         Boolean isRepresentative
 ) {
-
-    public static AvatarGetResponse of(Avatar avatar, List<AvatarLine> avatarLines, User user) {
+    public static AvatarGetResponse of(Avatar avatar, List<AvatarLine> avatarLines, Byte representativeAvatarId) {
         int avatarLineSize = avatarLines.size();
         int randomNumber = new Random().nextInt(avatarLineSize);
-        Byte representativeAvatarId = user.getAvatarId();
         return new AvatarGetResponse(
                 avatar.getAvatarId(),
                 avatar.getAvatarName(),

--- a/src/main/java/org/websoso/WSSServer/dto/avatar/AvatarGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/avatar/AvatarGetResponse.java
@@ -1,7 +1,5 @@
 package org.websoso.WSSServer.dto.avatar;
 
-import java.util.List;
-import java.util.Random;
 import org.websoso.WSSServer.domain.Avatar;
 import org.websoso.WSSServer.domain.AvatarLine;
 
@@ -12,13 +10,11 @@ public record AvatarGetResponse(
         String avatarImage,
         Boolean isRepresentative
 ) {
-    public static AvatarGetResponse of(Avatar avatar, List<AvatarLine> avatarLines, Byte representativeAvatarId) {
-        int avatarLineSize = avatarLines.size();
-        int randomNumber = new Random().nextInt(avatarLineSize);
+    public static AvatarGetResponse of(Avatar avatar, AvatarLine avatarLine, Byte representativeAvatarId) {
         return new AvatarGetResponse(
                 avatar.getAvatarId(),
                 avatar.getAvatarName(),
-                avatarLines.get(randomNumber).getAvatarLine(),
+                avatarLine.getAvatarLine(),
                 avatar.getAvatarImage(),
                 avatar.getAvatarId().equals(representativeAvatarId)
         );

--- a/src/main/java/org/websoso/WSSServer/dto/avatar/AvatarsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/avatar/AvatarsGetResponse.java
@@ -1,0 +1,8 @@
+package org.websoso.WSSServer.dto.avatar;
+
+import java.util.List;
+
+public record AvatarsGetResponse(
+        List<AvatarGetResponse> avatars
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/repository/AvatarRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/AvatarRepository.java
@@ -1,0 +1,10 @@
+package org.websoso.WSSServer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.Avatar;
+
+@Repository
+public interface AvatarRepository extends JpaRepository<Avatar, Byte> {
+
+}

--- a/src/main/java/org/websoso/WSSServer/service/AvatarService.java
+++ b/src/main/java/org/websoso/WSSServer/service/AvatarService.java
@@ -27,11 +27,13 @@ public class AvatarService {
         List<AvatarGetResponse> avatarGetResponses = avatars.stream()
                 .map(avatar -> {
                     List<AvatarLine> avatarLines = avatar.getAvatarLine();
-                    final int avatarLineSize = avatarLines.size();
-                    int randomNumber = random.nextInt(avatarLineSize);
-                    AvatarLine avatarLine = avatarLines.get(randomNumber);
-                    return AvatarGetResponse.of(avatar, avatarLine, representativeAvatarId);
+                    return AvatarGetResponse.of(avatar, getRandomAvatarLine(avatarLines), representativeAvatarId);
                 }).toList();
         return new AvatarsGetResponse(avatarGetResponses);
+    }
+
+    private static AvatarLine getRandomAvatarLine(List<AvatarLine> avatarLines) {
+        final int avatarLineSize = avatarLines.size();
+        return avatarLines.get(random.nextInt(avatarLineSize));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/AvatarService.java
+++ b/src/main/java/org/websoso/WSSServer/service/AvatarService.java
@@ -1,0 +1,31 @@
+package org.websoso.WSSServer.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.domain.Avatar;
+import org.websoso.WSSServer.domain.AvatarLine;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.dto.avatar.AvatarGetResponse;
+import org.websoso.WSSServer.dto.avatar.AvatarsGetResponse;
+import org.websoso.WSSServer.repository.AvatarRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AvatarService {
+
+    private final AvatarRepository avatarRepository;
+
+    @Transactional(readOnly = true)
+    public AvatarsGetResponse getAvatarList(User user) {
+        List<Avatar> avatars = avatarRepository.findAll();
+        List<AvatarGetResponse> avatarGetResponses = avatars.stream()
+                .map(avatar -> {
+                    List<AvatarLine> avatarLines = avatar.getAvatarLine();
+                    return AvatarGetResponse.of(avatar, avatarLines, user);
+                }).toList();
+        return new AvatarsGetResponse(avatarGetResponses);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/service/AvatarService.java
+++ b/src/main/java/org/websoso/WSSServer/service/AvatarService.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.service;
 
 import java.util.List;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,7 @@ import org.websoso.WSSServer.repository.AvatarRepository;
 public class AvatarService {
 
     private final AvatarRepository avatarRepository;
+    private static final Random random = new Random();      //TODO thread-safe하지 않아서 multi-thread 환경에서는 사용X
 
     @Transactional(readOnly = true)
     public AvatarsGetResponse getAvatarList(User user) {
@@ -25,7 +27,10 @@ public class AvatarService {
         List<AvatarGetResponse> avatarGetResponses = avatars.stream()
                 .map(avatar -> {
                     List<AvatarLine> avatarLines = avatar.getAvatarLine();
-                    return AvatarGetResponse.of(avatar, avatarLines, representativeAvatarId);
+                    final int avatarLineSize = avatarLines.size();
+                    int randomNumber = random.nextInt(avatarLineSize);
+                    AvatarLine avatarLine = avatarLines.get(randomNumber);
+                    return AvatarGetResponse.of(avatar, avatarLine, representativeAvatarId);
                 }).toList();
         return new AvatarsGetResponse(avatarGetResponses);
     }

--- a/src/main/java/org/websoso/WSSServer/service/AvatarService.java
+++ b/src/main/java/org/websoso/WSSServer/service/AvatarService.java
@@ -20,11 +20,12 @@ public class AvatarService {
 
     @Transactional(readOnly = true)
     public AvatarsGetResponse getAvatarList(User user) {
+        Byte representativeAvatarId = user.getAvatarId();
         List<Avatar> avatars = avatarRepository.findAll();
         List<AvatarGetResponse> avatarGetResponses = avatars.stream()
                 .map(avatar -> {
                     List<AvatarLine> avatarLines = avatar.getAvatarLine();
-                    return AvatarGetResponse.of(avatar, avatarLines, user);
+                    return AvatarGetResponse.of(avatar, avatarLines, representativeAvatarId);
                 }).toList();
         return new AvatarsGetResponse(avatarGetResponses);
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#59 -> dev
- close #59

## Key Changes
<!-- 최대한 자세히 -->
유저에 따라 대표 아바타를 표시하고, 아바타들의 이름, 대사, 이미지 등을 내려줍니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 최대한 성능 향상과 재사용할 수 있게 리팩토링했는데, avatarLine의 개수가 정해져있다면 더 효율적으로 개선할 수도 있을 것 같습니다.
