### PR TITLE
[FEAT] 일반 검색 API 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
@@ -27,6 +27,7 @@ public class SecurityConfig {
             "/users/login",
             "/users/nickname/check",
             "/actuator/health",
+            "/novels",
             "/novels/{novelId}",
             "/novels/{novelId}/info",
             "/soso-picks"

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -29,7 +29,8 @@ public class NovelController {
     private final UserService userService;
 
     @GetMapping("/{novelId}")
-    public ResponseEntity<NovelGetResponseBasic> getNovelInfoBasic(Principal principal, @PathVariable Long novelId) {
+    public ResponseEntity<NovelGetResponseBasic> getNovelInfoBasic(Principal principal,
+                                                                   @PathVariable Long novelId) {
         if (principal == null) {
             return ResponseEntity
                     .status(OK)
@@ -74,7 +75,8 @@ public class NovelController {
 
     @GetMapping
     public ResponseEntity<SearchedNovelsGetResponse> searchNovels(@RequestParam(required = false) String query,
-                                                                  @RequestParam int page, @RequestParam int size) {
+                                                                  @RequestParam int page,
+                                                                  @RequestParam int size) {
 
         return ResponseEntity
                 .status(OK)

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -11,10 +11,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseBasic;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseInfoTab;
+import org.websoso.WSSServer.dto.novel.SearchedNovelsGetResponse;
 import org.websoso.WSSServer.service.NovelService;
 import org.websoso.WSSServer.service.UserService;
 
@@ -68,6 +70,15 @@ public class NovelController {
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();
+    }
+
+    @GetMapping
+    public ResponseEntity<SearchedNovelsGetResponse> searchNovels(@RequestParam(required = false) String query,
+                                                                  @RequestParam int page, @RequestParam int size) {
+
+        return ResponseEntity
+                .status(OK)
+                .body(novelService.searchNovels(query, page, size));
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponsePreview.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponsePreview.java
@@ -7,12 +7,12 @@ public record NovelGetResponsePreview(
         String novelImage,
         String title,
         String author,
-        Integer interestCount,
+        Long interestCount,
         Float novelRating,
-        Integer novelRatingCount
+        Long novelRatingCount
 ) {
-    public static NovelGetResponsePreview of(Novel novel, Integer interestCount, Float novelRating,
-                                             Integer novelRatingCount) {
+    public static NovelGetResponsePreview of(Novel novel, Long interestCount, Float novelRating,
+                                             Long novelRatingCount) {
         return new NovelGetResponsePreview(
                 novel.getNovelId(),
                 novel.getNovelImage(),

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponsePreview.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponsePreview.java
@@ -1,0 +1,26 @@
+package org.websoso.WSSServer.dto.novel;
+
+import org.websoso.WSSServer.domain.Novel;
+
+public record NovelGetResponsePreview(
+        Long novelId,
+        String novelImage,
+        String title,
+        String author,
+        Integer interestCount,
+        Float novelRating,
+        Integer novelRatingCount
+) {
+    public static NovelGetResponsePreview of(Novel novel, Integer interestCount, Float novelRating,
+                                             Integer novelRatingCount) {
+        return new NovelGetResponsePreview(
+                novel.getNovelId(),
+                novel.getNovelImage(),
+                novel.getTitle(),
+                novel.getAuthor(),
+                interestCount,
+                novelRating,
+                novelRatingCount
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/novel/SearchedNovelsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/SearchedNovelsGetResponse.java
@@ -1,0 +1,18 @@
+package org.websoso.WSSServer.dto.novel;
+
+import java.util.List;
+
+public record SearchedNovelsGetResponse(
+        Long resultCount,
+        Boolean isLoadable,
+        List<NovelGetResponsePreview> novels
+) {
+    public static SearchedNovelsGetResponse of(Long resultCount, Boolean isLoadable,
+                                               List<NovelGetResponsePreview> novels) {
+        return new SearchedNovelsGetResponse(
+                resultCount,
+                isLoadable,
+                novels
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepository.java
@@ -1,0 +1,11 @@
+package org.websoso.WSSServer.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.websoso.WSSServer.domain.Novel;
+
+public interface NovelCustomRepository {
+
+    Page<Novel> findSearchedNovels(Pageable pageable, String query);
+
+}

--- a/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
@@ -8,7 +8,6 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -25,10 +24,6 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 
     @Override
     public Page<Novel> findSearchedNovels(Pageable pageable, String query) {
-
-        if (query.isEmpty() || query.isBlank()) {
-            return new PageImpl<>(Collections.emptyList(), pageable, 0);
-        }
 
         String searchQuery = query.replaceAll("\\s+", "");
 

--- a/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
@@ -48,14 +48,16 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
         BooleanExpression titleContainsQuery = cleanTitle.containsIgnoreCase(searchQuery);
         BooleanExpression authorContainsQuery = cleanAuthor.containsIgnoreCase(searchQuery);
 
-        List<Novel> novelsByTitle = jpaQueryFactory.selectFrom(novel)
+        List<Novel> novelsByTitle = jpaQueryFactory
+                .selectFrom(novel)
                 .leftJoin(novel.userNovels, userNovel)
                 .where(titleContainsQuery)
                 .groupBy(novel.novelId)
                 .orderBy(popularity.desc())
                 .fetch();
 
-        List<Novel> novelsByAuthor = jpaQueryFactory.selectFrom(novel)
+        List<Novel> novelsByAuthor = jpaQueryFactory
+                .selectFrom(novel)
                 .leftJoin(novel.userNovels, userNovel)
                 .where(authorContainsQuery.and(titleContainsQuery.not()))
                 .groupBy(novel.novelId)

--- a/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
@@ -46,14 +46,14 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
         BooleanExpression authorContainsQuery = cleanAuthor.containsIgnoreCase(searchQuery);
 
         List<Novel> novelsByTitle = jpaQueryFactory.selectFrom(novel)
-                .join(novel.userNovels, userNovel)
-                .where(novel.title.containsIgnoreCase(query))
+                .leftJoin(novel.userNovels, userNovel)
+                .where(titleContainsQuery)
                 .groupBy(novel.novelId)
                 .orderBy(popularity.desc())
                 .fetch();
 
         List<Novel> novelsByAuthor = jpaQueryFactory.selectFrom(novel)
-                .join(novel.userNovels, userNovel)
+                .leftJoin(novel.userNovels, userNovel)
                 .where(authorContainsQuery.and(titleContainsQuery.not()))
                 .groupBy(novel.novelId)
                 .orderBy(popularity.desc())

--- a/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
@@ -1,5 +1,8 @@
 package org.websoso.WSSServer.repository;
 
+import static org.websoso.WSSServer.domain.QNovel.novel;
+import static org.websoso.WSSServer.domain.QUserNovel.userNovel;
+
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
@@ -13,8 +16,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Novel;
-import org.websoso.WSSServer.domain.QNovel;
-import org.websoso.WSSServer.domain.QUserNovel;
 
 @Repository
 @RequiredArgsConstructor
@@ -24,9 +25,6 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 
     @Override
     public Page<Novel> findSearchedNovels(Pageable pageable, String query) {
-
-        QNovel novel = QNovel.novel;
-        QUserNovel userNovel = QUserNovel.userNovel;
 
         if (query.isEmpty() || query.isBlank()) {
             return new PageImpl<>(Collections.emptyList(), pageable, 0);

--- a/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -51,13 +52,13 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
                 .orderBy(popularity.desc())
                 .fetch();
 
-        novelsByTitle.addAll(novelsByAuthor);
+        List<Novel> result = Stream.concat(novelsByTitle.stream(), novelsByAuthor.stream()).toList();
 
-        long total = novelsByTitle.size();
+        long total = result.size();
         int start = (int) pageable.getOffset();
         int end = Math.min((start + pageable.getPageSize()), (int) total);
 
-        return new PageImpl<>(novelsByTitle.subList(start, end), pageable, total);
+        return new PageImpl<>(result.subList(start, end), pageable, total);
     }
 
     private StringTemplate getSpaceRemovedString(StringPath stringPath) {

--- a/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
@@ -50,7 +50,9 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
                 .orderBy(getPopularity(novel).desc())
                 .fetch();
 
-        List<Novel> result = Stream.concat(novelsByTitle.stream(), novelsByAuthor.stream()).toList();
+        List<Novel> result = Stream
+                .concat(novelsByTitle.stream(), novelsByAuthor.stream())
+                .toList();
 
         long total = result.size();
         int start = (int) pageable.getOffset();

--- a/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -26,6 +27,10 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 
         QNovel novel = QNovel.novel;
         QUserNovel userNovel = QUserNovel.userNovel;
+
+        if (query.isEmpty() || query.isBlank()) {
+            return new PageImpl<>(Collections.emptyList(), pageable, 0);
+        }
 
         String searchQuery = query.replaceAll("\\s+", "");
 

--- a/src/main/java/org/websoso/WSSServer/repository/NovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelRepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Novel;
 
 @Repository
-public interface NovelRepository extends JpaRepository<Novel, Long> {
+public interface NovelRepository extends JpaRepository<Novel, Long>, NovelCustomRepository {
 
     @Query("SELECT n FROM Novel n JOIN UserNovel un ON n.novelId = un.novel.novelId " +
             "GROUP BY n.novelId " +

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
@@ -1,6 +1,5 @@
 package org.websoso.WSSServer.repository;
 
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,8 +13,6 @@ import org.websoso.WSSServer.domain.common.ReadStatus;
 public interface UserNovelRepository extends JpaRepository<UserNovel, Long> {
 
     Optional<UserNovel> findByNovelAndUser(Novel novel, User user);
-
-    List<UserNovel> findAllByNovel(Novel novel);
 
     Integer countByNovelAndStatus(Novel novel, ReadStatus status);
 

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,6 +14,8 @@ import org.websoso.WSSServer.domain.common.ReadStatus;
 public interface UserNovelRepository extends JpaRepository<UserNovel, Long> {
 
     Optional<UserNovel> findByNovelAndUser(Novel novel, User user);
+
+    List<UserNovel> findAllByNovel(Novel novel);
 
     Integer countByNovelAndStatus(Novel novel, ReadStatus status);
 

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -238,6 +238,10 @@ public class NovelService {
 
         PageRequest pageRequest = PageRequest.of(page, size);
 
+        if(query.isEmpty() || query.isBlank()){
+            return SearchedNovelsGetResponse.of(0L, false, Collections.emptyList());
+        }
+
         Page<Novel> novels = novelRepository.findSearchedNovels(pageRequest, query);
 
         List<NovelGetResponsePreview> novelGetResponsePreviews = novels.stream()

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -246,7 +246,7 @@ public class NovelService {
 
     private NovelGetResponsePreview convertToDTO(Novel novel) {
 
-        List<UserNovel> userNovels = userNovelRepository.findAllByNovel(novel);
+        List<UserNovel> userNovels = novel.getUserNovels();
 
         long interestCount = userNovels.stream().filter(UserNovel::getIsInterest).count();
         long novelRatingCount = userNovels.stream().filter(un -> un.getUserNovelRating() != 0.0f).count();

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -238,7 +238,7 @@ public class NovelService {
 
         PageRequest pageRequest = PageRequest.of(page, size);
 
-        if(query.isEmpty() || query.isBlank()){
+        if (query.isEmpty() || query.isBlank()) {
             return SearchedNovelsGetResponse.of(0L, false, Collections.emptyList());
         }
 
@@ -273,9 +273,9 @@ public class NovelService {
 
         return NovelGetResponsePreview.of(
                 novel,
-                (int) interestCount,
+                interestCount,
                 novelRatingAverage,
-                (int) novelRatingCount
+                novelRatingCount
         );
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -86,7 +86,8 @@ public class NovelService {
     }
 
     private String getNovelGenreNames(List<NovelGenre> novelGenres) {
-        return novelGenres.stream().map(novelGenre -> novelGenre.getGenre().getGenreName())
+        return novelGenres.stream()
+                .map(novelGenre -> novelGenre.getGenre().getGenreName())
                 .collect(Collectors.joining("/"));
     }
 
@@ -146,7 +147,8 @@ public class NovelService {
     }
 
     private List<PlatformGetResponse> getPlatforms(Novel novel) {
-        return novelPlatformRepository.findAllByNovel(novel).stream().map(PlatformGetResponse::of)
+        return novelPlatformRepository.findAllByNovel(novel).stream()
+                .map(PlatformGetResponse::of)
                 .collect(Collectors.toList());
     }
 
@@ -238,7 +240,8 @@ public class NovelService {
 
         Page<Novel> novels = novelRepository.findSearchedNovels(pageRequest, query);
 
-        List<NovelGetResponsePreview> novelGetResponsePreviews = novels.stream().map(this::convertToDTO)
+        List<NovelGetResponsePreview> novelGetResponsePreviews = novels.stream()
+                .map(this::convertToDTO)
                 .collect(Collectors.toList());
 
         return SearchedNovelsGetResponse.of(novels.getTotalElements(), novels.hasNext(), novelGetResponsePreviews);
@@ -248,10 +251,19 @@ public class NovelService {
 
         List<UserNovel> userNovels = novel.getUserNovels();
 
-        long interestCount = userNovels.stream().filter(UserNovel::getIsInterest).count();
-        long novelRatingCount = userNovels.stream().filter(un -> un.getUserNovelRating() != 0.0f).count();
-        double novelRatingSum = userNovels.stream().filter(un -> un.getUserNovelRating() != 0.0f)
-                .mapToDouble(UserNovel::getUserNovelRating).sum();
+        long interestCount = userNovels.stream()
+                .filter(UserNovel::getIsInterest)
+                .count();
+
+        long novelRatingCount = userNovels.stream()
+                .filter(un -> un.getUserNovelRating() != 0.0f)
+                .count();
+
+        double novelRatingSum = userNovels.stream()
+                .filter(un -> un.getUserNovelRating() != 0.0f)
+                .mapToDouble(UserNovel::getUserNovelRating)
+                .sum();
+
         Float novelRatingAverage = novelRatingCount == 0 ? 0.0f
                 : Math.round((float) (novelRatingSum / novelRatingCount) * 10.0f) / 10.0f;
 

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -248,7 +248,7 @@ public class NovelService {
 
         PageRequest pageRequest = PageRequest.of(page, size);
 
-        if (query.isEmpty() || query.isBlank()) {
+        if (query.isBlank()) {
             return SearchedNovelsGetResponse.of(0L, false, Collections.emptyList());
         }
 

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -268,7 +268,8 @@ public class NovelService {
                 .mapToDouble(UserNovel::getUserNovelRating)
                 .sum();
 
-        Float novelRatingAverage = novelRatingCount == 0 ? 0.0f
+        Float novelRatingAverage = novelRatingCount == 0
+                ? 0.0f
                 : Math.round((float) (novelRatingSum / novelRatingCount) * 10.0f) / 10.0f;
 
         return NovelGetResponsePreview.of(


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#124 -> dev
- close #124 

## Key Changes
<!-- 최대한 자세히 -->
일반 검색 API를 구현했습니다.
- 상세탐색과 마찬가지로 인기순으로 정렬해야 하기에 lastNovelId가 아닌 page 값을 받습니다.
- 상세탐색과 마찬가지로 검색 결과로 나온 전체 작품 수를 응답해야 하기 때문에 Slice가 아닌 Page를 사용하였습니다.
- 정렬 순서를 살펴보면,
  제목에서 쿼리를 포함하는 작품들 -> 인기순으로 정렬
  작가에서 쿼리를 포함하는 작품들 -> 인기순으로 정렬
  위 두 결과(리스트)를 합치기
  와 같이 진행됩니다.
  * 이 때 인기란 "관심 등록수, 보는 중 등록수, 봤어요 등록수를 총합한 값"을 뜻합니다.
- 위와 같은 정렬을 JPQL 쿼리로 만들기는 어려워 Querydsl을 사용하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
