### PR TITLE
[FIX] BaseEntity 클래스 내 생성, 수정 시간 컬럼 타입 LocalDateTime 로 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/common/BaseEntity.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/BaseEntity.java
@@ -6,8 +6,6 @@ import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Locale;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -20,24 +18,21 @@ public abstract class BaseEntity {
 
     @CreatedDate
     @Column(nullable = false)
-    protected String createdDate;
+    protected LocalDateTime createdDate;
 
     @LastModifiedDate
     @Column(nullable = false)
-    protected String modifiedDate;
+    protected LocalDateTime modifiedDate;
 
     @PrePersist
     public void onPrePersist() {
-        String formattedDateTime = LocalDateTime.now()
-                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd a hh:mm").withLocale(Locale.forLanguageTag("ko")));
-
-        this.createdDate = formattedDateTime;
-        this.modifiedDate = formattedDateTime;
+        this.createdDate = LocalDateTime.now();
+        this.modifiedDate = createdDate;
     }
 
     @PreUpdate
     public void onPreUpdate() {
-        this.modifiedDate = LocalDateTime.now()
-                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd a hh:mm").withLocale(Locale.forLanguageTag("ko")));
+        this.modifiedDate = LocalDateTime.now();
     }
+
 }

--- a/src/main/java/org/websoso/WSSServer/dto/notice/NoticeGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notice/NoticeGetResponse.java
@@ -18,10 +18,7 @@ public record NoticeGetResponse(
         );
     }
 
-    private static String formatDateString(String dateTime) {
-        DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd a hh:mm");
-        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
-        LocalDateTime date = LocalDateTime.parse(dateTime, inputFormatter);
-        return date.format(outputFormatter);
+    private static String formatDateString(LocalDateTime dateTime) {
+        return dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#64 -> dev
- close #64 
<br>

## Key Changes
<!-- 최대한 자세히 -->
### 공용으로 사용하는 `BaseEntity` 클래스의 `엔티티 생성 시간`, `수정 시간` 컬럼의 타입을 LocalDateTime으로 변경했습니다.

- 엔티티 생성 시간, 수정 시간 타입이 변경됨에 따라 이미 개발되어 있던 관련 로직도 일부 수정했습니다.  -> `NoticeGetResponse`
<br>

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
두 분 다 승인해주시면 병합하기 전에 DB도 알맞게 수정해두겠습니다!
<br>