### PR TITLE
[FEAT] 소소피드 전체 조회 API 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig {
             "/actuator/health",
             "/novels/{novelId}",
             "/novels/{novelId}/info",
-            "/soso-picks"
+            "/soso-picks",
+            "/feeds"
     };
 
     @Bean

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -15,11 +15,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
+import org.websoso.WSSServer.dto.feed.FeedsGetResponse;
 import org.websoso.WSSServer.service.FeedService;
 import org.websoso.WSSServer.service.UserService;
 
@@ -95,6 +97,18 @@ public class FeedController {
         return ResponseEntity
                 .status(OK)
                 .body(feedService.getFeedById(user, feedId));
+    }
+
+    @GetMapping
+    public ResponseEntity<FeedsGetResponse> getFeeds(Principal principal,
+                                                     @RequestParam("category") String category,
+                                                     @RequestParam("lastFeedId") Long lastFeedId,
+                                                     @RequestParam("size") int size) {
+        User user = principal == null ? null : userService.getUserOrException(Long.valueOf(principal.getName()));
+
+        return ResponseEntity
+                .status(OK)
+                .body(feedService.getFeeds(user, category, lastFeedId, size));
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/common/CategoryName.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/CategoryName.java
@@ -1,8 +1,5 @@
 package org.websoso.WSSServer.domain.common;
 
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,24 +7,17 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CategoryName {
 
-    RF("romanceFantasy"),
-    RO("romance"),
-    FA("fantasy"),
-    MF("modernFantasy"),
-    DR("drama"),
-    LN("lightNovel"),
-    WU("wuxia"),
-    MY("mystery"),
+    romanceFantasy("로판"),
+    romance("로맨스"),
+    fantasy("판타지"),
+    modernFantasy("현판"),
+    drama("드라마"),
+    lightNovel("라이트노벨"),
+    wuxia("무협"),
+    mystery("미스터리"),
     BL("BL"),
-    ETC("etc");
+    etc("기타");
 
     private final String label;
-
-    private static final Map<String, CategoryName> BY_LABEL =
-            Stream.of(values()).collect(Collectors.toMap(CategoryName::getLabel, e -> e));
-
-    public static CategoryName of(String label) {
-        return BY_LABEL.get(label);
-    }
 
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedInfo.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedInfo.java
@@ -1,0 +1,74 @@
+package org.websoso.WSSServer.dto.feed;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.UserNovel;
+import org.websoso.WSSServer.dto.user.UserBasicInfo;
+
+public record FeedInfo(
+        Long feedId,
+        Long userId,
+        String nickname,
+        String avatarImage,
+        String createdDate,
+        String feedContent,
+        Integer likeCount,
+        Boolean isLiked,
+        Integer commentCount,
+        Long novelId,
+        String title,
+        Integer novelRatingCount,
+        Float novelRating,
+        List<String> relevantCategories,
+        Boolean isSpoiler,
+        Boolean isModified,
+        Boolean isMyFeed
+
+) {
+    public static FeedInfo of(Feed feed, UserBasicInfo userBasicInfo, Novel novel, Boolean isLiked,
+                              List<String> relevantCategories, Boolean isMyFeed) {
+        String title = null;
+        Integer novelRatingCount = null;
+        Float novelRating = null;
+
+        if (novel != null) {
+            List<UserNovel> userNovels = novel.getUserNovels().stream().filter(un -> un.getUserNovelRating() > 0.0)
+                    .toList();
+            title = novel.getTitle();
+            novelRatingCount = userNovels.size();
+            novelRating = calculateNovelRating(
+                    (float) userNovels.stream().map(UserNovel::getUserNovelRating).mapToDouble(d -> d).sum(),
+                    novelRatingCount);
+        }
+
+        return new FeedInfo(
+                feed.getFeedId(),
+                userBasicInfo.userId(),
+                userBasicInfo.nickname(),
+                userBasicInfo.avatarImage(),
+                feed.getCreatedDate().format(DateTimeFormatter.ofPattern("M월 d일")),
+                feed.getFeedContent(),
+                feed.getLikes().size(),
+                isLiked,
+                feed.getComments().size(),
+                feed.getNovelId(),
+                title,
+                novelRatingCount,
+                novelRating,
+                relevantCategories,
+                feed.getIsSpoiler(),
+                !feed.getCreatedDate().equals(feed.getModifiedDate()),
+                isMyFeed
+        );
+    }
+
+    private static Float calculateNovelRating(Float novelRatingSum, Integer novelRatingCount) {
+        if (novelRatingCount == 0) {
+            return 0.0f;
+        }
+        return Math.round((novelRatingSum / (float) novelRatingCount) * 10) / 10.0f;
+    }
+
+}

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedsGetResponse.java
@@ -1,0 +1,17 @@
+package org.websoso.WSSServer.dto.feed;
+
+import java.util.List;
+
+public record FeedsGetResponse(
+        String category,
+        Boolean isLoadable,
+        List<FeedInfo> feeds
+) {
+    static public FeedsGetResponse of(String category, Boolean isLoadable, List<FeedInfo> feeds) {
+        return new FeedsGetResponse(
+                category,
+                isLoadable,
+                feeds
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
@@ -2,7 +2,10 @@ package org.websoso.WSSServer.repository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Category;
 import org.websoso.WSSServer.domain.Feed;
@@ -14,4 +17,12 @@ public interface FeedCategoryRepository extends JpaRepository<FeedCategory, Long
     Optional<List<FeedCategory>> findByFeed(Feed feed);
 
     void deleteByCategory(Category category);
+
+    @Query(value = "SELECT fc.feed FROM FeedCategory fc "
+            + "WHERE fc.category = ?1 "
+            + "AND (?2 = 0 OR fc.feed.feedId < ?2) "
+            + "AND fc.feed.isHidden = false "
+            + "ORDER BY fc.feed.feedId DESC")
+    Slice<Feed> findFeedByCategory(Category category, Long lastFeedId, PageRequest pageRequest);
+
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
@@ -23,6 +23,6 @@ public interface FeedCategoryRepository extends JpaRepository<FeedCategory, Long
             + "AND (?2 = 0 OR fc.feed.feedId < ?2) "
             + "AND fc.feed.isHidden = false "
             + "ORDER BY fc.feed.feedId DESC")
-    Slice<Feed> findFeedByCategory(Category category, Long lastFeedId, PageRequest pageRequest);
+    Slice<Feed> findFeedsByCategory(Category category, Long lastFeedId, PageRequest pageRequest);
 
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
@@ -22,7 +22,9 @@ public interface FeedCategoryRepository extends JpaRepository<FeedCategory, Long
             + "WHERE fc.category = ?1 "
             + "AND (?2 = 0 OR fc.feed.feedId < ?2) "
             + "AND fc.feed.isHidden = false "
+            + "AND fc.feed.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = ?3) "
+            + "AND fc.feed.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = ?3) "
             + "ORDER BY fc.feed.feedId DESC")
-    Slice<Feed> findFeedsByCategory(Category category, Long lastFeedId, PageRequest pageRequest);
+    Slice<Feed> findFeedsByCategory(Category category, Long lastFeedId, Long userId, PageRequest pageRequest);
 
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
@@ -22,8 +22,9 @@ public interface FeedCategoryRepository extends JpaRepository<FeedCategory, Long
             + "WHERE fc.category = ?1 "
             + "AND (?2 = 0 OR fc.feed.feedId < ?2) "
             + "AND fc.feed.isHidden = false "
-            + "AND fc.feed.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = ?3) "
-            + "AND fc.feed.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = ?3) "
+            + "AND (?2 IS NULL "
+            + "OR (fc.feed.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = ?2)) "
+            + "AND fc.feed.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = ?2)) "
             + "ORDER BY fc.feed.feedId DESC")
     Slice<Feed> findFeedsByCategory(Category category, Long lastFeedId, Long userId, PageRequest pageRequest);
 

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
@@ -1,7 +1,6 @@
 package org.websoso.WSSServer.repository;
 
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,7 +13,7 @@ import org.websoso.WSSServer.domain.FeedCategory;
 @Repository
 public interface FeedCategoryRepository extends JpaRepository<FeedCategory, Long> {
 
-    Optional<List<FeedCategory>> findByFeed(Feed feed);
+    List<FeedCategory> findByFeed(Feed feed);
 
     void deleteByCategory(Category category);
 

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
@@ -19,12 +19,12 @@ public interface FeedCategoryRepository extends JpaRepository<FeedCategory, Long
     void deleteByCategory(Category category);
 
     @Query(value = "SELECT fc.feed FROM FeedCategory fc "
-            + "WHERE fc.category = ?1 "
-            + "AND (?2 = 0 OR fc.feed.feedId < ?2) "
+            + "WHERE fc.category = :category "
+            + "AND (:lastFeedId = 0 OR fc.feed.feedId < :lastFeedId) "
             + "AND fc.feed.isHidden = false "
-            + "AND (?2 IS NULL "
-            + "OR (fc.feed.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = ?2)) "
-            + "AND fc.feed.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = ?2)) "
+            + "AND (:lastFeedId IS NULL "
+            + "OR (fc.feed.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = :userId)) "
+            + "AND fc.feed.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = :userId)) "
             + "ORDER BY fc.feed.feedId DESC")
     Slice<Feed> findFeedsByCategory(Category category, Long lastFeedId, Long userId, PageRequest pageRequest);
 

--- a/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
@@ -15,7 +15,9 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     @Query(value = "SELECT f FROM Feed f WHERE "
             + "(?1 = 0 OR f.feedId < ?1) "
             + "AND f.isHidden = false "
+            + "AND f.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = ?2) "
+            + "AND f.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = ?2) "
             + "ORDER BY f.feedId DESC")
-    Slice<Feed> findFeeds(Long lastFeedId, PageRequest pageRequest);
+    Slice<Feed> findFeeds(Long lastFeedId, Long userId, PageRequest pageRequest);
 
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
@@ -13,11 +13,11 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     Integer countByNovelId(Long novelId);
 
     @Query(value = "SELECT f FROM Feed f WHERE "
-            + "(?1 = 0 OR f.feedId < ?1) "
+            + "(:lastFeedId = 0 OR f.feedId < :lastFeedId) "
             + "AND f.isHidden = false "
-            + "AND (?2 IS NULL "
-            + "OR (f.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = ?2)) "
-            + "AND f.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = ?2)) "
+            + "AND (:userId IS NULL "
+            + "OR (f.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = :userId)) "
+            + "AND f.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = :userId)) "
             + "ORDER BY f.feedId DESC")
     Slice<Feed> findFeeds(Long lastFeedId, Long userId, PageRequest pageRequest);
 

--- a/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
@@ -1,6 +1,9 @@
 package org.websoso.WSSServer.repository;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Feed;
 
@@ -8,4 +11,11 @@ import org.websoso.WSSServer.domain.Feed;
 public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     Integer countByNovelId(Long novelId);
+
+    @Query(value = "SELECT f FROM Feed f WHERE "
+            + "(?1 = 0 OR f.feedId < ?1) "
+            + "AND f.isHidden = false "
+            + "ORDER BY f.feedId DESC")
+    Slice<Feed> findFeeds(Long lastFeedId, PageRequest pageRequest);
+
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
@@ -15,8 +15,9 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     @Query(value = "SELECT f FROM Feed f WHERE "
             + "(?1 = 0 OR f.feedId < ?1) "
             + "AND f.isHidden = false "
-            + "AND f.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = ?2) "
-            + "AND f.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = ?2) "
+            + "AND (?2 IS NULL "
+            + "OR (f.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = ?2)) "
+            + "AND f.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = ?2)) "
             + "ORDER BY f.feedId DESC")
     Slice<Feed> findFeeds(Long lastFeedId, Long userId, PageRequest pageRequest);
 

--- a/src/main/java/org/websoso/WSSServer/service/CategoryService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CategoryService.java
@@ -18,10 +18,10 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
 
     @Transactional(readOnly = true)
-    public Category getCategory(String label) {
-        return categoryRepository.findByCategoryName(CategoryName.of(label))
+    public Category getCategory(String categoryName) {
+        return categoryRepository.findByCategoryName(CategoryName.valueOf(categoryName))
                 .orElseThrow(() -> new CustomCategoryException(INVALID_CATEGORY_FORMAT,
                         "Category for the given feed was not found"));
     }
-    
+
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedCategoryService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedCategoryService.java
@@ -60,9 +60,10 @@ public class FeedCategoryService {
     }
 
     @Transactional(readOnly = true)
-    public Slice<Feed> getFeedsByCategoryLabel(String categoryLabel, Long lastFeedId, PageRequest pageRequest) {
-        return feedcategoryRepository.findFeedsByCategory(categoryservice.getCategory(categoryLabel), lastFeedId,
-                pageRequest);
+    public Slice<Feed> getFeedsByCategoryLabel(String category, Long lastFeedId, Long userId,
+                                               PageRequest pageRequest) {
+        return feedcategoryRepository.findFeedsByCategory(categoryservice.getCategory(category), lastFeedId,
+                userId, pageRequest);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedCategoryService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedCategoryService.java
@@ -60,7 +60,7 @@ public class FeedCategoryService {
 
     @Transactional(readOnly = true)
     public List<Feed> getFeedsByCategoryLabel(String categoryLabel, Long lastFeedId, PageRequest pageRequest) {
-        return feedcategoryRepository.findFeedByCategory(categoryservice.getCategory(categoryLabel), lastFeedId,
+        return feedcategoryRepository.findFeedsByCategory(categoryservice.getCategory(categoryLabel), lastFeedId,
                         pageRequest)
                 .getContent();
     }

--- a/src/main/java/org/websoso/WSSServer/service/FeedCategoryService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedCategoryService.java
@@ -31,8 +31,13 @@ public class FeedCategoryService {
     }
 
     public void updateFeedCategory(Feed feed, List<String> relevantCategories) {
-        Set<Category> categories = feedcategoryRepository.findByFeed(feed).orElseThrow(
-                        () -> new CustomCategoryException(CATEGORY_NOT_FOUND, "Category for the given feed was not found"))
+        List<FeedCategory> feedCategories = feedcategoryRepository.findByFeed(feed);
+
+        if (feedCategories.isEmpty()) {
+            throw new CustomCategoryException(CATEGORY_NOT_FOUND, "Category for the given feed was not found");
+        }
+
+        Set<Category> categories = feedCategories
                 .stream()
                 .map(FeedCategory::getCategory).collect(Collectors.toSet());
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedCategoryService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedCategoryService.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Category;
@@ -59,10 +60,9 @@ public class FeedCategoryService {
     }
 
     @Transactional(readOnly = true)
-    public List<Feed> getFeedsByCategoryLabel(String categoryLabel, Long lastFeedId, PageRequest pageRequest) {
+    public Slice<Feed> getFeedsByCategoryLabel(String categoryLabel, Long lastFeedId, PageRequest pageRequest) {
         return feedcategoryRepository.findFeedsByCategory(categoryservice.getCategory(categoryLabel), lastFeedId,
-                        pageRequest)
-                .getContent();
+                pageRequest);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedCategoryService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedCategoryService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Category;
@@ -55,6 +56,13 @@ public class FeedCategoryService {
         return feedCategories.stream()
                 .map(feedCategory -> feedCategory.getCategory().getCategoryName().getLabel())
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<Feed> getFeedsByCategoryLabel(String categoryLabel, Long lastFeedId, PageRequest pageRequest) {
+        return feedcategoryRepository.findFeedByCategory(categoryservice.getCategory(categoryLabel), lastFeedId,
+                        pageRequest)
+                .getContent();
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -122,13 +122,10 @@ public class FeedService {
 
     @Transactional(readOnly = true)
     public FeedsGetResponse getFeeds(User user, String category, Long lastFeedId, int size) {
-        PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
-
         Slice<Feed> feeds = findFeedsByCategoryLabel(category == null ? DEFAULT_CATEGORY : category,
-                lastFeedId, pageRequest);
+                lastFeedId, user.getUserId(), PageRequest.of(DEFAULT_PAGE_NUMBER, size));
 
         List<FeedInfo> feedGetResponses = feeds.getContent().stream()
-                .filter(feed -> isNotBlocked(feed.getUser(), user))
                 .map(feed -> createFeedInfo(feed, user)).toList();
 
         return FeedsGetResponse.of(category == null ? DEFAULT_CATEGORY : category, feeds.hasNext(),
@@ -188,12 +185,12 @@ public class FeedService {
         return FeedInfo.of(feed, userBasicInfo, novel, isLiked, relevantCategories, isMyFeed);
     }
 
-    private Slice<Feed> findFeedsByCategoryLabel(String categoryLabel, Long lastFeedId,
+    private Slice<Feed> findFeedsByCategoryLabel(String category, Long lastFeedId, Long userId,
                                                  PageRequest pageRequest) {
-        if (categoryLabel.equals(DEFAULT_CATEGORY)) {
-            return (feedRepository.findFeeds(lastFeedId, pageRequest));
+        if (category.equals(DEFAULT_CATEGORY)) {
+            return (feedRepository.findFeeds(lastFeedId, userId, pageRequest));
         }
-        return feedCategoryService.getFeedsByCategoryLabel(categoryLabel, lastFeedId, pageRequest);
+        return feedCategoryService.getFeedsByCategoryLabel(category, lastFeedId, userId, pageRequest);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -139,7 +139,7 @@ public class FeedService {
                     .toList());
         }
 
-        return FeedsGetResponse.of(category, isLoadable, feedGetResponses);
+        return FeedsGetResponse.of(category == null ? DEFAULT_CATEGORY : category, isLoadable, feedGetResponses);
     }
 
     private Feed getFeedOrException(Long feedId) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -182,7 +182,7 @@ public class FeedService {
     }
 
     private Boolean isNotBlocked(User createdFeedUser, User user) {
-        return user != null && !blockService.isBlockedRelationship(user.getUserId(), createdFeedUser.getUserId());
+        return user == null || !blockService.isBlockedRelationship(user.getUserId(), createdFeedUser.getUserId());
     }
 
     private FeedInfo createFeedInfo(Feed feed, User user) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -182,7 +182,7 @@ public class FeedService {
     }
 
     private Boolean isNotBlocked(User createdFeedUser, User user) {
-        return !blockService.isBlockedRelationship(user.getUserId(), createdFeedUser.getUserId());
+        return user != null && !blockService.isBlockedRelationship(user.getUserId(), createdFeedUser.getUserId());
     }
 
     private FeedInfo createFeedInfo(Feed feed, User user) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -171,10 +171,6 @@ public class FeedService {
         return createdUser.equals(user);
     }
 
-    private Boolean isNotBlocked(User createdFeedUser, User user) {
-        return user == null || !blockService.isBlockedRelationship(user.getUserId(), createdFeedUser.getUserId());
-    }
-
     private FeedInfo createFeedInfo(Feed feed, User user) {
         UserBasicInfo userBasicInfo = getUserBasicInfo(feed.getUser());
         Novel novel = getLinkedNovelOrNull(feed.getNovelId());

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -123,7 +123,7 @@ public class FeedService {
     @Transactional(readOnly = true)
     public FeedsGetResponse getFeeds(User user, String category, Long lastFeedId, int size) {
         Slice<Feed> feeds = findFeedsByCategoryLabel(category == null ? DEFAULT_CATEGORY : category,
-                lastFeedId, user.getUserId(), PageRequest.of(DEFAULT_PAGE_NUMBER, size));
+                lastFeedId, user == null ? null : user.getUserId(), PageRequest.of(DEFAULT_PAGE_NUMBER, size));
 
         List<FeedInfo> feedGetResponses = feeds.getContent().stream()
                 .map(feed -> createFeedInfo(feed, user)).toList();


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#77 -> dev
- close #77 

## Key Changes
<!-- 최대한 자세히 -->
### 소소피드 전체를 조회하는 API를 구현했습니다. (무한스크롤)

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
엔티티 수정사항 반영 건에 비하면 비교적 간단(?) 합니다 허허허 ..

## References
<!-- 참고한 자료-->
