### PR TITLE
[FIX] 소소피드 수정 로직의 작품 통계-작품 피드 수 감소, 증가 로직 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -19,6 +19,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -125,6 +126,14 @@ public class Feed extends BaseEntity {
 
         this.likeUsers = this.likeUsers.replace(unLikeUserIdFormatted, "");
         this.likeCount--;
+    }
+
+    public boolean isNovelLinked() {
+        return this.novelId != null;
+    }
+
+    public boolean isNovelChanged(Long novelId) {
+        return !Objects.equals(this.novelId, novelId);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -48,6 +48,15 @@ public class FeedService {
 
         feed.validateUserAuthorization(user, UPDATE);
 
+        if (feed.isNovelChanged(request.novelId())) {
+            if (feed.isNovelLinked()) {
+                novelStatisticsService.decreaseNovelFeedCount(novelService.getNovelOrException(feed.getNovelId()));
+            }
+            if (request.novelId() != null) {
+                novelStatisticsService.increaseNovelFeedCount(novelService.getNovelOrException(request.novelId()));
+            }
+        }
+
         feed.updateFeed(request.feedContent(), request.isSpoiler() ? Y : N, request.novelId());
         categoryService.updateCategory(feed, request.relevantCategories());
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#66 -> dev
- close #66
<br>

## Key Changes
<!-- 최대한 자세히 -->
소소피드 수정 API 로직에서 수정하는 Feed의 noveId에 변경이 있을 시, 작품 통계 엔티티의 `작품 피드 수` 감소, 증가 로직을 추가했습니다.

피드 수정 시, 작품 통계 엔티티의 `작품 피드 수`를 증감하는 경우는 3가지가 있습니다.
1. 기존 Feed에 연결된 novel이 없었는데 생긴 경우 -> `증가`
2. 기존 Feed에 연결된 novel이 있었는데 없어진 경우 -> `감소`
3. 기존 Feed에 연결된 novel이 있었는데 새로운 novel을 연결하는 경우 -> `기존 것 감소`, `새로운 것 증가`

<br>

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X
<br>