### PR TITLE
[FEAT] 작품정보 조회 API(피드탭) 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
             "/actuator/health",
             "/novels/{novelId}",
             "/novels/{novelId}/info",
+            "/novels/{novelId}/feeds",
             "/soso-picks",
             "/feeds"
     };

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -17,6 +17,7 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseBasic;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseFeedTab;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseInfoTab;
+import org.websoso.WSSServer.service.FeedService;
 import org.websoso.WSSServer.service.NovelService;
 import org.websoso.WSSServer.service.UserService;
 
@@ -27,6 +28,7 @@ public class NovelController {
 
     private final NovelService novelService;
     private final UserService userService;
+    private final FeedService feedService;
 
     @GetMapping("/{novelId}")
     public ResponseEntity<NovelGetResponseBasic> getNovelInfoBasic(Principal principal, @PathVariable Long novelId) {
@@ -60,7 +62,7 @@ public class NovelController {
 
         return ResponseEntity
                 .status(OK)
-                .body(novelService.getNovelInfoFeedTab(user, novelId, lastFeedId, size));
+                .body(feedService.getNovelInfoFeedTab(user, novelId, lastFeedId, size));
     }
 
     @PostMapping("/{novelId}/is-interest")

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -55,7 +55,6 @@ public class NovelController {
                                                                    @PathVariable Long novelId,
                                                                    @RequestParam("lastFeedId") Long lastFeedId,
                                                                    @RequestParam("size") int size) {
-
         User user = principal == null
                 ? null
                 : userService.getUserOrException(Long.valueOf(principal.getName()));

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -11,9 +11,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseBasic;
+import org.websoso.WSSServer.dto.novel.NovelGetResponseFeedTab;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseInfoTab;
 import org.websoso.WSSServer.service.NovelService;
 import org.websoso.WSSServer.service.UserService;
@@ -44,6 +46,21 @@ public class NovelController {
         return ResponseEntity
                 .status(OK)
                 .body(novelService.getNovelInfoInfoTab(novelId));
+    }
+
+    @GetMapping("/{novelId}/feeds")
+    public ResponseEntity<NovelGetResponseFeedTab> getNovelInfoFeedTab(Principal principal,
+                                                                       @PathVariable Long novelId,
+                                                                       @RequestParam("lastFeedId") Long lastFeedId,
+                                                                       @RequestParam("size") int size) {
+
+        User user = principal == null
+                ? null
+                : userService.getUserOrException(Long.valueOf(principal.getName()));
+
+        return ResponseEntity
+                .status(OK)
+                .body(novelService.getNovelInfoFeedTab(user, novelId, lastFeedId, size));
     }
 
     @PostMapping("/{novelId}/is-interest")

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -51,10 +51,10 @@ public class NovelController {
     }
 
     @GetMapping("/{novelId}/feeds")
-    public ResponseEntity<NovelGetResponseFeedTab> getNovelInfoFeedTab(Principal principal,
-                                                                       @PathVariable Long novelId,
-                                                                       @RequestParam("lastFeedId") Long lastFeedId,
-                                                                       @RequestParam("size") int size) {
+    public ResponseEntity<NovelGetResponseFeedTab> getFeedsByNovel(Principal principal,
+                                                                   @PathVariable Long novelId,
+                                                                   @RequestParam("lastFeedId") Long lastFeedId,
+                                                                   @RequestParam("size") int size) {
 
         User user = principal == null
                 ? null
@@ -62,7 +62,7 @@ public class NovelController {
 
         return ResponseEntity
                 .status(OK)
-                .body(feedService.getNovelInfoFeedTab(user, novelId, lastFeedId, size));
+                .body(feedService.getFeedsByNovel(user, novelId, lastFeedId, size));
     }
 
     @PostMapping("/{novelId}/is-interest")

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponseFeedTab.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponseFeedTab.java
@@ -1,0 +1,16 @@
+package org.websoso.WSSServer.dto.novel;
+
+import java.util.List;
+import org.websoso.WSSServer.dto.feed.FeedInfo;
+
+public record NovelGetResponseFeedTab(
+        Boolean isLoadable,
+        List<FeedInfo> feeds
+) {
+    public static NovelGetResponseFeedTab of(Boolean isLoadable, List<FeedInfo> feeds) {
+        return new NovelGetResponseFeedTab(
+                isLoadable,
+                feeds
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
@@ -22,8 +22,8 @@ public interface FeedCategoryRepository extends JpaRepository<FeedCategory, Long
             + "AND (:lastFeedId = 0 OR fc.feed.feedId < :lastFeedId) "
             + "AND fc.feed.isHidden = false "
             + "AND (:lastFeedId IS NULL "
-            + "OR (fc.feed.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = :userId)) "
-            + "AND fc.feed.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = :userId)) "
+            + "OR (fc.feed.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = :userId) "
+            + "AND fc.feed.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = :userId))) "
             + "ORDER BY fc.feed.feedId DESC")
     Slice<Feed> findFeedsByCategory(Category category, Long lastFeedId, Long userId, PageRequest pageRequest);
 

--- a/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
@@ -16,8 +16,8 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
             + "(:lastFeedId = 0 OR f.feedId < :lastFeedId) "
             + "AND f.isHidden = false "
             + "AND (:userId IS NULL "
-            + "OR (f.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = :userId)) "
-            + "AND f.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = :userId)) "
+            + "OR (f.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = :userId) "
+            + "AND f.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = :userId))) "
             + "ORDER BY f.feedId DESC")
     Slice<Feed> findFeeds(Long lastFeedId, Long userId, PageRequest pageRequest);
 

--- a/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
@@ -21,4 +21,14 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
             + "ORDER BY f.feedId DESC")
     Slice<Feed> findFeeds(Long lastFeedId, Long userId, PageRequest pageRequest);
 
+    @Query(value = "SELECT f FROM Feed f WHERE "
+            + "(:lastFeedId = 0 OR f.feedId < :lastFeedId) "
+            + "AND f.novelId = :novelId "
+            + "AND f.isHidden = false "
+            + "AND (:userId IS NULL "
+            + "OR (f.user.userId NOT IN (SELECT b.blockingId FROM Block b WHERE b.blockedId = :userId) "
+            + "AND f.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = :userId))) "
+            + "ORDER BY f.feedId DESC")
+    Slice<Feed> findFeedsByNovelId(Long novelId, Long lastFeedId, Long userId, PageRequest pageRequest);
+
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -191,7 +191,6 @@ public class FeedService {
     }
 
     public NovelGetResponseFeedTab getFeedsByNovel(User user, Long novelId, Long lastFeedId, int size) {
-
         Slice<Feed> feeds = feedRepository.findFeedsByNovelId(novelId, lastFeedId,
                 user == null ? null : user.getUserId(), PageRequest.of(DEFAULT_PAGE_NUMBER, size));
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -195,9 +195,10 @@ public class FeedService {
         Slice<Feed> feeds = feedRepository.findFeedsByNovelId(novelId, lastFeedId,
                 user == null ? null : user.getUserId(), PageRequest.of(DEFAULT_PAGE_NUMBER, size));
 
-        List<FeedInfo> feedGetResponses = feeds.getContent().stream().map(feed -> createFeedInfo(feed, user)).toList();
+        List<FeedInfo> feedGetResponses = feeds.getContent().stream()
+                .map(feed -> createFeedInfo(feed, user))
+                .toList();
 
         return NovelGetResponseFeedTab.of(feeds.hasNext(), feedGetResponses);
     }
-
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -191,11 +191,11 @@ public class FeedService {
     }
 
     public NovelGetResponseFeedTab getFeedsByNovel(User user, Long novelId, Long lastFeedId, int size) {
-        Long userId = user == null
+        Long userIdOrNull = user == null
                 ? null
                 : user.getUserId();
 
-        Slice<Feed> feeds = feedRepository.findFeedsByNovelId(novelId, lastFeedId, userId,
+        Slice<Feed> feeds = feedRepository.findFeedsByNovelId(novelId, lastFeedId, userIdOrNull,
                 PageRequest.of(DEFAULT_PAGE_NUMBER, size));
 
         List<FeedInfo> feedGetResponses = feeds.getContent().stream()

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -190,7 +190,7 @@ public class FeedService {
         return feedCategoryService.getFeedsByCategoryLabel(category, lastFeedId, userId, pageRequest);
     }
 
-    public NovelGetResponseFeedTab getNovelInfoFeedTab(User user, Long novelId, Long lastFeedId, int size) {
+    public NovelGetResponseFeedTab getFeedsByNovel(User user, Long novelId, Long lastFeedId, int size) {
 
         Slice<Feed> feeds = feedRepository.findFeedsByNovelId(novelId, lastFeedId,
                 user == null ? null : user.getUserId(), PageRequest.of(DEFAULT_PAGE_NUMBER, size));

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -20,6 +20,7 @@ import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedInfo;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 import org.websoso.WSSServer.dto.feed.FeedsGetResponse;
+import org.websoso.WSSServer.dto.novel.NovelGetResponseFeedTab;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
 import org.websoso.WSSServer.repository.FeedRepository;
@@ -187,6 +188,16 @@ public class FeedService {
             return (feedRepository.findFeeds(lastFeedId, userId, pageRequest));
         }
         return feedCategoryService.getFeedsByCategoryLabel(category, lastFeedId, userId, pageRequest);
+    }
+
+    public NovelGetResponseFeedTab getNovelInfoFeedTab(User user, Long novelId, Long lastFeedId, int size) {
+
+        Slice<Feed> feeds = feedRepository.findFeedsByNovelId(novelId, lastFeedId,
+                user == null ? null : user.getUserId(), PageRequest.of(DEFAULT_PAGE_NUMBER, size));
+
+        List<FeedInfo> feedGetResponses = feeds.getContent().stream().map(feed -> createFeedInfo(feed, user)).toList();
+
+        return NovelGetResponseFeedTab.of(feeds.hasNext(), feedGetResponses);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -191,8 +191,12 @@ public class FeedService {
     }
 
     public NovelGetResponseFeedTab getFeedsByNovel(User user, Long novelId, Long lastFeedId, int size) {
-        Slice<Feed> feeds = feedRepository.findFeedsByNovelId(novelId, lastFeedId,
-                user == null ? null : user.getUserId(), PageRequest.of(DEFAULT_PAGE_NUMBER, size));
+        Long userId = user == null
+                ? null
+                : user.getUserId();
+
+        Slice<Feed> feeds = feedRepository.findFeedsByNovelId(novelId, lastFeedId, userId,
+                PageRequest.of(DEFAULT_PAGE_NUMBER, size));
 
         List<FeedInfo> feedGetResponses = feeds.getContent().stream()
                 .map(feed -> createFeedInfo(feed, user))


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#103 -> dev
- close #103 

## Key Changes
<!-- 최대한 자세히 -->
작품정보 조회 API(피드탭)을 구현했습니다.
- 이전 피드 전체 조회에서 쓰인 쿼리문 2개에 괄호를 살짝 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 피드 전체조회 pr과 크게 다른 점 없어서 금방 확인 하실 수 있을겁니다!

## References
<!-- 참고한 자료-->
