### PR TITLE
[FEAT] 소소피드 댓글 CRUD API 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
+import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
@@ -161,6 +162,15 @@ public class FeedController {
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();
+    }
+
+    @GetMapping("/{feedId}/comments")
+    public ResponseEntity<CommentsGetResponse> getComments(Principal principal,
+                                                           @PathVariable("feedId") Long feedId) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(OK)
+                .body(feedService.getComments(user, feedId));
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -133,7 +133,6 @@ public class FeedController {
                                               @Valid @RequestBody CommentCreateRequest request) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         feedService.createComment(user, feedId, request);
-
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();
@@ -146,7 +145,6 @@ public class FeedController {
                                               @Valid @RequestBody CommentUpdateRequest request) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         feedService.updateComment(user, feedId, commentId, request);
-
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();
@@ -158,7 +156,6 @@ public class FeedController {
                                               @PathVariable("commentId") Long commentId) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         feedService.deleteComment(user, feedId, commentId);
-
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
@@ -86,6 +87,18 @@ public class FeedController {
                                            @PathVariable("feedId") Long feedId) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         feedService.unLikeFeed(user, feedId);
+
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
+    }
+
+    @PostMapping("/{feedId}/comments")
+    public ResponseEntity<Void> createComment(Principal principal,
+                                              @PathVariable("feedId") Long feedId,
+                                              @Valid @RequestBody CommentCreateRequest request) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        feedService.createComment(user, feedId, request);
 
         return ResponseEntity
                 .status(NO_CONTENT)

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
+import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
@@ -93,18 +94,6 @@ public class FeedController {
                 .build();
     }
 
-    @PostMapping("/{feedId}/comments")
-    public ResponseEntity<Void> createComment(Principal principal,
-                                              @PathVariable("feedId") Long feedId,
-                                              @Valid @RequestBody CommentCreateRequest request) {
-        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
-        feedService.createComment(user, feedId, request);
-
-        return ResponseEntity
-                .status(NO_CONTENT)
-                .build();
-    }
-
     @GetMapping("/{feedId}")
     public ResponseEntity<FeedGetResponse> getFeed(Principal principal,
                                                    @PathVariable("feedId") Long feedId) {
@@ -136,5 +125,30 @@ public class FeedController {
                 .status(OK)
                 .body(feedService.getFeeds(user, category, lastFeedId, size));
     }
-  
+
+    @PostMapping("/{feedId}/comments")
+    public ResponseEntity<Void> createComment(Principal principal,
+                                              @PathVariable("feedId") Long feedId,
+                                              @Valid @RequestBody CommentCreateRequest request) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        feedService.createComment(user, feedId, request);
+
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
+    }
+
+    @PutMapping("/{feedId}/comments/{commentId}")
+    public ResponseEntity<Void> updateComment(Principal principal,
+                                              @PathVariable("feedId") Long feedId,
+                                              @PathVariable("commentId") Long commentId,
+                                              @Valid @RequestBody CommentUpdateRequest request) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        feedService.updateComment(user, feedId, commentId, request);
+
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -133,6 +133,7 @@ public class FeedController {
                                               @Valid @RequestBody CommentCreateRequest request) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         feedService.createComment(user, feedId, request);
+
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();
@@ -145,6 +146,7 @@ public class FeedController {
                                               @Valid @RequestBody CommentUpdateRequest request) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         feedService.updateComment(user, feedId, commentId, request);
+
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();
@@ -156,6 +158,7 @@ public class FeedController {
                                               @PathVariable("commentId") Long commentId) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         feedService.deleteComment(user, feedId, commentId);
