### PR TITLE
[HOTFIX] NovelStatisticsService에서 NovelService 참조 로직 제거

### DIFF
--- a/src/main/java/org/websoso/WSSServer/repository/NovelStatisticsRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelStatisticsRepository.java
@@ -2,18 +2,13 @@ package org.websoso.WSSServer.repository;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.NovelStatistics;
 
 @Repository
 public interface NovelStatisticsRepository extends JpaRepository<NovelStatistics, Long> {
-
-    @Query("SELECT ns FROM NovelStatistics ns WHERE ns.novel.novelId = :novelId")
-    Optional<NovelStatistics> findByNovelId(@Param("novelId") Long novelId);
-  
+    
     Optional<NovelStatistics> findByNovel(Novel novel);
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -23,6 +23,7 @@ public class FeedService {
     private final FeedRepository feedRepository;
     private final CategoryService categoryService;
     private final NovelStatisticsService novelStatisticsService;
+    private final NovelService novelService;
 
     @Transactional
     public void createFeed(User user, FeedCreateRequest request) {
@@ -34,7 +35,7 @@ public class FeedService {
                 .build();
 
         if (request.novelId() != null) {
-            novelStatisticsService.increaseNovelFeedCount(request.novelId());
+            novelStatisticsService.increaseNovelFeedCount(novelService.getNovelOrException(request.novelId()));
         }
 
         feedRepository.save(feed);
@@ -58,7 +59,7 @@ public class FeedService {
         feed.validateUserAuthorization(user, DELETE);
 
         if (feed.getNovelId() != null) {
-            novelStatisticsService.decreaseNovelFeedCount(feed.getNovelId());
+            novelStatisticsService.decreaseNovelFeedCount(novelService.getNovelOrException(feed.getNovelId()));
         }
 
         feedRepository.delete(feed);

--- a/src/main/java/org/websoso/WSSServer/service/NovelStatisticsService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelStatisticsService.java
@@ -15,20 +15,17 @@ import org.websoso.WSSServer.repository.NovelStatisticsRepository;
 public class NovelStatisticsService {
 
     private final NovelStatisticsRepository novelStatisticsRepository;
-    private final NovelService novelService;
 
     @Transactional
-    public void increaseNovelFeedCount(Long novelId) {
-        NovelStatistics novelStatistics = novelStatisticsRepository.findByNovelId(novelId)
-                .orElseGet(() -> createNovelStatistics(novelId));
+    public void increaseNovelFeedCount(Novel novel) {
+        NovelStatistics novelStatistics = novelStatisticsRepository.findByNovel(novel)
+                .orElseGet(() -> createNovelStatistics(novel));
 
         novelStatistics.increaseNovelFeedCount();
     }
 
     @Transactional
-    public NovelStatistics createNovelStatistics(Long novelId) {
-        Novel novel = novelService.getNovelOrException(novelId);
-
+    public NovelStatistics createNovelStatistics(Novel novel) {
         return novelStatisticsRepository.save(
                 NovelStatistics.builder()
                         .novel(novel)
@@ -37,10 +34,8 @@ public class NovelStatisticsService {
     }
 
     @Transactional
-    public void decreaseNovelFeedCount(Long novelId) {
-        NovelStatistics novelStatistics = novelStatisticsRepository.findByNovelId(novelId)
-                .orElseThrow(() -> new InvalidNovelStatisticsException(NOVEL_STATISTICS_NOT_FOUND,
-                        "novel statistics not found"));
+    public void decreaseNovelFeedCount(Novel novel) {
+        NovelStatistics novelStatistics = getNovelStatisticsOrException(novel);
 
         novelStatistics.decreaseNovelFeedCount();
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#62 -> dev
- close #62 

## Key Changes
<!-- 최대한 자세히 -->
`NovelStatisticsService`와 `NovelService` 클래스 간 서로를 참조하고 있어, 발생하는 순환참조를 제거했습니다.

제거 방법은 `NovelStatisticsService`클래스에서 `NovelService` 참조를 제거하고, 

`FeedService`에서 `NovelStatisticsService`에게 `Novel` 엔티티 자체를 파라미터로 전달하는 식으로 로직을 변경해, 

순환참조를 없앴습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X