### PR TITLE
[FEAT] 소소피드 단건 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ## application.yml ##
 *.yml
+
+## QClass ##
+src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,12 @@ dependencies {
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    //QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/org/websoso/WSSServer/config/QueryDslConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package org.websoso.WSSServer.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -2,12 +2,14 @@ package org.websoso.WSSServer.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.OK;
 
 import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
+import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 import org.websoso.WSSServer.service.FeedService;
 import org.websoso.WSSServer.service.UserService;
@@ -50,7 +53,7 @@ public class FeedController {
                 .status(NO_CONTENT)
                 .build();
     }
-  
+
     @DeleteMapping("/{feedId}")
     public ResponseEntity<Void> deleteFeed(Principal principal,
                                            @PathVariable("feedId") Long feedId) {
@@ -78,10 +81,21 @@ public class FeedController {
                                            @PathVariable("feedId") Long feedId) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         feedService.unLikeFeed(user, feedId);
-  
+
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();
+    }
+
+    @GetMapping("/{feedId}")
+    public ResponseEntity<FeedGetResponse> getFeed(Principal principal,
+                                                   @PathVariable("feedId") Long feedId) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        FeedGetResponse response = feedService.getFeedById(user, feedId);
+
+        return ResponseEntity
+                .status(OK)
+                .body(response);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -91,11 +91,9 @@ public class FeedController {
     public ResponseEntity<FeedGetResponse> getFeed(Principal principal,
                                                    @PathVariable("feedId") Long feedId) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
-        FeedGetResponse response = feedService.getFeedById(user, feedId);
-
         return ResponseEntity
                 .status(OK)
-                .body(response);
+                .body(feedService.getFeedById(user, feedId));
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Category.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Category.java
@@ -4,8 +4,6 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -14,7 +12,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -26,52 +23,34 @@ public class Category {
     @Column(nullable = false)
     private Long categoryId;
 
-    @Column(nullable = false)
+    @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isRf;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    @ColumnDefault("'N'")
+    @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isRo;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    @ColumnDefault("'N'")
+    @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isFa;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    @ColumnDefault("'N'")
+    @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isMf;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    @ColumnDefault("'N'")
+    @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isDr;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    @ColumnDefault("'N'")
+    @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isLn;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    @ColumnDefault("'N'")
+    @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isWu;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    @ColumnDefault("'N'")
+    @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isMy;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    @ColumnDefault("'N'")
+    @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isBl;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    @ColumnDefault("'N'")
+    @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isEtc;
 
     @OneToOne

--- a/src/main/java/org/websoso/WSSServer/domain/Category.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Category.java
@@ -15,7 +15,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
-import org.websoso.WSSServer.domain.common.Flag;
 
 @Entity
 @Getter
@@ -27,63 +26,61 @@ public class Category {
     @Column(nullable = false)
     private Long categoryId;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    @ColumnDefault("'N'")
-    private Flag isRf;
+    private Boolean isRf;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @ColumnDefault("'N'")
-    private Flag isRo;
+    private Boolean isRo;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @ColumnDefault("'N'")
-    private Flag isFa;
+    private Boolean isFa;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @ColumnDefault("'N'")
-    private Flag isMf;
+    private Boolean isMf;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @ColumnDefault("'N'")
-    private Flag isDr;
+    private Boolean isDr;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @ColumnDefault("'N'")
-    private Flag isLn;
+    private Boolean isLn;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @ColumnDefault("'N'")
-    private Flag isWu;
+    private Boolean isWu;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @ColumnDefault("'N'")
-    private Flag isMy;
+    private Boolean isMy;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @ColumnDefault("'N'")
-    private Flag isBl;
+    private Boolean isBl;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @ColumnDefault("'N'")
-    private Flag isEtc;
+    private Boolean isEtc;
 
     @OneToOne
     @JoinColumn(name = "feed_id", nullable = false)
     private Feed feed;
 
     @Builder
-    public Category(Long categoryId, Flag isRf, Flag isRo, Flag isFa, Flag isMf, Flag isDr, Flag isLn, Flag isWu,
-                    Flag isMy, Flag isBl, Flag isEtc, Feed feed) {
+    public Category(Long categoryId, Boolean isRf, Boolean isRo, Boolean isFa, Boolean isMf, Boolean isDr, Boolean isLn,
+                    Boolean isWu, Boolean isMy, Boolean isBl, Boolean isEtc, Feed feed) {
         this.categoryId = categoryId;
         this.isRf = isRf;
         this.isRo = isRo;
@@ -97,5 +94,4 @@ public class Category {
         this.isEtc = isEtc;
         this.feed = feed;
     }
-
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -9,8 +9,6 @@ import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_AUTH
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -24,11 +22,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.websoso.WSSServer.domain.common.Action;
 import org.websoso.WSSServer.domain.common.BaseEntity;
-import org.websoso.WSSServer.domain.common.Flag;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
 
@@ -43,10 +39,8 @@ public class Feed extends BaseEntity {
     @Column(nullable = false)
     private Long feedId;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    @ColumnDefault("'N'")
-    private Flag isHidden;
+    private Boolean isHidden;
 
     @Column(columnDefinition = "varchar(2000)", nullable = false)
     private String feedContent;
@@ -54,10 +48,8 @@ public class Feed extends BaseEntity {
     @Column
     private Long novelId;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    @ColumnDefault("'N'")
-    private Flag isSpoiler;
+    private Boolean isSpoiler;
 
     @Column(columnDefinition = "int default 0", nullable = false)
     private Integer likeCount;
@@ -82,14 +74,14 @@ public class Feed extends BaseEntity {
     private List<Comment> comments = new ArrayList<>();
 
     @Builder
-    public Feed(String feedContent, Flag isSpoiler, Long novelId, User user) {
+    public Feed(String feedContent, Boolean isSpoiler, Long novelId, User user) {
         this.feedContent = feedContent;
         this.isSpoiler = isSpoiler;
         this.novelId = novelId;
         this.user = user;
     }
 
-    public void updateFeed(String feedContent, Flag isSpoiler, Long novelId) {
+    public void updateFeed(String feedContent, Boolean isSpoiler, Long novelId) {
         this.feedContent = feedContent;
         this.isSpoiler = isSpoiler;
         this.novelId = novelId;

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -48,7 +48,7 @@ public class Feed extends BaseEntity {
     @Column
     private Long novelId;
 
-    @Column(columnDefinition = "Boolean", nullable = false)
+    @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isSpoiler;
 
     @Column(columnDefinition = "int default 0", nullable = false)

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -39,7 +39,7 @@ public class Feed extends BaseEntity {
     @Column(nullable = false)
     private Long feedId;
 
-    @Column(nullable = false)
+    @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isHidden;
 
     @Column(columnDefinition = "varchar(2000)", nullable = false)
@@ -48,7 +48,7 @@ public class Feed extends BaseEntity {
     @Column
     private Long novelId;
 
-    @Column(nullable = false)
+    @Column(columnDefinition = "Boolean", nullable = false)
     private Boolean isSpoiler;
 
     @Column(columnDefinition = "int default 0", nullable = false)

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.websoso.WSSServer.domain.common.Gender;
 import org.websoso.WSSServer.domain.common.Role;
+import org.websoso.WSSServer.dto.User.UserBasicInfo;
 
 @Entity
 @Getter
@@ -75,4 +76,9 @@ public class User {
     public void updateProfileStatus(Boolean profileStatus) {
         this.isProfilePublic = profileStatus;
     }
+
+    public UserBasicInfo getUserBasicInfo(String avatarImage) {
+        return UserBasicInfo.of(this.getUserId(), this.getNickname(), avatarImage);
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/dto/User/UserBasicInfo.java
+++ b/src/main/java/org/websoso/WSSServer/dto/User/UserBasicInfo.java
@@ -1,0 +1,15 @@
+package org.websoso.WSSServer.dto.User;
+
+public record UserBasicInfo(
+        Long userId,
+        String nickname,
+        String avatarImage
+) {
+    public static UserBasicInfo of(Long userId, String nickname, String avatarImage) {
+        return new UserBasicInfo(
+                userId,
+                nickname,
+                avatarImage
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -42,7 +42,7 @@ public record FeedGetResponse(
                 userBasicInfo.userId(),
                 userBasicInfo.nickname(),
                 userBasicInfo.avatarImage(),
-                feed.getCreatedDate().format(DateTimeFormatter.ofPattern("M월 d일")), // TODO : 형식 포맷팅
+                feed.getCreatedDate().format(DateTimeFormatter.ofPattern("M월 d일")),
                 feed.getFeedContent(),
                 feed.getLikeCount(),
                 isLiked,

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -34,8 +34,7 @@ public record FeedGetResponse(
         if (novel != null) {
             title = novel.getTitle();
             novelRatingCount = novel.getNovelRatingCount();
-            novelRating = novelRatingCount == 0 ? 0.0f
-                    : Math.round((novel.getNovelRatingSum() / (float) novelRatingCount) * 10) / 10.0f;
+            novelRating = calculateNovelRating(novel.getNovelRatingSum(), novelRatingCount);
         }
 
         return new FeedGetResponse(
@@ -57,4 +56,12 @@ public record FeedGetResponse(
                 isMyFeed
         );
     }
+
+    private static Float calculateNovelRating(Float novelRatingSum, Integer novelRatingCount) {
+        if (novelRatingCount == 0) {
+            return 0.0f;
+        }
+        return Math.round((novelRatingSum / (float) novelRatingCount) * 10) / 10.0f;
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.dto.feed;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
@@ -41,7 +42,7 @@ public record FeedGetResponse(
                 userBasicInfo.userId(),
                 userBasicInfo.nickname(),
                 userBasicInfo.avatarImage(),
-                feed.getCreatedDate(), // TODO : 형식 포맷팅
+                feed.getCreatedDate().format(DateTimeFormatter.ofPattern("M월 d일")), // TODO : 형식 포맷팅
                 feed.getFeedContent(),
                 feed.getLikeCount(),
                 isLiked,

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -41,7 +41,7 @@ public record FeedGetResponse(
                 userBasicInfo.userId(),
                 userBasicInfo.nickname(),
                 userBasicInfo.avatarImage(),
-                feed.getCreatedDate(),
+                feed.getCreatedDate(), // TODO : 형식 포맷팅
                 feed.getFeedContent(),
                 feed.getLikeCount(),
                 isLiked,
@@ -52,7 +52,7 @@ public record FeedGetResponse(
                 novelRating,
                 relevantCategories,
                 feed.getIsSpoiler(),
-                !feed.getModifiedDate().isBlank(),
+                !feed.getCreatedDate().equals(feed.getModifiedDate()),
                 isMyFeed
         );
     }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -1,0 +1,61 @@
+package org.websoso.WSSServer.dto.feed;
+
+import static org.websoso.WSSServer.domain.common.Flag.Y;
+
+import java.util.List;
+import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.dto.User.UserBasicInfo;
+
+public record FeedGetResponse(
+        Long userId,
+        String nickname,
+        String avatarImage,
+        String createdDate,
+        String feedContent,
+        Integer likeCount,
+        Boolean isLiked,
+        Integer commentCount,
+        Long novelId,
+        String title,
+        Integer novelRatingCount,
+        Float novelRating,
+        List<String> relevantCategories,
+        Boolean isSpoiler,
+        Boolean isModified,
+        Boolean isMyFeed
+
+) {
+    public static FeedGetResponse of(Feed feed, UserBasicInfo userBasicInfo, Novel novel, Boolean isLiked,
+                                     List<String> relevantCategories, Boolean isMyFeed) {
+        String title = null;
+        Integer novelRatingCount = null;
+        Float novelRating = null;
+
+        if (novel != null) {
+            title = novel.getTitle();
+            novelRatingCount = novel.getNovelRatingCount();
+            novelRating = novelRatingCount == 0 ? 0.0f
+                    : Math.round((novel.getNovelRatingSum() / (float) novelRatingCount) * 10) / 10.0f;
+        }
+
+        return new FeedGetResponse(
+                userBasicInfo.userId(),
+                userBasicInfo.nickname(),
+                userBasicInfo.avatarImage(),
+                feed.getCreatedDate(),
+                feed.getFeedContent(),
+                feed.getLikeCount(),
+                isLiked,
+                feed.getCommentCount(),
+                feed.getNovelId(),
+                title,
+                novelRatingCount,
+                novelRating,
+                relevantCategories,
+                feed.getIsSpoiler().equals(Y),
+                !feed.getModifiedDate().isBlank(),
+                isMyFeed
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -1,7 +1,5 @@
 package org.websoso.WSSServer.dto.feed;
 
-import static org.websoso.WSSServer.domain.common.Flag.Y;
-
 import java.util.List;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
@@ -53,7 +51,7 @@ public record FeedGetResponse(
                 novelRatingCount,
                 novelRating,
                 relevantCategories,
-                feed.getIsSpoiler().equals(Y),
+                feed.getIsSpoiler(),
                 !feed.getModifiedDate().isBlank(),
                 isMyFeed
         );

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomAvatarError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomAvatarError.java
@@ -16,4 +16,5 @@ public enum CustomAvatarError implements ICustomError {
     private final String code;
     private final String description;
     private final HttpStatus statusCode;
+
 }

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomFeedError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomFeedError.java
@@ -19,7 +19,7 @@ public enum CustomFeedError implements ICustomError {
     LIKE_USER_NOT_FOUND("FEED-003", "해당 사용자가 이 피드에 좋아요를 누르지 않았습니다.", NOT_FOUND),
     INVALID_LIKE_COUNT("FEED-004", "좋아요 수가 유효하지 않습니다.", BAD_REQUEST),
     HIDDEN_FEED_ACCESS("FEED-005", "이 피드는 숨겨져 있어 접근할 수 없습니다.", FORBIDDEN),
-    BLOCKED_USER_ACCESS("FEED-006", "해당 사용자와 피드 작성자가 차단 상태이기 때문에 이 피드에 접근할 수 없습니다.", FORBIDDEN);
+    BLOCKED_USER_ACCESS("FEED-006", "해당 사용자와 피드 작성자가 차단 상태이므로 이 피드에 접근할 수 없습니다.", FORBIDDEN);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomFeedError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomFeedError.java
@@ -2,6 +2,7 @@ package org.websoso.WSSServer.exception.error;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.AllArgsConstructor;
@@ -16,7 +17,9 @@ public enum CustomFeedError implements ICustomError {
     FEED_NOT_FOUND("FEED-001", "해당 ID를 가진 피드를 찾을 수 없습니다.", NOT_FOUND),
     ALREADY_LIKED("FEED-002", "이미 해당 피드에 좋아요를 눌렀습니다.", CONFLICT),
     LIKE_USER_NOT_FOUND("FEED-003", "해당 사용자가 이 피드에 좋아요를 누르지 않았습니다.", NOT_FOUND),
-    INVALID_LIKE_COUNT("FEED-004", "좋아요 수가 유효하지 않습니다.", BAD_REQUEST);
+    INVALID_LIKE_COUNT("FEED-004", "좋아요 수가 유효하지 않습니다.", BAD_REQUEST),
+    HIDDEN_FEED_ACCESS("FEED-005", "이 피드는 숨겨져 있어 접근할 수 없습니다.", FORBIDDEN),
+    BLOCKED_USER_ACCESS("FEED-006", "해당 사용자와 피드 작성자가 차단 상태이기 때문에 이 피드에 접근할 수 없습니다.", FORBIDDEN);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/repository/AvatarRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/AvatarRepository.java
@@ -6,8 +6,4 @@ import org.websoso.WSSServer.domain.Avatar;
 
 @Repository
 public interface AvatarRepository extends JpaRepository<Avatar, Byte> {
-<<<<<<< HEAD
-
-=======
->>>>>>> 8e88fcb ([FEAT] 소소피드 단건 조회 API 구현)
 }

--- a/src/main/java/org/websoso/WSSServer/repository/AvatarRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/AvatarRepository.java
@@ -6,5 +6,8 @@ import org.websoso.WSSServer.domain.Avatar;
 
 @Repository
 public interface AvatarRepository extends JpaRepository<Avatar, Byte> {
+<<<<<<< HEAD
 
+=======
+>>>>>>> 8e88fcb ([FEAT] 소소피드 단건 조회 API 구현)
 }

--- a/src/main/java/org/websoso/WSSServer/repository/BlockCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/BlockCustomRepository.java
@@ -1,0 +1,5 @@
+package org.websoso.WSSServer.repository;
+
+public interface BlockCustomRepository {
+    Boolean existsByTwoUserId(Long blockedId, Long blockingId);
+}

--- a/src/main/java/org/websoso/WSSServer/repository/BlockCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/BlockCustomRepositoryImpl.java
@@ -3,11 +3,11 @@ package org.websoso.WSSServer.repository;
 import static org.websoso.WSSServer.domain.QBlock.block;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class BlockCustomRepositoryImpl implements BlockCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;

--- a/src/main/java/org/websoso/WSSServer/repository/BlockCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/BlockCustomRepositoryImpl.java
@@ -1,0 +1,24 @@
+package org.websoso.WSSServer.repository;
+
+import static org.websoso.WSSServer.domain.QBlock.block;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@AllArgsConstructor
+public class BlockCustomRepositoryImpl implements BlockCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Boolean existsByTwoUserId(Long blockedId, Long blockingId) {
+        return jpaQueryFactory
+                .selectOne()
+                .from(block)
+                .where(block.blockedId.eq(blockedId).and(block.blockingId.eq(blockingId))
+                        .or(block.blockedId.eq(blockingId).and(block.blockingId.eq(blockedId))))
+                .fetchFirst() != null;
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/repository/BlockRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/BlockRepository.java
@@ -1,7 +1,6 @@
 package org.websoso.WSSServer.repository;
 
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,7 +14,7 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
 
     List<Block> findByBlockingId(Long blockingId);
 
-    @Query("SELECT b FROM Block b WHERE (b.blockingId = :firstUserId AND b.blockedId = :secondUserId) OR (b.blockingId = :secondUserId AND b.blockedId = :firstUserId)")
-    Optional<Block> findByTwoUserId(@Param("firstUserId") Long firstUserId, @Param("secondUserId") Long secondUserId);
+    @Query("SELECT (COUNT(b) > 0) FROM Block b WHERE (b.blockingId = :firstUserId AND b.blockedId = :secondUserId) OR (b.blockingId = :secondUserId AND b.blockedId = :firstUserId)")
+    boolean existsByTwoUserId(@Param("firstUserId") Long firstUserId, @Param("secondUserId") Long secondUserId);
 
 }

--- a/src/main/java/org/websoso/WSSServer/repository/BlockRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/BlockRepository.java
@@ -2,19 +2,13 @@ package org.websoso.WSSServer.repository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Block;
 
 @Repository
-public interface BlockRepository extends JpaRepository<Block, Long> {
+public interface BlockRepository extends JpaRepository<Block, Long>, BlockCustomRepository {
 
     boolean existsByBlockingIdAndBlockedId(Long blockingId, Long blockedId);
 
     List<Block> findByBlockingId(Long blockingId);
-
-    @Query("SELECT (COUNT(b) > 0) FROM Block b WHERE (b.blockingId = :firstUserId AND b.blockedId = :secondUserId) OR (b.blockingId = :secondUserId AND b.blockedId = :firstUserId)")
-    boolean existsByTwoUserId(@Param("firstUserId") Long firstUserId, @Param("secondUserId") Long secondUserId);
-
 }

--- a/src/main/java/org/websoso/WSSServer/repository/BlockRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/BlockRepository.java
@@ -1,7 +1,10 @@
 package org.websoso.WSSServer.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Block;
 
@@ -11,4 +14,8 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
     boolean existsByBlockingIdAndBlockedId(Long blockingId, Long blockedId);
 
     List<Block> findByBlockingId(Long blockingId);
+
+    @Query("SELECT b FROM Block b WHERE (b.blockingId = :firstUserId AND b.blockedId = :secondUserId) OR (b.blockingId = :secondUserId AND b.blockedId = :firstUserId)")
+    Optional<Block> findByTwoUserId(@Param("firstUserId") Long firstUserId, @Param("secondUserId") Long secondUserId);
+
 }

--- a/src/main/java/org/websoso/WSSServer/service/AvatarService.java
+++ b/src/main/java/org/websoso/WSSServer/service/AvatarService.java
@@ -45,4 +45,5 @@ public class AvatarService {
         final int avatarLineSize = avatarLines.size();
         return avatarLines.get(random.nextInt(avatarLineSize));
     }
+
 }

--- a/src/main/java/org/websoso/WSSServer/service/BlockService.java
+++ b/src/main/java/org/websoso/WSSServer/service/BlockService.java
@@ -68,4 +68,9 @@ public class BlockService {
         }
         blockRepository.delete(block);
     }
+
+    public Boolean isBlockedRelationship(Long firstUserId, Long secondUserId) {
+        return blockRepository.findByTwoUserId(firstUserId, secondUserId).isPresent();
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/service/BlockService.java
+++ b/src/main/java/org/websoso/WSSServer/service/BlockService.java
@@ -69,8 +69,8 @@ public class BlockService {
         blockRepository.delete(block);
     }
 
-    public Boolean isBlockedRelationship(Long firstUserId, Long secondUserId) {
-        return blockRepository.findByTwoUserId(firstUserId, secondUserId).isPresent();
+    public boolean isBlockedRelationship(Long firstUserId, Long secondUserId) {
+        return blockRepository.existsByTwoUserId(firstUserId, secondUserId);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/CategoryService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CategoryService.java
@@ -10,8 +10,6 @@ import static org.websoso.WSSServer.domain.common.CategoryName.MY;
 import static org.websoso.WSSServer.domain.common.CategoryName.RF;
 import static org.websoso.WSSServer.domain.common.CategoryName.RO;
 import static org.websoso.WSSServer.domain.common.CategoryName.WU;
-import static org.websoso.WSSServer.domain.common.Flag.N;
-import static org.websoso.WSSServer.domain.common.Flag.Y;
 import static org.websoso.WSSServer.exception.error.CustomCategoryError.CATEGORY_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomCategoryError.INVALID_CATEGORY_FORMAT;
 
@@ -25,7 +23,6 @@ import org.websoso.WSSServer.domain.Category;
 import org.websoso.WSSServer.domain.Category.CategoryBuilder;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.common.CategoryName;
-import org.websoso.WSSServer.domain.common.Flag;
 import org.websoso.WSSServer.exception.exception.CustomCategoryException;
 import org.websoso.WSSServer.repository.CategoryRepository;
 
@@ -62,34 +59,34 @@ public class CategoryService {
     public List<String> getRelevantCategoryNames(Category category) {
         List<String> relevantCategories = new ArrayList<>();
 
-        if (category.getIsRf() == Y) {
+        if (category.getIsRf()) {
             relevantCategories.add(RF.getValue());
         }
-        if (category.getIsRo() == Y) {
+        if (category.getIsRo()) {
             relevantCategories.add(RO.getValue());
         }
-        if (category.getIsFa() == Y) {
+        if (category.getIsFa()) {
             relevantCategories.add(FA.getValue());
         }
-        if (category.getIsMf() == Y) {
+        if (category.getIsMf()) {
             relevantCategories.add(MF.getValue());
         }
-        if (category.getIsDr() == Y) {
+        if (category.getIsDr()) {
             relevantCategories.add(DR.getValue());
         }
-        if (category.getIsLn() == Y) {
+        if (category.getIsLn()) {
             relevantCategories.add(LN.getValue());
         }
-        if (category.getIsWu() == Y) {
+        if (category.getIsWu()) {
             relevantCategories.add(WU.getValue());
         }
-        if (category.getIsMy() == Y) {
+        if (category.getIsMy()) {
             relevantCategories.add(MY.getValue());
         }
-        if (category.getIsBl() == Y) {
+        if (category.getIsBl()) {
             relevantCategories.add(BL.getValue());
         }
-        if (category.getIsEtc() == Y) {
+        if (category.getIsEtc()) {
             relevantCategories.add(ETC.getValue());
         }
 
@@ -100,16 +97,16 @@ public class CategoryService {
         validateCategory(relevantCategories);
 
         return builder
-                .isRf(getCategoryFlag(relevantCategories, RF))
-                .isRo(getCategoryFlag(relevantCategories, RO))
-                .isFa(getCategoryFlag(relevantCategories, FA))
-                .isMf(getCategoryFlag(relevantCategories, MF))
-                .isDr(getCategoryFlag(relevantCategories, DR))
-                .isLn(getCategoryFlag(relevantCategories, LN))
-                .isWu(getCategoryFlag(relevantCategories, WU))
-                .isMy(getCategoryFlag(relevantCategories, MY))
-                .isBl(getCategoryFlag(relevantCategories, BL))
-                .isEtc(getCategoryFlag(relevantCategories, ETC))
+                .isRf(isContainCategoryName(relevantCategories, RF))
+                .isRo(isContainCategoryName(relevantCategories, RO))
+                .isFa(isContainCategoryName(relevantCategories, FA))
+                .isMf(isContainCategoryName(relevantCategories, MF))
+                .isDr(isContainCategoryName(relevantCategories, DR))
+                .isLn(isContainCategoryName(relevantCategories, LN))
+                .isWu(isContainCategoryName(relevantCategories, WU))
+                .isMy(isContainCategoryName(relevantCategories, MY))
+                .isBl(isContainCategoryName(relevantCategories, BL))
+                .isEtc(isContainCategoryName(relevantCategories, ETC))
                 .build();
     }
 
@@ -121,8 +118,8 @@ public class CategoryService {
         }
     }
 
-    private Flag getCategoryFlag(List<String> relevantCategories, CategoryName categoryName) {
-        return relevantCategories.contains(categoryName.getValue()) ? Y : N;
+    private Boolean isContainCategoryName(List<String> relevantCategories, CategoryName categoryName) {
+        return relevantCategories.contains(categoryName.getValue());
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/CategoryService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CategoryService.java
@@ -15,6 +15,7 @@ import static org.websoso.WSSServer.domain.common.Flag.Y;
 import static org.websoso.WSSServer.exception.error.CustomCategoryError.CATEGORY_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomCategoryError.INVALID_CATEGORY_FORMAT;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -56,6 +57,43 @@ public class CategoryService {
         Category category = setCategory(builder, relevantCategories);
 
         categoryRepository.save(category);
+    }
+
+    public List<String> getRelevantCategoryNames(Category category) {
+        List<String> relevantCategories = new ArrayList<>();
+
+        if (category.getIsRf() == Y) {
+            relevantCategories.add(RF.getValue());
+        }
+        if (category.getIsRo() == Y) {
+            relevantCategories.add(RO.getValue());
+        }
+        if (category.getIsFa() == Y) {
+            relevantCategories.add(FA.getValue());
+        }
+        if (category.getIsMf() == Y) {
+            relevantCategories.add(MF.getValue());
+        }
+        if (category.getIsDr() == Y) {
+            relevantCategories.add(DR.getValue());
+        }
+        if (category.getIsLn() == Y) {
+            relevantCategories.add(LN.getValue());
+        }
+        if (category.getIsWu() == Y) {
+            relevantCategories.add(WU.getValue());
+        }
+        if (category.getIsMy() == Y) {
+            relevantCategories.add(MY.getValue());
+        }
+        if (category.getIsBl() == Y) {
+            relevantCategories.add(BL.getValue());
+        }
+        if (category.getIsEtc() == Y) {
+            relevantCategories.add(ETC.getValue());
+        }
+
+        return relevantCategories;
     }
 
     private Category setCategory(CategoryBuilder builder, List<String> relevantCategories) {

--- a/src/main/java/org/websoso/WSSServer/service/CategoryService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CategoryService.java
@@ -56,6 +56,7 @@ public class CategoryService {
         categoryRepository.save(category);
     }
 
+    @Transactional(readOnly = true)
     public List<String> getRelevantCategoryNames(Category category) {
         List<String> relevantCategories = new ArrayList<>();
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -99,7 +99,7 @@ public class FeedService {
     public FeedGetResponse getFeedById(User user, Long feedId) {
         Feed feed = getFeedOrException(feedId);
 
-        UserBasicInfo userBasicInfo = getUserInformation(feed.getUser());
+        UserBasicInfo userBasicInfo = getUserBasicInfo(feed.getUser());
         Novel novel = getLinkedNovelOrNull(feed.getNovelId());
         Boolean isLiked = isUserLikedFeed(feed.getLikeUsers(), user);
         List<String> relevantCategories = categoryService.getRelevantCategoryNames(feed.getCategory());
@@ -113,7 +113,7 @@ public class FeedService {
                 new CustomFeedException(FEED_NOT_FOUND, "feed with the given id was not found"));
     }
 
-    private UserBasicInfo getUserInformation(User user) {
+    private UserBasicInfo getUserBasicInfo(User user) {
         return user.getUserBasicInfo(
                 avatarService.getAvatarOrException(user.getAvatarId()).getAvatarImage()
         );

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -100,8 +100,8 @@ public class FeedService {
     public FeedGetResponse getFeedById(User user, Long feedId) {
         Feed feed = getFeedOrException(feedId);
 
-        isHiddenFeed(feed);
-        isBlockedRelationship(feed.getUser(), user);
+        checkHiddenFeed(feed);
+        checkBlockedRelationship(feed.getUser(), user);
 
         UserBasicInfo userBasicInfo = getUserBasicInfo(feed.getUser());
         Novel novel = getLinkedNovelOrNull(feed.getNovelId());
@@ -117,13 +117,13 @@ public class FeedService {
                 new CustomFeedException(FEED_NOT_FOUND, "feed with the given id was not found"));
     }
 
-    private void isHiddenFeed(Feed feed) {
+    private void checkHiddenFeed(Feed feed) {
         if (feed.getIsHidden()) {
             throw new CustomFeedException(HIDDEN_FEED_ACCESS, "Cannot access hidden feed.");
         }
     }
 
-    private void isBlockedRelationship(User createdFeedUser, User user) {
+    private void checkBlockedRelationship(User createdFeedUser, User user) {
         if (blockService.isBlockedRelationship(user.getUserId(), createdFeedUser.getUserId())) {
             throw new CustomFeedException(BLOCKED_USER_ACCESS,
                     "cannot access this feed because either you or the feed author has blocked the other.");

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -25,7 +25,7 @@ import org.websoso.WSSServer.repository.FeedRepository;
 @Transactional
 public class FeedService {
 
-    private static final String LIKE_USER_PATTERN = "\\{%s\\}";
+    private static final String LIKE_USER_PATTERN = "{%s}";
 
     private final FeedRepository feedRepository;
     private final CategoryService categoryService;

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -2,8 +2,6 @@ package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.domain.common.Action.DELETE;
 import static org.websoso.WSSServer.domain.common.Action.UPDATE;
-import static org.websoso.WSSServer.domain.common.Flag.N;
-import static org.websoso.WSSServer.domain.common.Flag.Y;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOUND;
 
 import java.util.List;
@@ -36,7 +34,7 @@ public class FeedService {
     public void createFeed(User user, FeedCreateRequest request) {
         Feed feed = Feed.builder()
                 .feedContent(request.feedContent())
-                .isSpoiler(request.isSpoiler() ? Y : N)
+                .isSpoiler(request.isSpoiler())
                 .novelId(request.novelId())
                 .user(user)
                 .build();
@@ -63,7 +61,7 @@ public class FeedService {
             }
         }
 
-        feed.updateFeed(request.feedContent(), request.isSpoiler() ? Y : N, request.novelId());
+        feed.updateFeed(request.feedContent(), request.isSpoiler(), request.novelId());
         categoryService.updateCategory(feed, request.relevantCategories());
     }
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#50 -> dev
- close #50

## Key Changes
<!-- 최대한 자세히 -->
### 소소피드 단건을 조회하는 API를 구현했습니다.

주요 내용으로는 다음 내용 정도가 있을 것 같아요.
- `Flag` Enum 클래스를 대부분의 도메인 클래스에서 사용을 했었는데, 그냥 Boolean을 쓰는 것이 낫다는 얘기를 나눈적이 있습니다!
그걸 바탕으로 바꾸기 어렵지도 않고 다른 API _(이미 개발된, Flag를 사용하고 있는?)_ 가 없어서 그냥 Boolean 으로 바꿔버려 개발 진행했습니다!
**(요약 : Feed와 Comment 도메인 클래스에서 사용되던 모든 Flag 컬럼 -> Boolean 컬럼으로 변경)**
- 소소피드 목록을 볼 때 (소소피드 탭이던, 특정 작품의 피드 탭이던,,) 로그인 한 유저가 **차단한 유저** 또는 로그인유저를 **차단한 유저** 의 피드는 아예 조회 결과에서 제외를 해버리기 때문에 이 API에 접근 할 수가 없습니다!
그래서 이 API에 **_차단 유저 관련 에러 로직_** 을 추가했습니다!
<br>
+ 두 유저 간 차단관계를 확인하는 로직의 성능을 개선하기 위해 QueryDsl을 사용하여 기능 수정을 하였습니다.

### 두 유저 간 차단관계 확인 로직 실제 나가는 쿼리문
<img width="250" alt="image" src="https://github.com/Team-WSS/WSS-Server/assets/109871579/1643fb7d-1c0f-42b3-ad0e-7b154af7836d">

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
Comment로 주요한 부분에 달아놓을게요~ 

## References
<!-- 참고한 자료-->
X