+
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();
@@ -165,6 +168,7 @@ public class FeedController {
     public ResponseEntity<CommentsGetResponse> getComments(Principal principal,
                                                            @PathVariable("feedId") Long feedId) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+
         return ResponseEntity
                 .status(OK)
                 .body(feedService.getComments(user, feedId));

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -151,4 +151,16 @@ public class FeedController {
                 .build();
     }
 
+    @DeleteMapping("/{feedId}/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(Principal principal,
+                                              @PathVariable("feedId") Long feedId,
+                                              @PathVariable("commentId") Long commentId) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        feedService.deleteComment(user, feedId, commentId);
+
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Comment.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Comment.java
@@ -1,6 +1,8 @@
 package org.websoso.WSSServer.domain;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
+import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_NOT_BELONG_TO_FEED;
+import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_AUTHORIZED;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -9,11 +11,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
+import org.websoso.WSSServer.domain.common.Action;
 import org.websoso.WSSServer.domain.common.BaseEntity;
+import org.websoso.WSSServer.exception.exception.CustomCommentException;
+import org.websoso.WSSServer.exception.exception.CustomUserException;
 
 @Entity
 @Getter
@@ -41,6 +47,24 @@ public class Comment extends BaseEntity {
 
     public static Comment create(Long userId, Feed feed, String commentContent) {
         return new Comment(commentContent, userId, feed);
+    }
+
+    public void validateUserAuthorization(Long userId, Action action) {
+        if (!Objects.equals(this.userId, userId)) {
+            throw new CustomUserException(INVALID_AUTHORIZED,
+                    "only the author can " + action.getLabel() + " the comment");
+        }
+    }
+
+    public void updateContent(String commentContent) {
+        this.commentContent = commentContent;
+    }
+
+    public void validateFeedAssociation(Feed feed) {
+        if (this.feed != feed) {
+            throw new CustomCommentException(COMMENT_NOT_BELONG_TO_FEED,
+                    "the comment does not belong to the specified feed");
+        }
     }
 
     private Comment(String commentContent, Long userId, Feed feed) {

--- a/src/main/java/org/websoso/WSSServer/domain/Comment.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Comment.java
@@ -12,10 +12,12 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
 import org.websoso.WSSServer.domain.common.BaseEntity;
 
 @Entity
 @Getter
+@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseEntity {
 
@@ -36,5 +38,15 @@ public class Comment extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_id", nullable = false)
     private Feed feed;
+
+    public static Comment create(Long userId, Feed feed, String commentContent) {
+        return new Comment(commentContent, userId, feed);
+    }
+
+    private Comment(String commentContent, Long userId, Feed feed) {
+        this.commentContent = commentContent;
+        this.userId = userId;
+        this.feed = feed;
+    }
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -1,12 +1,12 @@
 package org.websoso.WSSServer.domain;
 
 import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_AUTHORIZED;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -47,17 +47,17 @@ public class Feed extends BaseEntity {
     @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isSpoiler;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = LAZY)
     private List<FeedCategory> feedCategories = new ArrayList<>();
 
-    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = LAZY)
     private List<Like> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = LAZY)
     private List<Comment> comments = new ArrayList<>();
 
     @Builder

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -1,12 +1,12 @@
 package org.websoso.WSSServer.domain;
 
 import static jakarta.persistence.CascadeType.ALL;
-import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_AUTHORIZED;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -47,17 +47,17 @@ public class Feed extends BaseEntity {
     @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isSpoiler;
 
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = LAZY)
+    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY)
     private List<FeedCategory> feedCategories = new ArrayList<>();
 
-    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = LAZY)
+    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY)
     private List<Like> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = LAZY)
+    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY)
     private List<Comment> comments = new ArrayList<>();
 
     @Builder

