### PR TITLE
[FIX] 엔티티 재설계 수정사항 반영

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/Avatar.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Avatar.java
@@ -1,11 +1,14 @@
 package org.websoso.WSSServer.domain;
 
+import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,4 +29,6 @@ public class Avatar {
     @Column(columnDefinition = "varchar(100)", nullable = false)
     private String avatarImage;
 
+    @OneToMany(mappedBy = "avatar", cascade = ALL, orphanRemoval = true)
+    private List<AvatarLine> avatarLines;
 }

--- a/src/main/java/org/websoso/WSSServer/service/AvatarService.java
+++ b/src/main/java/org/websoso/WSSServer/service/AvatarService.java
@@ -35,7 +35,7 @@ public class AvatarService {
         List<Avatar> avatars = avatarRepository.findAll();
         List<AvatarGetResponse> avatarGetResponses = avatars.stream()
                 .map(avatar -> {
-                    List<AvatarLine> avatarLines = avatar.getAvatarLine();
+                    List<AvatarLine> avatarLines = avatar.getAvatarLines();
                     return AvatarGetResponse.of(avatar, getRandomAvatarLine(avatarLines), representativeAvatarId);
                 }).toList();
         return new AvatarsGetResponse(avatarGetResponses);


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#98 -> dev
- close #98

## Key Changes
<!-- 최대한 자세히 -->
특별한 수정은 없었고, Avatar 엔티티가 들고 있던 avatarLine을 반환하던 방식에서 연관관계 매핑으로 수정되어 양방향 매핑으로 조회해서 반환하는 방식으로 수정되었습니다.