### PR TITLE
[FEAT] 회원 탈퇴 시 유저 등록 작품 수 조회 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -22,6 +22,8 @@ import org.websoso.WSSServer.dto.user.LoginResponse;
 import org.websoso.WSSServer.dto.user.MyProfileResponse;
 import org.websoso.WSSServer.dto.user.NicknameValidation;
 import org.websoso.WSSServer.dto.user.ProfileStatusResponse;
+import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
+import org.websoso.WSSServer.service.UserNovelService;
 import org.websoso.WSSServer.service.UserService;
 import org.websoso.WSSServer.validation.NicknameConstraint;
 
@@ -32,6 +34,7 @@ import org.websoso.WSSServer.validation.NicknameConstraint;
 public class UserController {
 
     private final UserService userService;
+    private final UserNovelService userNovelService;
 
     @GetMapping("/nickname/check")
     public ResponseEntity<NicknameValidation> checkNicknameAvailability(
@@ -82,5 +85,13 @@ public class UserController {
         return ResponseEntity
                 .status(OK)
                 .body(userService.getMyProfileInfo(user));
+    }
+
+    @GetMapping("/user-novel-stats")
+    public ResponseEntity<UserNovelCountGetResponse> getUserNovelStatistics(Principal principal) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(OK)
+                .body(userNovelService.getUserNovelStatistics(user));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -107,3 +107,4 @@ public class UserController {
                 .status(OK)
                 .body(userNovelService.getUserNovelStatistics(user));
     }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/user/UserNovelCountGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/UserNovelCountGetResponse.java
@@ -1,0 +1,9 @@
+package org.websoso.WSSServer.dto.user;
+
+
+public record UserNovelCountGetResponse(
+        Integer interestNovelCount,
+        Integer watchingNovelCount,
+        Integer watchedNovelCount,
+        Integer quitNovelCount) {
+}

--- a/src/main/java/org/websoso/WSSServer/dto/user/UserNovelCountGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/UserNovelCountGetResponse.java
@@ -5,5 +5,6 @@ public record UserNovelCountGetResponse(
         Integer interestNovelCount,
         Integer watchingNovelCount,
         Integer watchedNovelCount,
-        Integer quitNovelCount) {
+        Integer quitNovelCount
+) {
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepository.java
@@ -1,0 +1,9 @@
+package org.websoso.WSSServer.repository;
+
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
+
+public interface UserNovelCustomRepository {
+
+    UserNovelCountGetResponse findUserNovelStatistics(User user);
+}

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
@@ -26,22 +26,26 @@ public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository 
                                 .when(true)
                                 .then(1)
                                 .otherwise(0)
-                                .sum(),
+                                .sum()
+                                .coalesce(0),
                         userNovel.status
                                 .when(WATCHING)
                                 .then(1)
                                 .otherwise(0)
-                                .sum(),
+                                .sum()
+                                .coalesce(0),
                         userNovel.status
                                 .when(WATCHED)
                                 .then(1)
                                 .otherwise(0)
-                                .sum(),
+                                .sum()
+                                .coalesce(0),
                         userNovel.status
                                 .when(QUIT)
                                 .then(1)
                                 .otherwise(0)
                                 .sum()
+                                .coalesce(0)
                 ))
                 .from(userNovel)
                 .where(userNovel.user.eq(user))

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
@@ -1,0 +1,50 @@
+package org.websoso.WSSServer.repository;
+
+import static org.websoso.WSSServer.domain.QUserNovel.userNovel;
+import static org.websoso.WSSServer.domain.common.ReadStatus.QUIT;
+import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHED;
+import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHING;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
+
+@Repository
+@RequiredArgsConstructor
+public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public UserNovelCountGetResponse findUserNovelStatistics(User user) {
+        return jpaQueryFactory
+                .select(Projections.constructor(UserNovelCountGetResponse.class,
+                        userNovel.isInterest
+                                .when(true)
+                                .then(1)
+                                .otherwise(0)
+                                .sum(),
+                        userNovel.status
+                                .when(WATCHING)
+                                .then(1)
+                                .otherwise(0)
+                                .sum(),
+                        userNovel.status
+                                .when(WATCHED)
+                                .then(1)
+                                .otherwise(0)
+                                .sum(),
+                        userNovel.status
+                                .when(QUIT)
+                                .then(1)
+                                .otherwise(0)
+                                .sum()
+                ))
+                .from(userNovel)
+                .where(userNovel.user.eq(user))
+                .fetchOne();
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
@@ -10,7 +10,7 @@ import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.domain.common.ReadStatus;
 
 @Repository
-public interface UserNovelRepository extends JpaRepository<UserNovel, Long> {
+public interface UserNovelRepository extends JpaRepository<UserNovel, Long>, UserNovelCustomRepository {
 
     Optional<UserNovel> findByNovelAndUser(Novel novel, User user);
 

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -21,6 +21,7 @@ import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.domain.UserNovelAttractivePoint;
 import org.websoso.WSSServer.domain.UserNovelKeyword;
 import org.websoso.WSSServer.dto.keyword.KeywordGetResponse;
+import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
 import org.websoso.WSSServer.dto.userNovel.UserNovelCreateRequest;
 import org.websoso.WSSServer.dto.userNovel.UserNovelGetResponse;
 import org.websoso.WSSServer.exception.exception.CustomNovelException;
@@ -144,4 +145,8 @@ public class UserNovelService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
+    public UserNovelCountGetResponse getUserNovelStatistics(User user) {
+        return userNovelRepository.findUserNovelStatistics(user);
+    }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#122 -> dev
- close #122

## Key Changes
<!-- 최대한 자세히 -->
- 유저의 등록 작품의 수를 조회하는 기능을 구현했습니다. (관심, 보는 중, 봤어요, 하차)
- UserNovel 테이블에서 조회할 때 보는 중, 봤어요, 하차만 고려한다면 ReadStatus를 기준으로 group by를 하고 싶었는데 isInterest 컬럼도 고려해야해서 CASE문을 사용했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- SELECT 절에서 CASE 문 사용시에 성능 이슈가 있을 수 있어서 UNION ALL을 사용한다고 하는데, 추후에 성능 테스트를 통해 리팩터링하고 결과 공유하겠습니다! 제 쿼리는 UNION ALL을 할 필요는 없고 한 방 쿼리가 아니라 4개의 쿼리를 날려서 값을 구하는 방식이 될 것 같네요.
  - `ref1`: https://stackoverflow.com/questions/43781585/mysql-5-7-slow-case-when-then-query
  - `ref2`: https://okky.kr/questions/389347

## References
<!-- 참고한 자료-->
http://querydsl.com/static/querydsl/3.4.2/reference/html/