### PR TITLE
[FEAT] 실시간 인기글 조회 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig {
             "/actuator/health",
             "/novels/{novelId}",
             "/novels/{novelId}/info",
-            "/soso-picks"
+            "/soso-picks",
+            "/feeds/popular"
     };
 
     @Bean

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -102,9 +102,14 @@ public class FeedController {
 
     @GetMapping("/popular")
     public ResponseEntity<PopularFeedsGetResponse> getPopularFeeds(Principal principal) {
-        //TODO 차단 관계에 있는 유저의 피드글 처리
+        if (principal == null) {
+            return ResponseEntity
+                    .status(OK)
+                    .body(popularFeedService.getPopularFeeds(null));
+        }
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
                 .status(OK)
-                .body(popularFeedService.getPopularFeeds());
+                .body(popularFeedService.getPopularFeeds(user));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -102,12 +102,9 @@ public class FeedController {
 
     @GetMapping("/popular")
     public ResponseEntity<PopularFeedsGetResponse> getPopularFeeds(Principal principal) {
-        if (principal == null) {
-            return ResponseEntity
-                    .status(OK)
-                    .body(popularFeedService.getPopularFeeds(null));
-        }
-        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        User user = principal == null ?
+                null :
+                userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
                 .status(OK)
                 .body(popularFeedService.getPopularFeeds(user));

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -20,7 +20,9 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
+import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
 import org.websoso.WSSServer.service.FeedService;
+import org.websoso.WSSServer.service.PopularFeedService;
 import org.websoso.WSSServer.service.UserService;
 
 @RequestMapping("/feeds")
@@ -30,6 +32,7 @@ public class FeedController {
 
     private final FeedService feedService;
     private final UserService userService;
+    private final PopularFeedService popularFeedService;
 
     @PostMapping
     public ResponseEntity<Void> createFeed(Principal principal,
@@ -97,4 +100,11 @@ public class FeedController {
                 .body(feedService.getFeedById(user, feedId));
     }
 
+    @GetMapping("/popular")
+    public ResponseEntity<PopularFeedsGetResponse> getPopularFeeds(Principal principal) {
+        //TODO 차단 관계에 있는 유저의 피드글 처리
+        return ResponseEntity
+                .status(OK)
+                .body(popularFeedService.getPopularFeeds());
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -15,7 +15,9 @@ import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseBasic;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseInfoTab;
+import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
 import org.websoso.WSSServer.service.NovelService;
+import org.websoso.WSSServer.service.PopularFeedService;
 import org.websoso.WSSServer.service.UserService;
 
 @RestController
@@ -25,6 +27,7 @@ public class NovelController {
 
     private final NovelService novelService;
     private final UserService userService;
+    private final PopularFeedService popularFeedService;
 
     @GetMapping("/{novelId}")
     public ResponseEntity<NovelGetResponseBasic> getNovelInfoBasic(Principal principal, @PathVariable Long novelId) {
@@ -70,4 +73,11 @@ public class NovelController {
                 .build();
     }
 
+    @GetMapping("/popular")
+    public ResponseEntity<PopularFeedsGetResponse> getPopularFeeds(Principal principal) {
+        //TODO 차단 관계에 있는 유저의 피드글 처리
+        return ResponseEntity
+                .status(OK)
+                .body(popularFeedService.getPopularFeeds());
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -15,9 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseBasic;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseInfoTab;
-import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
 import org.websoso.WSSServer.service.NovelService;
-import org.websoso.WSSServer.service.PopularFeedService;
 import org.websoso.WSSServer.service.UserService;
 
 @RestController
@@ -27,7 +25,6 @@ public class NovelController {
 
     private final NovelService novelService;
     private final UserService userService;
-    private final PopularFeedService popularFeedService;
 
     @GetMapping("/{novelId}")
     public ResponseEntity<NovelGetResponseBasic> getNovelInfoBasic(Principal principal, @PathVariable Long novelId) {
@@ -71,13 +68,5 @@ public class NovelController {
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();
-    }
-
-    @GetMapping("/popular")
-    public ResponseEntity<PopularFeedsGetResponse> getPopularFeeds(Principal principal) {
-        //TODO 차단 관계에 있는 유저의 피드글 처리
-        return ResponseEntity
-                .status(OK)
-                .body(popularFeedService.getPopularFeeds());
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/popularFeed/PopularFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/popularFeed/PopularFeedGetResponse.java
@@ -1,0 +1,10 @@
+package org.websoso.WSSServer.dto.popularFeed;
+
+public record PopularFeedGetResponse(
+        Long feedId,
+        String feedContent,
+        Integer likeCount,
+        Integer commentCount,
+        Boolean isSpoiler
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/dto/popularFeed/PopularFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/popularFeed/PopularFeedGetResponse.java
@@ -1,5 +1,7 @@
 package org.websoso.WSSServer.dto.popularFeed;
 
+import org.websoso.WSSServer.domain.PopularFeed;
+
 public record PopularFeedGetResponse(
         Long feedId,
         String feedContent,
@@ -7,4 +9,14 @@ public record PopularFeedGetResponse(
         Integer commentCount,
         Boolean isSpoiler
 ) {
+
+    public static PopularFeedGetResponse of(PopularFeed popularFeed) {
+        return new PopularFeedGetResponse(
+                popularFeed.getFeed().getFeedId(),
+                popularFeed.getFeed().getFeedContent(),
+                popularFeed.getFeed().getLikes().size(),
+                popularFeed.getFeed().getComments().size(),
+                popularFeed.getFeed().getIsSpoiler()
+        );
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/popularFeed/PopularFeedsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/popularFeed/PopularFeedsGetResponse.java
@@ -1,0 +1,12 @@
+package org.websoso.WSSServer.dto.popularFeed;
+
+import java.util.List;
+
+public record PopularFeedsGetResponse(
+        List<PopularFeedGetResponse> popularFeeds
+) {
+
+    public static PopularFeedsGetResponse of(List<PopularFeedGetResponse> popularFeedGetResponses) {
+        return new PopularFeedsGetResponse(popularFeedGetResponses);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/repository/PopularFeedCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/PopularFeedCustomRepository.java
@@ -1,0 +1,9 @@
+package org.websoso.WSSServer.repository;
+
+import java.util.List;
+import org.websoso.WSSServer.domain.PopularFeed;
+
+public interface PopularFeedCustomRepository {
+
+    List<PopularFeed> findTodayPopularFeeds(Long userId);
+}

--- a/src/main/java/org/websoso/WSSServer/repository/PopularFeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/PopularFeedCustomRepositoryImpl.java
@@ -1,0 +1,44 @@
+package org.websoso.WSSServer.repository;
+
+import static org.websoso.WSSServer.domain.QBlock.block;
+import static org.websoso.WSSServer.domain.QPopularFeed.popularFeed;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.PopularFeed;
+
+@Repository
+@RequiredArgsConstructor
+public class PopularFeedCustomRepositoryImpl implements PopularFeedCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<PopularFeed> findTodayPopularFeeds(Long userId) {
+        List<Long> blockingIds = jpaQueryFactory
+                .select(block.blockedId)
+                .from(block)
+                .where(block.blockingId.eq(userId))
+                .fetch();
+
+        List<Long> blockedIds = jpaQueryFactory
+                .select(block.blockingId)
+                .from(block)
+                .where(block.blockedId.eq(userId))
+                .fetch();
+
+        List<Long> blockIds = Stream.concat(blockingIds.stream(), blockedIds.stream())
+                .distinct()
+                .toList();
+
+        return jpaQueryFactory
+                .selectFrom(popularFeed)
+                .where(popularFeed.feed.user.userId.notIn(blockIds))
+                .orderBy(popularFeed.popularFeedId.desc())
+                .limit(9)
+                .fetch();
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/repository/PopularFeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/PopularFeedRepository.java
@@ -7,7 +7,7 @@ import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.PopularFeed;
 
 @Repository
-public interface PopularFeedRepository extends JpaRepository<PopularFeed, Long> {
+public interface PopularFeedRepository extends JpaRepository<PopularFeed, Long>, PopularFeedCustomRepository {
 
     Boolean existsByFeed(Feed feed);
 

--- a/src/main/java/org/websoso/WSSServer/repository/PopularFeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/PopularFeedRepository.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Feed;
@@ -9,4 +10,6 @@ import org.websoso.WSSServer.domain.PopularFeed;
 public interface PopularFeedRepository extends JpaRepository<PopularFeed, Long> {
 
     Boolean existsByFeed(Feed feed);
+
+    List<PopularFeed> findTop9ByOrderByPopularFeedIdDesc();
 }

--- a/src/main/java/org/websoso/WSSServer/repository/PopularFeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/PopularFeedRepository.java
@@ -1,9 +1,11 @@
 package org.websoso.WSSServer.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.PopularFeed;
 
+@Repository
 public interface PopularFeedRepository extends JpaRepository<PopularFeed, Long> {
 
     Boolean existsByFeed(Feed feed);

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -27,7 +27,7 @@ public class PopularFeedService {
     @Transactional(readOnly = true)
     public PopularFeedsGetResponse getPopularFeeds(User user) {
         List<PopularFeed> popularFeeds = findPopularFeeds(user);
-        List<PopularFeedGetResponse> popularFeedGetResponses = getPopularFeedGetResponses(popularFeeds);
+        List<PopularFeedGetResponse> popularFeedGetResponses = mapToPopularFeedGetResponseList(popularFeeds);
         return new PopularFeedsGetResponse(popularFeedGetResponses);
     }
 
@@ -38,7 +38,7 @@ public class PopularFeedService {
         return popularFeedRepository.findTodayPopularFeeds(user.getUserId());
     }
 
-    private static List<PopularFeedGetResponse> getPopularFeedGetResponses(List<PopularFeed> popularFeeds) {
+    private static List<PopularFeedGetResponse> mapToPopularFeedGetResponseList(List<PopularFeed> popularFeeds) {
         return popularFeeds.stream()
                 .map(PopularFeedGetResponse::of)
                 .toList();

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -1,10 +1,13 @@
 package org.websoso.WSSServer.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.PopularFeed;
+import org.websoso.WSSServer.dto.popularFeed.PopularFeedGetResponse;
+import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
 import org.websoso.WSSServer.repository.PopularFeedRepository;
 
 @Service
@@ -20,4 +23,19 @@ public class PopularFeedService {
         }
     }
 
+    @Transactional(readOnly = true)
+    public PopularFeedsGetResponse getPopularFeeds() {
+        List<PopularFeed> popularFeeds = popularFeedRepository.findTop9ByOrderByPopularFeedIdDesc();
+
+        List<PopularFeedGetResponse> popularFeedGetResponses = popularFeeds.stream()
+                .map(popularFeed -> new PopularFeedGetResponse(
+                        popularFeed.getFeed().getFeedId(),
+                        popularFeed.getFeed().getFeedContent(),
+                        popularFeed.getFeed().getLikes().size(),
+                        popularFeed.getFeed().getComments().size(),
+                        popularFeed.getFeed().getIsSpoiler()
+                ))
+                .toList();
+        return new PopularFeedsGetResponse(popularFeedGetResponses);
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.PopularFeed;
+import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedGetResponse;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
 import org.websoso.WSSServer.repository.PopularFeedRepository;
@@ -24,8 +25,8 @@ public class PopularFeedService {
     }
 
     @Transactional(readOnly = true)
-    public PopularFeedsGetResponse getPopularFeeds() {
-        List<PopularFeed> popularFeeds = findPopularFeeds();
+    public PopularFeedsGetResponse getPopularFeeds(User user) {
+        List<PopularFeed> popularFeeds = findPopularFeeds(user);
         List<PopularFeedGetResponse> popularFeedGetResponses = getPopularFeedGetResponses(popularFeeds);
         return getPopularFeedsGetResponse(popularFeedGetResponses);
     }
@@ -47,7 +48,7 @@ public class PopularFeedService {
                 .toList();
     }
 
-    private List<PopularFeed> findPopularFeeds() {
-        return popularFeedRepository.findTop9ByOrderByPopularFeedIdDesc();
+    private List<PopularFeed> findPopularFeeds(User user) {
+        return popularFeedRepository.findTodayPopularFeeds(user.getUserId());
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -31,9 +31,11 @@ public class PopularFeedService {
         return getPopularFeedsGetResponse(popularFeedGetResponses);
     }
 
-    private static PopularFeedsGetResponse getPopularFeedsGetResponse(
-            List<PopularFeedGetResponse> popularFeedGetResponses) {
-        return new PopularFeedsGetResponse(popularFeedGetResponses);
+    private List<PopularFeed> findPopularFeeds(User user) {
+        if (user == null) {
+            return popularFeedRepository.findTop9ByOrderByPopularFeedIdDesc();
+        }
+        return popularFeedRepository.findTodayPopularFeeds(user.getUserId());
     }
 
     private static List<PopularFeedGetResponse> getPopularFeedGetResponses(List<PopularFeed> popularFeeds) {
@@ -48,10 +50,8 @@ public class PopularFeedService {
                 .toList();
     }
 
-    private List<PopularFeed> findPopularFeeds(User user) {
-        if (user == null) {
-            return popularFeedRepository.findTop9ByOrderByPopularFeedIdDesc();
-        }
-        return popularFeedRepository.findTodayPopularFeeds(user.getUserId());
+    private static PopularFeedsGetResponse getPopularFeedsGetResponse(
+            List<PopularFeedGetResponse> popularFeedGetResponses) {
+        return new PopularFeedsGetResponse(popularFeedGetResponses);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -28,7 +28,7 @@ public class PopularFeedService {
     public PopularFeedsGetResponse getPopularFeeds(User user) {
         List<PopularFeed> popularFeeds = findPopularFeeds(user);
         List<PopularFeedGetResponse> popularFeedGetResponses = getPopularFeedGetResponses(popularFeeds);
-        return getPopularFeedsGetResponse(popularFeedGetResponses);
+        return new PopularFeedsGetResponse(popularFeedGetResponses);
     }
 
     private List<PopularFeed> findPopularFeeds(User user) {
@@ -42,10 +42,5 @@ public class PopularFeedService {
         return popularFeeds.stream()
                 .map(PopularFeedGetResponse::of)
                 .toList();
-    }
-
-    private static PopularFeedsGetResponse getPopularFeedsGetResponse(
-            List<PopularFeedGetResponse> popularFeedGetResponses) {
-        return new PopularFeedsGetResponse(popularFeedGetResponses);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -25,9 +25,18 @@ public class PopularFeedService {
 
     @Transactional(readOnly = true)
     public PopularFeedsGetResponse getPopularFeeds() {
-        List<PopularFeed> popularFeeds = popularFeedRepository.findTop9ByOrderByPopularFeedIdDesc();
+        List<PopularFeed> popularFeeds = findPopularFeeds();
+        List<PopularFeedGetResponse> popularFeedGetResponses = getPopularFeedGetResponses(popularFeeds);
+        return getPopularFeedsGetResponse(popularFeedGetResponses);
+    }
 
-        List<PopularFeedGetResponse> popularFeedGetResponses = popularFeeds.stream()
+    private static PopularFeedsGetResponse getPopularFeedsGetResponse(
+            List<PopularFeedGetResponse> popularFeedGetResponses) {
+        return new PopularFeedsGetResponse(popularFeedGetResponses);
+    }
+
+    private static List<PopularFeedGetResponse> getPopularFeedGetResponses(List<PopularFeed> popularFeeds) {
+        return popularFeeds.stream()
                 .map(popularFeed -> new PopularFeedGetResponse(
                         popularFeed.getFeed().getFeedId(),
                         popularFeed.getFeed().getFeedContent(),
@@ -36,6 +45,9 @@ public class PopularFeedService {
                         popularFeed.getFeed().getIsSpoiler()
                 ))
                 .toList();
-        return new PopularFeedsGetResponse(popularFeedGetResponses);
+    }
+
+    private List<PopularFeed> findPopularFeeds() {
+        return popularFeedRepository.findTop9ByOrderByPopularFeedIdDesc();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -40,13 +40,7 @@ public class PopularFeedService {
 
     private static List<PopularFeedGetResponse> getPopularFeedGetResponses(List<PopularFeed> popularFeeds) {
         return popularFeeds.stream()
-                .map(popularFeed -> new PopularFeedGetResponse(
-                        popularFeed.getFeed().getFeedId(),
-                        popularFeed.getFeed().getFeedContent(),
-                        popularFeed.getFeed().getLikes().size(),
-                        popularFeed.getFeed().getComments().size(),
-                        popularFeed.getFeed().getIsSpoiler()
-                ))
+                .map(PopularFeedGetResponse::of)
                 .toList();
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -49,6 +49,9 @@ public class PopularFeedService {
     }
 
     private List<PopularFeed> findPopularFeeds(User user) {
+        if (user == null) {
+            return popularFeedRepository.findTop9ByOrderByPopularFeedIdDesc();
+        }
         return popularFeedRepository.findTodayPopularFeeds(user.getUserId());
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#116 -> dev
- close #116

## Key Changes
<!-- 최대한 자세히 -->
- 실시간 인기글 조회
  - 비회원과 회원 분기 처리했습니다. 
  - 차단관계를 고려하여 피드를 조회할 때 JOIN을 쓸까 서브쿼리를 쓸까 고민하다가, QueryDsl을 이용해서 union으로 차단관계에 있는 ID를 얻고, IN 절 서브쿼리로 처리하는 방식을 사용했습니다. 
  - 비회원인 경우 차단관계를 고려하지 않아도 되기 때문에 간단하게 상위 9개 레코드를 반환하는 JPA 쿼리 메서드를 호출하도록 했습니다.

## References
<!-- 참고한 자료-->
- https://github.com/querydsl/querydsl/blob/master/querydsl-sql/src/test/java/com/querydsl/sql/UnionBase.java