### PR TITLE
[FIX] 닉네임 유효성 체크 validation 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -34,9 +34,10 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/nickname/check")
-    public ResponseEntity<NicknameValidation> checkNicknameAvailability(
-            @RequestParam("nickname")
-            @NicknameConstraint String nickname) {
+    public ResponseEntity<NicknameValidation> checkNicknameAvailability(Principal principal,
+                                                                        @RequestParam("nickname")
+                                                                        @NicknameConstraint String nickname) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
                 .status(OK)
                 .body(userService.isNicknameAvailable(nickname));

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -40,7 +40,7 @@ public class UserController {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
                 .status(OK)
-                .body(userService.isNicknameAvailable(nickname));
+                .body(userService.isNicknameAvailable(user, nickname));
     }
 
     @GetMapping("/email")

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
@@ -23,7 +23,8 @@ public enum CustomUserError implements ICustomError {
     INVALID_AUTHORIZED("USER-007", "사용자에게 권한이 없습니다.", FORBIDDEN),
     INVALID_USER_ID("USER-008", "유효하지 않은 ID입니다.", BAD_REQUEST),
     DUPLICATED_NICKNAME("USER-009", "중복된 닉네임입니다.", CONFLICT),
-    INVALID_PROFILE_STATUS("USER-010", "프로필 상태는 이미 설정된 값과 동일합니다.", BAD_REQUEST);
+    INVALID_PROFILE_STATUS("USER-010", "프로필 상태는 이미 설정된 값과 동일합니다.", BAD_REQUEST),
+    ALREADY_SET_NICKNAME("USER-011", "닉네임은 이미 설정된 닉네임과 동일합니다.", BAD_REQUEST);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -39,7 +39,7 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public NicknameValidation isNicknameAvailable(User user, String nickname) {
-        if (user.getNickname().equals(nickname)) {
+        if (user.getNickname() != null && user.getNickname().equals(nickname)) {
             throw new CustomUserException(ALREADY_SET_NICKNAME, "nickname with given is already set");
         }
         if (userRepository.existsByNickname(nickname)) {

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.exception.error.CustomAvatarError.AVATAR_NOT_FOUND;
+import static org.websoso.WSSServer.exception.error.CustomUserError.ALREADY_SET_NICKNAME;
 import static org.websoso.WSSServer.exception.error.CustomUserError.DUPLICATED_NICKNAME;
 import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_PROFILE_STATUS;
 import static org.websoso.WSSServer.exception.error.CustomUserError.USER_NOT_FOUND;
@@ -13,7 +14,6 @@ import org.websoso.WSSServer.config.jwt.JwtProvider;
 import org.websoso.WSSServer.config.jwt.UserAuthentication;
 import org.websoso.WSSServer.domain.Avatar;
 import org.websoso.WSSServer.domain.GenrePreference;
-import org.websoso.WSSServer.repository.GenrePreferenceRepository;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
 import org.websoso.WSSServer.dto.user.EmailGetResponse;
@@ -24,6 +24,7 @@ import org.websoso.WSSServer.dto.user.ProfileStatusResponse;
 import org.websoso.WSSServer.exception.exception.CustomAvatarException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
 import org.websoso.WSSServer.repository.AvatarRepository;
+import org.websoso.WSSServer.repository.GenrePreferenceRepository;
 import org.websoso.WSSServer.repository.UserRepository;
 
 @Service
@@ -37,7 +38,10 @@ public class UserService {
     private final GenrePreferenceRepository genrePreferenceRepository;
 
     @Transactional(readOnly = true)
-    public NicknameValidation isNicknameAvailable(String nickname) {
+    public NicknameValidation isNicknameAvailable(User user, String nickname) {
+        if (user.getNickname().equals(nickname)) {
+            throw new CustomUserException(ALREADY_SET_NICKNAME, "nickname with given is already set");
+        }
         if (userRepository.existsByNickname(nickname)) {
             throw new CustomUserException(DUPLICATED_NICKNAME, "nickname is duplicated.");
         }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#118 -> dev
- close #118

## Key Changes
<!-- 최대한 자세히 -->
- 기존 로직에서는 Request header를 안받는 상태였습니다. 누락되어 있었어서 받도록 수정했습니다.
- request의 nickname이 원래의 nickname과 동일한 경우 예외를 던지고 잡아서 처리하도록 수정했습니다.