--- a/src/main/java/org/websoso/WSSServer/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Novel.java
@@ -2,10 +2,15 @@ package org.websoso.WSSServer.domain;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,5 +38,8 @@ public class Novel {
 
     @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isCompleted;
+
+    @OneToMany(mappedBy = "novel", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<UserNovel> userNovels = new ArrayList<>();
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Novel.java
@@ -1,15 +1,11 @@
 package org.websoso.WSSServer.domain;
 
-import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,8 +33,5 @@ public class Novel {
 
     @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isCompleted;
-
-    @OneToMany(mappedBy = "novel", fetch = LAZY)
-    private List<UserNovel> userNovels = new ArrayList<>();
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Novel.java
@@ -2,7 +2,6 @@ package org.websoso.WSSServer.domain;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -39,7 +38,7 @@ public class Novel {
     @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isCompleted;
 
-    @OneToMany(mappedBy = "novel", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "novel", fetch = FetchType.LAZY)
     private List<UserNovel> userNovels = new ArrayList<>();
 
 }

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentCreateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentCreateRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record CommentCreateRequest(
-        @NotBlank(message = "댓글 내용은 비어 있거나, 공백일 수 없습니다.")
+        @NotBlank(message = "댓글 내용은 null 이거나, 공백일 수 없습니다.")
         @Size(max = 100, message = "댓글 내용은 100자를 초과할 수 없습니다.")
         String commentContent
 ) {

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentCreateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentCreateRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 
 public record CommentCreateRequest(
         @NotBlank(message = "댓글 내용은 비어 있거나, 공백일 수 없습니다.")
-        @Size(max = 2000, message = "댓글 내용은 100자를 초과할 수 없습니다.")
+        @Size(max = 100, message = "댓글 내용은 100자를 초과할 수 없습니다.")
         String commentContent
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentCreateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentCreateRequest.java
@@ -1,0 +1,11 @@
+package org.websoso.WSSServer.dto.comment;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CommentCreateRequest(
+        @NotBlank(message = "댓글 내용은 비어 있거나, 공백일 수 없습니다.")
+        @Size(max = 2000, message = "댓글 내용은 100자를 초과할 수 없습니다.")
+        String commentContent
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
@@ -1,0 +1,29 @@
+package org.websoso.WSSServer.dto.comment;
+
+import java.time.format.DateTimeFormatter;
+import org.websoso.WSSServer.domain.Comment;
+import org.websoso.WSSServer.dto.user.UserBasicInfo;
+
+public record CommentGetResponse(
+        Long userId,
+        String nickname,
+        String avatarImage,
+        Long commentId,
+        String createdDate,
+        String commentContent,
+        Boolean isModified,
+        Boolean isMyComment
+) {
+    public static CommentGetResponse of(UserBasicInfo userBasicInfo, Comment comment, Boolean isMyComment) {
+        return new CommentGetResponse(
+                userBasicInfo.userId(),
+                userBasicInfo.nickname(),
+                userBasicInfo.avatarImage(),
+                comment.getCommentId(),
+                comment.getCreatedDate().format(DateTimeFormatter.ofPattern("M월 d일")),
+                comment.getCommentContent(),
+                !comment.getCreatedDate().equals(comment.getModifiedDate()),
+                isMyComment
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.dto.comment;
 
-import java.time.format.DateTimeFormatter;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
 import org.websoso.WSSServer.domain.Comment;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 
@@ -9,7 +10,8 @@ public record CommentGetResponse(
         String nickname,
         String avatarImage,
         Long commentId,
-        String createdDate,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "M월 d일", timezone = "Asia/Seoul")
+        LocalDate createdDate,
         String commentContent,
         Boolean isModified,
         Boolean isMyComment
@@ -20,7 +22,7 @@ public record CommentGetResponse(
                 userBasicInfo.nickname(),
                 userBasicInfo.avatarImage(),
                 comment.getCommentId(),
-                comment.getCreatedDate().format(DateTimeFormatter.ofPattern("M월 d일")),
+                comment.getCreatedDate().toLocalDate(),
                 comment.getCommentContent(),
                 !comment.getCreatedDate().equals(comment.getModifiedDate()),
                 isMyComment

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentUpdateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentUpdateRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 
 public record CommentUpdateRequest(
         @NotBlank(message = "댓글 내용은 비어 있거나, 공백일 수 없습니다.")
-        @Size(max = 2000, message = "댓글 내용은 100자를 초과할 수 없습니다.")
+        @Size(max = 100, message = "댓글 내용은 100자를 초과할 수 없습니다.")
         String commentContent
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentUpdateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentUpdateRequest.java
@@ -1,0 +1,11 @@
+package org.websoso.WSSServer.dto.comment;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CommentUpdateRequest(
+        @NotBlank(message = "댓글 내용은 비어 있거나, 공백일 수 없습니다.")
+        @Size(max = 2000, message = "댓글 내용은 100자를 초과할 수 없습니다.")
+        String commentContent
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentUpdateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentUpdateRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record CommentUpdateRequest(
-        @NotBlank(message = "댓글 내용은 비어 있거나, 공백일 수 없습니다.")
+        @NotBlank(message = "댓글 내용은 null 이거나, 공백일 수 없습니다.")
         @Size(max = 100, message = "댓글 내용은 100자를 초과할 수 없습니다.")
         String commentContent
 ) {

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentsGetResponse.java
@@ -6,9 +6,9 @@ public record CommentsGetResponse(
         Integer commentsCount,
         List<CommentGetResponse> comments
 ) {
-    public static CommentsGetResponse of(List<CommentGetResponse> comments) {
+    public static CommentsGetResponse of(Integer commentsCount, List<CommentGetResponse> comments) {
         return new CommentsGetResponse(
-                comments.size(),
+                commentsCount,
                 comments
         );
     }

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentsGetResponse.java
@@ -1,0 +1,15 @@
+package org.websoso.WSSServer.dto.comment;
+
+import java.util.List;
+
+public record CommentsGetResponse(
+        Integer commentsCount,
+        List<CommentGetResponse> comments
+) {
+    public static CommentsGetResponse of(List<CommentGetResponse> comments) {
+        return new CommentsGetResponse(
+                comments.size(),
+                comments
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomCommentError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomCommentError.java
@@ -1,0 +1,21 @@
+package org.websoso.WSSServer.exception.error;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.websoso.WSSServer.exception.common.ICustomError;
+
+@Getter
+@AllArgsConstructor
+public enum CustomCommentError implements ICustomError {
+
+    COMMENT_NOT_FOUND("COMMENT-001", "해당 ID를 가진 댓글을 찾을 수 없습니다.", NOT_FOUND),
+    COMMENT_NOT_BELONG_TO_FEED("COMMENT-002", "댓글이 지정된 피드에 속하지 않습니다.", NOT_FOUND);
+
+    private final String code;
+    private final String description;
+    private final HttpStatus statusCode;
+
+}

--- a/src/main/java/org/websoso/WSSServer/exception/exception/CustomCommentException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/exception/CustomCommentException.java
@@ -1,0 +1,13 @@
+package org.websoso.WSSServer.exception.exception;
+
+import lombok.Getter;
+import org.websoso.WSSServer.exception.common.AbstractCustomException;
+import org.websoso.WSSServer.exception.error.CustomCommentError;
+
+@Getter
+public class CustomCommentException extends AbstractCustomException {
+
+    public CustomCommentException(CustomCommentError customCommentError, String message) {
+        super(customCommentError, message);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/websoso/WSSServer/exception/handler/GlobalExceptionHandler.java
@@ -62,4 +62,5 @@ public class GlobalExceptionHandler {
                 .status(iCustomError.getStatusCode())
                 .body(new ErrorResult(iCustomError.getCode(), iCustomError.getDescription()));
     }
+
 }

--- a/src/main/java/org/websoso/WSSServer/repository/BlockRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/BlockRepository.java
@@ -11,4 +11,5 @@ public interface BlockRepository extends JpaRepository<Block, Long>, BlockCustom
     boolean existsByBlockingIdAndBlockedId(Long blockingId, Long blockedId);
 
     List<Block> findByBlockingId(Long blockingId);
+
 }

--- a/src/main/java/org/websoso/WSSServer/repository/CommentRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package org.websoso.WSSServer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.Comment;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -1,0 +1,21 @@
+package org.websoso.WSSServer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.domain.Comment;
+import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.repository.CommentRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+
+    public void createComment(Long userId, Feed feed, String commentContent) {
+        commentRepository.save(Comment.create(userId, feed, commentContent));
+    }
+
+}

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -54,18 +54,19 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public CommentsGetResponse getComments(User user, Feed feed) {
-        List<CommentGetResponse> comments = new ArrayList<>();
+        List<Comment> comments = feed.getComments();
+        List<CommentGetResponse> responses = new ArrayList<>();
 
-        for (Comment comment : feed.getComments()) {
+        for (Comment comment : comments) {
             User createdUser = userService.getUserOrException(comment.getUserId());
             if (comment.getIsHidden() || isBlocked(createdUser, user)) {
                 continue;
             }
-            comments.add(CommentGetResponse.of(getUserBasicInfo(createdUser), comment,
+            responses.add(CommentGetResponse.of(getUserBasicInfo(createdUser), comment,
                     isUserCommentOwner(createdUser, user)));
         }
 
-        return CommentsGetResponse.of(comments);
+        return CommentsGetResponse.of(comments.size(), responses);
     }
 
     private Comment getCommentOrException(Long commentId) {

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -34,21 +34,15 @@ public class CommentService {
 
     public void updateComment(Long userId, Feed feed, Long commentId, String commentContent) {
         Comment comment = getCommentOrException(commentId);
-
         comment.validateFeedAssociation(feed);
-
         comment.validateUserAuthorization(userId, UPDATE);
-
         comment.updateContent(commentContent);
     }
 
     public void deleteComment(Long userId, Feed feed, Long commentId) {
         Comment comment = getCommentOrException(commentId);
-
         comment.validateFeedAssociation(feed);
-
         comment.validateUserAuthorization(userId, DELETE);
-
         commentRepository.delete(comment);
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -4,11 +4,17 @@ import static org.websoso.WSSServer.domain.common.Action.DELETE;
 import static org.websoso.WSSServer.domain.common.Action.UPDATE;
 import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_NOT_FOUND;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Comment;
 import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.dto.comment.CommentGetResponse;
+import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
+import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomCommentException;
 import org.websoso.WSSServer.repository.CommentRepository;
 
@@ -18,6 +24,9 @@ import org.websoso.WSSServer.repository.CommentRepository;
 public class CommentService {
 
     private final CommentRepository commentRepository;
+    private final UserService userService;
+    private final AvatarService avatarService;
+    private final BlockService blockService;
 
     public void createComment(Long userId, Feed feed, String commentContent) {
         commentRepository.save(Comment.create(userId, feed, commentContent));
@@ -43,9 +52,39 @@ public class CommentService {
         commentRepository.delete(comment);
     }
 
+    @Transactional(readOnly = true)
+    public CommentsGetResponse getComments(User user, Feed feed) {
+        List<CommentGetResponse> comments = new ArrayList<>();
+
+        for (Comment comment : feed.getComments()) {
+            User createdUser = userService.getUserOrException(comment.getUserId());
+            if (comment.getIsHidden() || isBlocked(createdUser, user)) {
+                continue;
+            }
+            comments.add(CommentGetResponse.of(getUserBasicInfo(createdUser), comment,
+                    isUserCommentOwner(createdUser, user)));
+        }
+
+        return CommentsGetResponse.of(comments);
+    }
+
     private Comment getCommentOrException(Long commentId) {
         return commentRepository.findById(commentId).orElseThrow(() ->
                 new CustomCommentException(COMMENT_NOT_FOUND, "comment with the given id was not found"));
+    }
+
+    private UserBasicInfo getUserBasicInfo(User user) {
+        return user.getUserBasicInfo(
+                avatarService.getAvatarOrException(user.getAvatarId()).getAvatarImage()
+        );
+    }
+
+    private Boolean isUserCommentOwner(User createdUser, User user) {
+        return createdUser.equals(user);
+    }
+
+    private Boolean isBlocked(User createdFeedUser, User user) {
+        return blockService.isBlockedRelationship(user.getUserId(), createdFeedUser.getUserId());
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -1,10 +1,14 @@
 package org.websoso.WSSServer.service;
 
+import static org.websoso.WSSServer.domain.common.Action.UPDATE;
+import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_NOT_FOUND;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Comment;
 import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.exception.exception.CustomCommentException;
 import org.websoso.WSSServer.repository.CommentRepository;
 
 @Service
@@ -16,6 +20,21 @@ public class CommentService {
 
     public void createComment(Long userId, Feed feed, String commentContent) {
         commentRepository.save(Comment.create(userId, feed, commentContent));
+    }
+
+    public void updateComment(Long userId, Feed feed, Long commentId, String commentContent) {
+        Comment comment = getCommentOrException(commentId);
+
+        comment.validateFeedAssociation(feed);
+
+        comment.validateUserAuthorization(userId, UPDATE);
+
+        comment.updateContent(commentContent);
+    }
+
+    private Comment getCommentOrException(Long commentId) {
+        return commentRepository.findById(commentId).orElseThrow(() ->
+                new CustomCommentException(COMMENT_NOT_FOUND, "comment with the given id was not found"));
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.service;
 
+import static org.websoso.WSSServer.domain.common.Action.DELETE;
 import static org.websoso.WSSServer.domain.common.Action.UPDATE;
 import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_NOT_FOUND;
 
@@ -30,6 +31,16 @@ public class CommentService {
         comment.validateUserAuthorization(userId, UPDATE);
 
         comment.updateContent(commentContent);
+    }
+
+    public void deleteComment(Long userId, Feed feed, Long commentId) {
+        Comment comment = getCommentOrException(commentId);
+
+        comment.validateFeedAssociation(feed);
+
+        comment.validateUserAuthorization(userId, DELETE);
+
+        commentRepository.delete(comment);
     }
 
     private Comment getCommentOrException(Long commentId) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -140,10 +140,7 @@ public class FeedService {
     public void createComment(User user, Long feedId, CommentCreateRequest request) {
         Feed feed = getFeedOrException(feedId);
 
-        if (!feed.getUser().equals(user)) {
-            checkHiddenFeed(feed);
-            checkBlockedRelationship(feed.getUser(), user);
-        }
+        validateFeedAccess(feed, user);
 
         commentService.createComment(user.getUserId(), feed, request.commentContent());
     }
@@ -151,10 +148,7 @@ public class FeedService {
     public void updateComment(User user, Long feedId, Long commentId, CommentUpdateRequest request) {
         Feed feed = getFeedOrException(feedId);
 
-        if (!feed.getUser().equals(user)) {
-            checkHiddenFeed(feed);
-            checkBlockedRelationship(feed.getUser(), user);
-        }
+        validateFeedAccess(feed, user);
 
         commentService.updateComment(user.getUserId(), feed, commentId, request.commentContent());
     }
@@ -162,10 +156,7 @@ public class FeedService {
     public void deleteComment(User user, Long feedId, Long commentId) {
         Feed feed = getFeedOrException(feedId);
 
-        if (!feed.getUser().equals(user)) {
-            checkHiddenFeed(feed);
-            checkBlockedRelationship(feed.getUser(), user);
-        }
+        validateFeedAccess(feed, user);
 
         commentService.deleteComment(user.getUserId(), feed, commentId);
     }
@@ -174,10 +165,7 @@ public class FeedService {
     public CommentsGetResponse getComments(User user, Long feedId) {
         Feed feed = getFeedOrException(feedId);
 
-        if (!feed.getUser().equals(user)) {
-            checkHiddenFeed(feed);
-            checkBlockedRelationship(feed.getUser(), user);
-        }
+        validateFeedAccess(feed, user);
 
         return commentService.getComments(user, feed);
     }
@@ -253,4 +241,12 @@ public class FeedService {
 
         return NovelGetResponseFeedTab.of(feeds.hasNext(), feedGetResponses);
     }
+
+    private void validateFeedAccess(Feed feed, User user) {
+        if (!feed.getUser().equals(user)) {
+            checkHiddenFeed(feed);
+            checkBlockedRelationship(feed.getUser(), user);
+        }
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -48,53 +48,43 @@ public class FeedService {
         if (request.novelId() != null) {
             novelService.getNovelOrException(request.novelId());
         }
-
         Feed feed = Feed.builder()
                 .feedContent(request.feedContent())
                 .isSpoiler(request.isSpoiler())
                 .novelId(request.novelId())
                 .user(user)
                 .build();
-
         feedRepository.save(feed);
         feedCategoryService.createFeedCategory(feed, request.relevantCategories());
     }
 
     public void updateFeed(User user, Long feedId, FeedUpdateRequest request) {
         Feed feed = getFeedOrException(feedId);
-
         feed.validateUserAuthorization(user, UPDATE);
 
         if (feed.isNovelChanged(request.novelId())) {
             novelService.getNovelOrException(feed.getNovelId());
         }
-
         feed.updateFeed(request.feedContent(), request.isSpoiler(), request.novelId());
         feedCategoryService.updateFeedCategory(feed, request.relevantCategories());
     }
 
     public void deleteFeed(User user, Long feedId) {
         Feed feed = getFeedOrException(feedId);
-
         feed.validateUserAuthorization(user, DELETE);
-
         feedRepository.delete(feed);
     }
 
     public void likeFeed(User user, Long feedId) {
         Feed feed = getFeedOrException(feedId);
-
         checkHiddenFeed(feed);
         checkBlockedRelationship(feed.getUser(), user);
 
         boolean isPopularFeed = false;
-
         if (feed.getLikes().size() == 9) {
             isPopularFeed = true;
         }
-
         likeService.createLike(user, feed);
-
         if (isPopularFeed) {
             popularFeedService.createPopularFeed(feed);
         }
@@ -102,17 +92,14 @@ public class FeedService {
 
     public void unLikeFeed(User user, Long feedId) {
         Feed feed = getFeedOrException(feedId);
-
         checkHiddenFeed(feed);
         checkBlockedRelationship(feed.getUser(), user);
-
         likeService.deleteLike(user, feed);
     }
 
     @Transactional(readOnly = true)
     public FeedGetResponse getFeedById(User user, Long feedId) {
         Feed feed = getFeedOrException(feedId);
-
         checkHiddenFeed(feed);
         checkBlockedRelationship(feed.getUser(), user);
 
@@ -139,34 +126,26 @@ public class FeedService {
 
     public void createComment(User user, Long feedId, CommentCreateRequest request) {
         Feed feed = getFeedOrException(feedId);
-
         validateFeedAccess(feed, user);
-
         commentService.createComment(user.getUserId(), feed, request.commentContent());
     }
 
     public void updateComment(User user, Long feedId, Long commentId, CommentUpdateRequest request) {
         Feed feed = getFeedOrException(feedId);
-
         validateFeedAccess(feed, user);
-
         commentService.updateComment(user.getUserId(), feed, commentId, request.commentContent());
     }
 
     public void deleteComment(User user, Long feedId, Long commentId) {
         Feed feed = getFeedOrException(feedId);
-
         validateFeedAccess(feed, user);
-
         commentService.deleteComment(user.getUserId(), feed, commentId);
     }
 
     @Transactional(readOnly = true)
     public CommentsGetResponse getComments(User user, Long feedId) {
         Feed feed = getFeedOrException(feedId);
-
         validateFeedAccess(feed, user);
-
         return commentService.getComments(user, feed);
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -222,10 +222,11 @@ public class FeedService {
     }
 
     private void validateFeedAccess(Feed feed, User user) {
-        if (!feed.getUser().equals(user)) {
-            checkHiddenFeed(feed);
-            checkBlockedRelationship(feed.getUser(), user);
+        if (feed.getUser().equals(user)) {
+            return;
         }
+        checkHiddenFeed(feed);
+        checkBlockedRelationship(feed.getUser(), user);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedInfo;
@@ -39,6 +40,7 @@ public class FeedService {
     private final BlockService blockService;
     private final LikeService likeService;
     private final PopularFeedService popularFeedService;
+    private final CommentService commentService;
 
     public void createFeed(User user, FeedCreateRequest request) {
         if (request.novelId() != null) {
@@ -131,6 +133,17 @@ public class FeedService {
 
         return FeedsGetResponse.of(category == null ? DEFAULT_CATEGORY : category, feeds.hasNext(),
                 feedGetResponses);
+    }
+
+    public void createComment(User user, Long feedId, CommentCreateRequest request) {
+        Feed feed = getFeedOrException(feedId);
+
+        if (!feed.getUser().equals(user)) {
+            checkHiddenFeed(feed);
+            checkBlockedRelationship(feed.getUser(), user);
+        }
+
+        commentService.createComment(user.getUserId(), feed, request.commentContent());
     }
 
     private Feed getFeedOrException(Long feedId) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -158,6 +158,17 @@ public class FeedService {
         commentService.updateComment(user.getUserId(), feed, commentId, request.commentContent());
     }
 
+    public void deleteComment(User user, Long feedId, Long commentId) {
+        Feed feed = getFeedOrException(feedId);
+
+        if (!feed.getUser().equals(user)) {
+            checkHiddenFeed(feed);
+            checkBlockedRelationship(feed.getUser(), user);
+        }
+
+        commentService.deleteComment(user.getUserId(), feed, commentId);
+    }
+
     private Feed getFeedOrException(Long feedId) {
         return feedRepository.findById(feedId).orElseThrow(() ->
                 new CustomFeedException(FEED_NOT_FOUND, "feed with the given id was not found"));

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -17,6 +17,7 @@ import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
+import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedInfo;
@@ -167,6 +168,18 @@ public class FeedService {
         }
 
         commentService.deleteComment(user.getUserId(), feed, commentId);
+    }
+
+    @Transactional(readOnly = true)
+    public CommentsGetResponse getComments(User user, Long feedId) {
+        Feed feed = getFeedOrException(feedId);
+
+        if (!feed.getUser().equals(user)) {
+            checkHiddenFeed(feed);
+            checkBlockedRelationship(feed.getUser(), user);
+        }
+
+        return commentService.getComments(user, feed);
     }
 
     private Feed getFeedOrException(Long feedId) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -16,6 +16,7 @@ import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
+import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedInfo;
@@ -144,6 +145,17 @@ public class FeedService {
         }
 
         commentService.createComment(user.getUserId(), feed, request.commentContent());
+    }
+
+    public void updateComment(User user, Long feedId, Long commentId, CommentUpdateRequest request) {
+        Feed feed = getFeedOrException(feedId);
+
+        if (!feed.getUser().equals(user)) {
+            checkHiddenFeed(feed);
+            checkBlockedRelationship(feed.getUser(), user);
+        }
+
+        commentService.updateComment(user.getUserId(), feed, commentId, request.commentContent());
     }
 
     private Feed getFeedOrException(Long feedId) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#68 -> dev
- close #68

## Key Changes
<!-- 최대한 자세히 -->
### 소소피드 댓글 CRUD API를 구현했습니다.

🔑
- 댓글은 무조건 로그인 한 유저만이 확인이 가능합니다. -> 댓글은 특정 소소피드에 들어가서 볼 수 있기 때문에 비로그인 유저는 접근 불가능
- 댓글을 작성한 유저와 차단 관계이면 그 댓글은 보이지 않습니다.
- 여러번 신고를 받아, 숨김 처리가 된 댓글은 보이지 않습니다.
- 특정 피드의 **댓글 수**는 차단, 숨김 여부와 상관 없이 실제 있는 전체 댓글 개수를 나타내는 것입니다. (기획과 이야기 O)

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
현재 PR이 열려있는 소소피드 전체 조회 API를 rebase 해서 수정사항이 섞여있는데요!
해당 부분을 코멘트로 남겨놓을테니 제외하고 봐주시면 될 것 같습니다!

## References
<!-- 참고한 자료-->
