### PR TITLE
[FEAT] 소소피드, 소소피드 댓글 신고 API 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -174,4 +174,14 @@ public class FeedController {
                 .body(feedService.getComments(user, feedId));
     }
 
+    @PostMapping("/{feedId}/spoiler")
+    public ResponseEntity<Void> reportFeedSpoiler(Principal principal,
+                                                  @PathVariable("feedId") Long feedId) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        feedService.reportFeedSpoiler(user, feedId);
+
+        return ResponseEntity
+                .status(CREATED)
+                .build();
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -197,4 +197,28 @@ public class FeedController {
                 .status(CREATED)
                 .build();
     }
+
+    @PostMapping("/{feedId}/comments/{commentId}/spoiler")
+    public ResponseEntity<Void> reportCommentSpoiler(Principal principal,
+                                                     @PathVariable("feedId") Long feedId,
+                                                     @PathVariable("commentId") Long commentId) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        feedService.reportComment(user, feedId, commentId, SPOILER);
+
+        return ResponseEntity
+                .status(CREATED)
+                .build();
+    }
+
+    @PostMapping("/{feedId}/comments/{commentId}/impertinence")
+    public ResponseEntity<Void> reportCommentImpertinence(Principal principal,
+                                                          @PathVariable("feedId") Long feedId,
+                                                          @PathVariable("commentId") Long commentId) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        feedService.reportComment(user, feedId, commentId, IMPERTINENCE);
+
+        return ResponseEntity
+                .status(CREATED)
+                .build();
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -184,4 +184,15 @@ public class FeedController {
                 .status(CREATED)
                 .build();
     }
+
+    @PostMapping("/{feedId}/impertinence")
+    public ResponseEntity<Void> reportedFeedImpertinence(Principal principal,
+                                                         @PathVariable("feedId") Long feedId) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        feedService.reportFeedImpertinence(user, feedId);
+
+        return ResponseEntity
+                .status(CREATED)
+                .build();
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -3,6 +3,8 @@ package org.websoso.WSSServer.controller;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
+import static org.websoso.WSSServer.domain.common.ReportedType.IMPERTINENCE;
+import static org.websoso.WSSServer.domain.common.ReportedType.SPOILER;
 
 import jakarta.validation.Valid;
 import java.security.Principal;
@@ -178,7 +180,7 @@ public class FeedController {
     public ResponseEntity<Void> reportFeedSpoiler(Principal principal,
                                                   @PathVariable("feedId") Long feedId) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
-        feedService.reportFeedSpoiler(user, feedId);
+        feedService.reportFeed(user, feedId, SPOILER);
 
         return ResponseEntity
                 .status(CREATED)
@@ -189,7 +191,7 @@ public class FeedController {
     public ResponseEntity<Void> reportedFeedImpertinence(Principal principal,
                                                          @PathVariable("feedId") Long feedId) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
-        feedService.reportFeedImpertinence(user, feedId);
+        feedService.reportFeed(user, feedId, IMPERTINENCE);
 
         return ResponseEntity
                 .status(CREATED)

--- a/src/main/java/org/websoso/WSSServer/domain/Comment.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Comment.java
@@ -73,4 +73,7 @@ public class Comment extends BaseEntity {
         this.feed = feed;
     }
 
+    public void hideComment() {
+        this.isHidden = true;
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -60,7 +60,7 @@ public class Feed extends BaseEntity {
     @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY)
     private List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<ReportedFeed> reportedFeeds = new ArrayList<>();
 
     @Builder

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -60,6 +60,9 @@ public class Feed extends BaseEntity {
     @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY)
     private List<Comment> comments = new ArrayList<>();
 
+    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY)
+    private List<ReportedFeed> reportedFeeds = new ArrayList<>();
+
     @Builder
     public Feed(String feedContent, Boolean isSpoiler, Long novelId, User user) {
         this.feedContent = feedContent;
@@ -83,6 +86,10 @@ public class Feed extends BaseEntity {
 
     public boolean isNovelChanged(Long novelId) {
         return !Objects.equals(this.novelId, novelId);
+    }
+
+    public void hideFeed() {
+        this.isHidden = true;
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/ReportedComment.java
+++ b/src/main/java/org/websoso/WSSServer/domain/ReportedComment.java
@@ -4,14 +4,17 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.websoso.WSSServer.domain.common.ReportedType;
 
 @Entity
 @Getter
@@ -23,14 +26,26 @@ public class ReportedComment {
     @Column(nullable = false)
     private Long reportedCommentId;
 
-    @Column(columnDefinition = "tinyint default 0", nullable = false)
-    private Byte spoilerCount;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportedType reportedType;
 
-    @Column(columnDefinition = "tinyint default 0", nullable = false)
-    private Byte impertinenceCount;
-
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id", nullable = false)
     private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private ReportedComment(Comment comment, User user, ReportedType reportedType) {
+        this.comment = comment;
+        this.user = user;
+        this.reportedType = reportedType;
+    }
+
+    public static ReportedComment create(Comment comment, User user, ReportedType reportedType) {
+        return new ReportedComment(comment, user, reportedType);
+    }
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/ReportedFeed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/ReportedFeed.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,5 +33,17 @@ public class ReportedFeed {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_id", nullable = false)
     private Feed feed;
+
+    private ReportedFeed(Feed feed) {
+        this.feed = feed;
+    }
+
+    public static ReportedFeed create(Feed feed) {
+        return new ReportedFeed(feed);
+    }
+
+    public void incrementSpoilerCount() {
+        this.spoilerCount = (byte) (Optional.ofNullable(this.spoilerCount).orElse((byte) 0) + 1);
+    }
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/ReportedFeed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/ReportedFeed.java
@@ -4,6 +4,8 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -12,6 +14,7 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.websoso.WSSServer.domain.common.ReportedType;
 
 @Entity
 @Getter
@@ -23,6 +26,10 @@ public class ReportedFeed {
     @Column(nullable = false)
     private Long reportedFeedId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(12)", nullable = false)
+    private ReportedType reportedType;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_id", nullable = false)
     private Feed feed;
@@ -31,13 +38,14 @@ public class ReportedFeed {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    private ReportedFeed(Feed feed, User user) {
+    private ReportedFeed(Feed feed, User user, ReportedType reportedType) {
         this.feed = feed;
         this.user = user;
+        this.reportedType = reportedType;
     }
 
-    public static ReportedFeed create(Feed feed, User user) {
-        return new ReportedFeed(feed, user);
+    public static ReportedFeed create(Feed feed, User user, ReportedType reportedType) {
+        return new ReportedFeed(feed, user, reportedType);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/ReportedFeed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/ReportedFeed.java
@@ -8,8 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import java.util.Optional;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,26 +23,21 @@ public class ReportedFeed {
     @Column(nullable = false)
     private Long reportedFeedId;
 
-    @Column(columnDefinition = "tinyint default 0", nullable = false)
-    private Byte spoilerCount;
-
-    @Column(columnDefinition = "tinyint default 0", nullable = false)
-    private Byte impertinenceCount;
-
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_id", nullable = false)
     private Feed feed;
 
-    private ReportedFeed(Feed feed) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private ReportedFeed(Feed feed, User user) {
         this.feed = feed;
+        this.user = user;
     }
 
-    public static ReportedFeed create(Feed feed) {
-        return new ReportedFeed(feed);
-    }
-
-    public void incrementSpoilerCount() {
-        this.spoilerCount = (byte) (Optional.ofNullable(this.spoilerCount).orElse((byte) 0) + 1);
+    public static ReportedFeed create(Feed feed, User user) {
+        return new ReportedFeed(feed, user);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/ReportedFeed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/ReportedFeed.java
@@ -27,7 +27,7 @@ public class ReportedFeed {
     private Long reportedFeedId;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "varchar(12)", nullable = false)
+    @Column(nullable = false)
     private ReportedType reportedType;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/websoso/WSSServer/domain/common/DiscordWebhookMessage.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/DiscordWebhookMessage.java
@@ -1,13 +1,13 @@
 package org.websoso.WSSServer.domain.common;
 
-public record Message(
+public record DiscordWebhookMessage(
         String content
 ) {
-    public static Message of(String content) {
+    public static DiscordWebhookMessage of(String content) {
         if (content.length() >= 2000) {
             content = content.substring(0, 1993) + "\n...```";
         }
-        return new Message(content);
+        return new DiscordWebhookMessage(content);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/common/Message.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/Message.java
@@ -5,7 +5,7 @@ public record Message(
 ) {
     public static Message of(String content) {
         if (content.length() >= 2000) {
-            content = content.substring(0, 1996) + "\n...";
+            content = content.substring(0, 1993) + "\n...```";
         }
         return new Message(content);
     }

--- a/src/main/java/org/websoso/WSSServer/domain/common/Message.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/Message.java
@@ -1,0 +1,9 @@
+package org.websoso.WSSServer.domain.common;
+
+public record Message(
+        String content
+) {
+    public static Message of(String content) {
+        return new Message(content);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/domain/common/Message.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/Message.java
@@ -4,6 +4,10 @@ public record Message(
         String content
 ) {
     public static Message of(String content) {
+        if (content.length() >= 2000) {
+            content = content.substring(0, 1996) + "\n...";
+        }
         return new Message(content);
     }
+
 }

--- a/src/main/java/org/websoso/WSSServer/domain/common/ReportedType.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/ReportedType.java
@@ -1,0 +1,15 @@
+package org.websoso.WSSServer.domain.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReportedType {
+    
+    SPOILER("spoiler"),
+    IMPERTINENCE("Impertinence");
+
+    private final String label;
+
+}

--- a/src/main/java/org/websoso/WSSServer/domain/common/ReportedType.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/ReportedType.java
@@ -6,10 +6,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ReportedType {
-    
-    SPOILER("spoiler"),
-    IMPERTINENCE("Impertinence");
+
+    SPOILER("spoiler", "스포일러"),
+    IMPERTINENCE("Impertinence", "부적절한 표현");
 
     private final String label;
+    private final String description;
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/common/ReportedType.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/ReportedType.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum ReportedType {
 
     SPOILER("spoiler", "스포일러"),
-    IMPERTINENCE("Impertinence", "부적절한 표현");
+    IMPERTINENCE("impertinence", "부적절한 표현");
 
     private final String label;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomCommentError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomCommentError.java
@@ -1,5 +1,7 @@
 package org.websoso.WSSServer.exception.error;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.AllArgsConstructor;
@@ -12,7 +14,9 @@ import org.websoso.WSSServer.exception.common.ICustomError;
 public enum CustomCommentError implements ICustomError {
 
     COMMENT_NOT_FOUND("COMMENT-001", "해당 ID를 가진 댓글을 찾을 수 없습니다.", NOT_FOUND),
-    COMMENT_NOT_BELONG_TO_FEED("COMMENT-002", "댓글이 지정된 피드에 속하지 않습니다.", NOT_FOUND);
+    COMMENT_NOT_BELONG_TO_FEED("COMMENT-002", "댓글이 지정된 피드에 속하지 않습니다.", NOT_FOUND),
+    ALREADY_REPORTED_COMMENT("COMMENT-003", "이미 사용자가 신고한 댓글입니다.", CONFLICT),
+    SELF_REPORT_NOT_ALLOWED("COMMENT-004", "자신의 댓글을 신고할 수 없습니다.", BAD_REQUEST);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomFeedError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomFeedError.java
@@ -20,7 +20,8 @@ public enum CustomFeedError implements ICustomError {
     INVALID_LIKE_COUNT("FEED-004", "좋아요 수가 유효하지 않습니다.", BAD_REQUEST),
     HIDDEN_FEED_ACCESS("FEED-005", "이 피드는 숨겨져 있어 접근할 수 없습니다.", FORBIDDEN),
     BLOCKED_USER_ACCESS("FEED-006", "해당 사용자와 피드 작성자가 차단 상태이므로 이 피드에 접근할 수 없습니다.", FORBIDDEN),
-    SELF_REPORT_NOT_ALLOWED("FEED-007", "자신의 피드를 신고할 수 없습니다.", BAD_REQUEST);
+    SELF_REPORT_NOT_ALLOWED("FEED-007", "자신의 피드를 신고할 수 없습니다.", BAD_REQUEST),
+    ALREADY_REPORTED_FEED("FEED-008", "이미 사용자가 신고한 피드입니다.", CONFLICT);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomFeedError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomFeedError.java
@@ -19,7 +19,8 @@ public enum CustomFeedError implements ICustomError {
     LIKE_USER_NOT_FOUND("FEED-003", "해당 사용자가 이 피드에 좋아요를 누르지 않았습니다.", NOT_FOUND),
     INVALID_LIKE_COUNT("FEED-004", "좋아요 수가 유효하지 않습니다.", BAD_REQUEST),
     HIDDEN_FEED_ACCESS("FEED-005", "이 피드는 숨겨져 있어 접근할 수 없습니다.", FORBIDDEN),
-    BLOCKED_USER_ACCESS("FEED-006", "해당 사용자와 피드 작성자가 차단 상태이므로 이 피드에 접근할 수 없습니다.", FORBIDDEN);
+    BLOCKED_USER_ACCESS("FEED-006", "해당 사용자와 피드 작성자가 차단 상태이므로 이 피드에 접근할 수 없습니다.", FORBIDDEN),
+    SELF_REPORT_NOT_ALLOWED("FEED-007", "자신의 피드를 신고할 수 없습니다.", BAD_REQUEST);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/repository/ReportedCommentRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/ReportedCommentRepository.java
@@ -1,0 +1,17 @@
+package org.websoso.WSSServer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.Comment;
+import org.websoso.WSSServer.domain.ReportedComment;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.common.ReportedType;
+
+@Repository
+public interface ReportedCommentRepository extends JpaRepository<ReportedComment, Long> {
+
+    Boolean existsByCommentAndUserAndReportedType(Comment comment, User user, ReportedType reportedType);
+
+    Integer countByCommentAndReportedType(Comment comment, ReportedType reportedType);
+
+}

--- a/src/main/java/org/websoso/WSSServer/repository/ReportedFeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/ReportedFeedRepository.java
@@ -1,13 +1,14 @@
 package org.websoso.WSSServer.repository;
 
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.ReportedFeed;
+import org.websoso.WSSServer.domain.User;
 
 @Repository
 public interface ReportedFeedRepository extends JpaRepository<ReportedFeed, Long> {
 
-    Optional<ReportedFeed> findByFeed(Feed feed);
+    Boolean existsByFeedAndUser(Feed feed, User user);
+    
 }

--- a/src/main/java/org/websoso/WSSServer/repository/ReportedFeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/ReportedFeedRepository.java
@@ -10,7 +10,7 @@ import org.websoso.WSSServer.domain.common.ReportedType;
 @Repository
 public interface ReportedFeedRepository extends JpaRepository<ReportedFeed, Long> {
 
-    Boolean existsByFeedAndUser(Feed feed, User user);
+    Boolean existsByFeedAndUserAndReportedType(Feed feed, User user, ReportedType reportedType);
 
     Integer countByFeedAndReportedType(Feed feed, ReportedType reportedType);
 

--- a/src/main/java/org/websoso/WSSServer/repository/ReportedFeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/ReportedFeedRepository.java
@@ -5,10 +5,13 @@ import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.ReportedFeed;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.common.ReportedType;
 
 @Repository
 public interface ReportedFeedRepository extends JpaRepository<ReportedFeed, Long> {
 
     Boolean existsByFeedAndUser(Feed feed, User user);
-    
+
+    Integer countByFeedAndReportedType(Feed feed, ReportedType reportedType);
+
 }

--- a/src/main/java/org/websoso/WSSServer/repository/ReportedFeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/ReportedFeedRepository.java
@@ -1,0 +1,13 @@
+package org.websoso.WSSServer.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.ReportedFeed;
+
+@Repository
+public interface ReportedFeedRepository extends JpaRepository<ReportedFeed, Long> {
+
+    Optional<ReportedFeed> findByFeed(Feed feed);
+}

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Comment;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.User;
-import org.websoso.WSSServer.domain.common.Message;
+import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.domain.common.ReportedType;
 import org.websoso.WSSServer.dto.comment.CommentGetResponse;
 import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
@@ -87,8 +87,9 @@ public class CommentService {
             comment.hideComment();
         }
 
-        messageService.sendMessage(
-                Message.of(MessageFormatter.formatCommentReportMessage(comment, reportedType, commentCreatedUser)));
+        messageService.sendDiscordWebhookMessage(
+                DiscordWebhookMessage.of(
+                        MessageFormatter.formatCommentReportMessage(comment, reportedType, commentCreatedUser)));
     }
 
     private Comment getCommentOrException(Long commentId) {

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -3,6 +3,7 @@ package org.websoso.WSSServer.service;
 import static org.websoso.WSSServer.domain.common.Action.DELETE;
 import static org.websoso.WSSServer.domain.common.Action.UPDATE;
 import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_NOT_FOUND;
+import static org.websoso.WSSServer.exception.error.CustomCommentError.SELF_REPORT_NOT_ALLOWED;
 
 import java.util.AbstractMap;
 import java.util.List;
@@ -12,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Comment;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.common.Message;
+import org.websoso.WSSServer.domain.common.ReportedType;
 import org.websoso.WSSServer.dto.comment.CommentGetResponse;
 import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
@@ -27,6 +30,8 @@ public class CommentService {
     private final UserService userService;
     private final AvatarService avatarService;
     private final BlockService blockService;
+    private final ReportedCommentService reportedCommentService;
+    private final MessageService messageService;
 
     public void createComment(Long userId, Feed feed, String commentContent) {
         commentRepository.save(Comment.create(userId, feed, commentContent));
@@ -65,6 +70,27 @@ public class CommentService {
         return CommentsGetResponse.of(comments.size(), responses);
     }
 
+    public void createReportedComment(Feed feed, Long commentId, User user, ReportedType reportedType) {
+        Comment comment = getCommentOrException(commentId);
+
+        comment.validateFeedAssociation(feed);
+
+        User commentCreatedUser = userService.getUserOrException(comment.getUserId());
+
+        if (isUserCommentOwner(commentCreatedUser, user)) {
+            throw new CustomCommentException(SELF_REPORT_NOT_ALLOWED, "cannot report own comment");
+        }
+
+        reportedCommentService.createReportedComment(comment, user, reportedType);
+
+        if (reportedCommentService.shouldHideComment(comment, reportedType)) {
+            comment.hideComment();
+        }
+
+        messageService.sendMessage(
+                Message.of(MessageFormatter.formatCommentReportMessage(comment, reportedType, commentCreatedUser)));
+    }
+
     private Comment getCommentOrException(Long commentId) {
         return commentRepository.findById(commentId).orElseThrow(() ->
                 new CustomCommentException(COMMENT_NOT_FOUND, "comment with the given id was not found"));
@@ -83,5 +109,4 @@ public class CommentService {
     private Boolean isBlocked(User createdFeedUser, User user) {
         return blockService.isBlockedRelationship(user.getUserId(), createdFeedUser.getUserId());
     }
-
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
-import org.websoso.WSSServer.domain.common.Message;
+import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.domain.common.ReportedType;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
@@ -171,7 +171,8 @@ public class FeedService {
             feed.hideFeed();
         }
 
-        messageService.sendMessage(Message.of(MessageFormatter.formatFeedReportMessage(feed, reportedType)));
+        messageService.sendDiscordWebhookMessage(
+                DiscordWebhookMessage.of(MessageFormatter.formatFeedReportMessage(feed, reportedType)));
     }
 
     public void reportComment(User user, Long feedId, Long commentId, ReportedType reportedType) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -48,6 +48,7 @@ public class FeedService {
     private final CommentService commentService;
     private final ReportedFeedService reportedFeedService;
     private final MessageService messageService;
+    private final CommentService commentService;
 
     public void createFeed(User user, FeedCreateRequest request) {
         if (request.novelId() != null) {
@@ -171,6 +172,15 @@ public class FeedService {
         }
 
         messageService.sendMessage(Message.of(MessageFormatter.formatFeedReportMessage(feed, reportedType)));
+    }
+
+    public void reportComment(User user, Long feedId, Long commentId, ReportedType reportedType) {
+        Feed feed = getFeedOrException(feedId);
+
+        checkHiddenFeed(feed);
+        checkBlockedRelationship(feed.getUser(), user);
+
+        commentService.createReportedComment(feed, commentId, user, reportedType);
     }
 
     private Feed getFeedOrException(Long feedId) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -162,6 +162,10 @@ public class FeedService {
         }
 
         reportedFeedService.createReportedFeed(feed, user);
+
+        if (feed.getReportedFeeds().size() >= 3) {
+            feed.hideFeed();
+        }
     }
 
     private Feed getFeedOrException(Long feedId) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -2,8 +2,6 @@ package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.domain.common.Action.DELETE;
 import static org.websoso.WSSServer.domain.common.Action.UPDATE;
-import static org.websoso.WSSServer.domain.common.ReportedType.IMPERTINENCE;
-import static org.websoso.WSSServer.domain.common.ReportedType.SPOILER;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.BLOCKED_USER_ACCESS;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.HIDDEN_FEED_ACCESS;
@@ -18,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.common.ReportedType;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
 import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
@@ -153,7 +152,7 @@ public class FeedService {
         return commentService.getComments(user, feed);
     }
 
-    public void reportFeedSpoiler(User user, Long feedId) {
+    public void reportFeed(User user, Long feedId, ReportedType reportedType) {
         Feed feed = getFeedOrException(feedId);
 
         checkHiddenFeed(feed);
@@ -163,26 +162,9 @@ public class FeedService {
             throw new CustomFeedException(SELF_REPORT_NOT_ALLOWED, "cannot report own feed");
         }
 
-        reportedFeedService.createReportedFeed(feed, user, SPOILER);
+        reportedFeedService.createReportedFeed(feed, user, reportedType);
 
-        if (reportedFeedService.shouldHideFeed(feed, SPOILER)) {
-            feed.hideFeed();
-        }
-    }
-
-    public void reportFeedImpertinence(User user, Long feedId) {
-        Feed feed = getFeedOrException(feedId);
-
-        checkHiddenFeed(feed);
-        checkBlockedRelationship(feed.getUser(), user);
-
-        if (isUserFeedOwner(feed.getUser(), user)) {
-            throw new CustomFeedException(SELF_REPORT_NOT_ALLOWED, "cannot report own feed");
-        }
-
-        reportedFeedService.createReportedFeed(feed, user, IMPERTINENCE);
-
-        if (reportedFeedService.shouldHideFeed(feed, IMPERTINENCE)) {
+        if (reportedFeedService.shouldHideFeed(feed, reportedType)) {
             feed.hideFeed();
         }
     }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -2,6 +2,8 @@ package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.domain.common.Action.DELETE;
 import static org.websoso.WSSServer.domain.common.Action.UPDATE;
+import static org.websoso.WSSServer.domain.common.ReportedType.IMPERTINENCE;
+import static org.websoso.WSSServer.domain.common.ReportedType.SPOILER;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.BLOCKED_USER_ACCESS;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.HIDDEN_FEED_ACCESS;
@@ -161,9 +163,26 @@ public class FeedService {
             throw new CustomFeedException(SELF_REPORT_NOT_ALLOWED, "cannot report own feed");
         }
 
-        reportedFeedService.createReportedFeed(feed, user);
+        reportedFeedService.createReportedFeed(feed, user, SPOILER);
 
-        if (feed.getReportedFeeds().size() >= 3) {
+        if (reportedFeedService.shouldHideFeed(feed, SPOILER)) {
+            feed.hideFeed();
+        }
+    }
+
+    public void reportFeedImpertinence(User user, Long feedId) {
+        Feed feed = getFeedOrException(feedId);
+
+        checkHiddenFeed(feed);
+        checkBlockedRelationship(feed.getUser(), user);
+
+        if (isUserFeedOwner(feed.getUser(), user)) {
+            throw new CustomFeedException(SELF_REPORT_NOT_ALLOWED, "cannot report own feed");
+        }
+
+        reportedFeedService.createReportedFeed(feed, user, IMPERTINENCE);
+
+        if (reportedFeedService.shouldHideFeed(feed, IMPERTINENCE)) {
             feed.hideFeed();
         }
     }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.common.Message;
 import org.websoso.WSSServer.domain.common.ReportedType;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
@@ -46,6 +47,7 @@ public class FeedService {
     private final PopularFeedService popularFeedService;
     private final CommentService commentService;
     private final ReportedFeedService reportedFeedService;
+    private final MessageService messageService;
 
     public void createFeed(User user, FeedCreateRequest request) {
         if (request.novelId() != null) {
@@ -166,6 +168,8 @@ public class FeedService {
 
         if (reportedFeedService.shouldHideFeed(feed, reportedType)) {
             feed.hideFeed();
+            messageService.sendMessage(Message.of(
+                    "피드 ID : " + feedId + " - " + reportedType.getDescription() + " 신고 누적 3회로 인해 해당 피드가 숨김처리 되었습니다."));
         }
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -168,9 +168,9 @@ public class FeedService {
 
         if (reportedFeedService.shouldHideFeed(feed, reportedType)) {
             feed.hideFeed();
-            messageService.sendMessage(Message.of(
-                    "피드 ID : " + feedId + " - " + reportedType.getDescription() + " 신고 누적 3회로 인해 해당 피드가 숨김처리 되었습니다."));
         }
+
+        messageService.sendMessage(Message.of(MessageFormatter.formatFeedReportMessage(feed, reportedType)));
     }
 
     private Feed getFeedOrException(Long feedId) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -48,7 +48,6 @@ public class FeedService {
     private final CommentService commentService;
     private final ReportedFeedService reportedFeedService;
     private final MessageService messageService;
-    private final CommentService commentService;
 
     public void createFeed(User user, FeedCreateRequest request) {
         if (request.novelId() != null) {

--- a/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
@@ -1,0 +1,50 @@
+package org.websoso.WSSServer.service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.websoso.WSSServer.domain.Comment;
+import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.common.ReportedType;
+
+public class MessageFormatter {
+
+    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm";
+
+    private static final String FEED_REPORT_MESSAGE =
+            "[%s] **피드 %s 신고가 접수되었습니다.**\n\n" +
+                    "**[신고된 피드 작성자]**\n" +
+                    "유저 아이디 : %d\n" +
+                    "유저 닉네임 : %s\n\n" +
+                    "**[신고된 피드 내용]**\n%s\n";
+
+    private static final String COMMENT_REPORT_MESSAGE =
+            "**[%s] 피드 댓글 %s 신고가 접수되었습니다.**\n\n" +
+                    "**[신고된 댓글 작성자]**\n" +
+                    "유저 아이디 : %d\n" +
+                    "유저 닉네임 : %s\n\n" +
+                    "**[신고된 댓글 내용]**\n%s\n";
+
+    public static String formatFeedReportMessage(Feed feed, ReportedType reportedType) {
+        return String.format(
+                FEED_REPORT_MESSAGE,
+                LocalDateTime.now().format(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT)),
+                reportedType.getDescription(),
+                feed.getUser().getUserId(),
+                feed.getUser().getNickname(),
+                feed.getFeedContent()
+        );
+    }
+
+    public static String formatCommentReportMessage(Comment comment, ReportedType reportedType, User user) {
+        return String.format(
+                COMMENT_REPORT_MESSAGE,
+                LocalDateTime.now().format(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT)),
+                reportedType.getDescription(),
+                user.getUserId(),
+                user.getNickname(),
+                comment.getCommentContent()
+        );
+    }
+
+}

--- a/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
@@ -12,18 +12,18 @@ public class MessageFormatter {
     private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm";
 
     private static final String FEED_REPORT_MESSAGE =
-            "[%s] **피드 %s 신고가 접수되었습니다.**\n\n" +
-                    "**[신고된 피드 작성자]**\n" +
+            "```[%s] 피드 %s 신고가 접수되었습니다.\n\n" +
+                    "[신고된 피드 작성자]\n" +
                     "유저 아이디 : %d\n" +
                     "유저 닉네임 : %s\n\n" +
-                    "**[신고된 피드 내용]**\n%s\n";
+                    "[신고된 피드 내용]\n%s\n```";
 
     private static final String COMMENT_REPORT_MESSAGE =
-            "**[%s] 피드 댓글 %s 신고가 접수되었습니다.**\n\n" +
-                    "**[신고된 댓글 작성자]**\n" +
+            "```[%s] 피드 댓글 %s 신고가 접수되었습니다.\n\n" +
+                    "[신고된 댓글 작성자]\n" +
                     "유저 아이디 : %d\n" +
                     "유저 닉네임 : %s\n\n" +
-                    "**[신고된 댓글 내용]**\n%s\n";
+                    "[신고된 댓글 내용]\n%s\n```";
 
     public static String formatFeedReportMessage(Feed feed, ReportedType reportedType) {
         return String.format(

--- a/src/main/java/org/websoso/WSSServer/service/MessageService.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageService.java
@@ -33,7 +33,6 @@ public class MessageService {
                     String.class
             );
 
-            // response에 대한 처리
             if (response.getStatusCode().value() != NO_CONTENT.value()) {
                 log.error("메시지 전송 이후 에러 발생");
             }

--- a/src/main/java/org/websoso/WSSServer/service/MessageService.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageService.java
@@ -1,0 +1,46 @@
+package org.websoso.WSSServer.service;
+
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.websoso.WSSServer.domain.common.Message;
+
+@Service
+@Slf4j
+public class MessageService {
+
+    @Value("${logging.discord.webhook-url}")
+    String discordWebhookUrl;
+
+    public void sendMessage(Message message) {
+        try {
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.add("Content-Type", "application/json; utf-8");
+            HttpEntity<Message> messageEntity = new HttpEntity<>(message, httpHeaders);
+
+            RestTemplate template = new RestTemplate();
+            ResponseEntity<String> response = template.exchange(
+                    discordWebhookUrl,
+                    POST,
+                    messageEntity,
+                    String.class
+            );
+
+            // response에 대한 처리
+            if (response.getStatusCode().value() != NO_CONTENT.value()) {
+                log.error("메시지 전송 이후 에러 발생");
+            }
+
+        } catch (Exception e) {
+            log.error("에러 발생 :: " + e);
+        }
+    }
+
+}

--- a/src/main/java/org/websoso/WSSServer/service/MessageService.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageService.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-import org.websoso.WSSServer.domain.common.Message;
+import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 
 @Service
 @Slf4j
@@ -19,11 +19,11 @@ public class MessageService {
     @Value("${logging.discord.webhook-url}")
     String discordWebhookUrl;
 
-    public void sendMessage(Message message) {
+    public void sendDiscordWebhookMessage(DiscordWebhookMessage message) {
         try {
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.add("Content-Type", "application/json; utf-8");
-            HttpEntity<Message> messageEntity = new HttpEntity<>(message, httpHeaders);
+            HttpEntity<DiscordWebhookMessage> messageEntity = new HttpEntity<>(message, httpHeaders);
 
             RestTemplate template = new RestTemplate();
             ResponseEntity<String> response = template.exchange(

--- a/src/main/java/org/websoso/WSSServer/service/ReportedCommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/ReportedCommentService.java
@@ -1,0 +1,34 @@
+package org.websoso.WSSServer.service;
+
+import static org.websoso.WSSServer.exception.error.CustomCommentError.ALREADY_REPORTED_COMMENT;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.domain.Comment;
+import org.websoso.WSSServer.domain.ReportedComment;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.common.ReportedType;
+import org.websoso.WSSServer.exception.exception.CustomCommentException;
+import org.websoso.WSSServer.repository.ReportedCommentRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReportedCommentService {
+
+    private final ReportedCommentRepository reportedCommentRepository;
+
+    public void createReportedComment(Comment comment, User user, ReportedType reportedType) {
+        if (reportedCommentRepository.existsByCommentAndUserAndReportedType(comment, user, reportedType)) {
+            throw new CustomCommentException(ALREADY_REPORTED_COMMENT, "comment has already been reported by the user");
+        }
+
+        reportedCommentRepository.save(ReportedComment.create(comment, user, reportedType));
+    }
+
+    public boolean shouldHideComment(Comment comment, ReportedType reportedType) {
+        return reportedCommentRepository.countByCommentAndReportedType(comment, reportedType) >= 3;
+    }
+
+}

--- a/src/main/java/org/websoso/WSSServer/service/ReportedFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/ReportedFeedService.java
@@ -1,0 +1,25 @@
+package org.websoso.WSSServer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.ReportedFeed;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.repository.ReportedFeedRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReportedFeedService {
+
+    private final ReportedFeedRepository reportedFeedRepository;
+
+    public void createReportedFeed(Feed feed, User user) {
+        ReportedFeed reportedFeed = reportedFeedRepository.findByFeed(feed)
+                .orElse(reportedFeedRepository.save(ReportedFeed.create(feed)));
+
+        reportedFeed.incrementSpoilerCount();
+    }
+
+}

--- a/src/main/java/org/websoso/WSSServer/service/ReportedFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/ReportedFeedService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.ReportedFeed;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.common.ReportedType;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
 import org.websoso.WSSServer.repository.ReportedFeedRepository;
 
@@ -18,12 +19,16 @@ public class ReportedFeedService {
 
     private final ReportedFeedRepository reportedFeedRepository;
 
-    public void createReportedFeed(Feed feed, User user) {
+    public void createReportedFeed(Feed feed, User user, ReportedType reportedType) {
         if (reportedFeedRepository.existsByFeedAndUser(feed, user)) {
             throw new CustomFeedException(ALREADY_REPORTED_FEED, "feed has already been reported by the user");
         }
 
-        reportedFeedRepository.save(ReportedFeed.create(feed, user));
+        reportedFeedRepository.save(ReportedFeed.create(feed, user, reportedType));
+    }
+
+    public boolean shouldHideFeed(Feed feed, ReportedType reportedType) {
+        return reportedFeedRepository.countByFeedAndReportedType(feed, reportedType) >= 3;
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/ReportedFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/ReportedFeedService.java
@@ -20,7 +20,7 @@ public class ReportedFeedService {
     private final ReportedFeedRepository reportedFeedRepository;
 
     public void createReportedFeed(Feed feed, User user, ReportedType reportedType) {
-        if (reportedFeedRepository.existsByFeedAndUser(feed, user)) {
+        if (reportedFeedRepository.existsByFeedAndUserAndReportedType(feed, user, reportedType)) {
             throw new CustomFeedException(ALREADY_REPORTED_FEED, "feed has already been reported by the user");
         }
 

--- a/src/main/java/org/websoso/WSSServer/service/ReportedFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/ReportedFeedService.java
@@ -1,11 +1,14 @@
 package org.websoso.WSSServer.service;
 
+import static org.websoso.WSSServer.exception.error.CustomFeedError.ALREADY_REPORTED_FEED;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.ReportedFeed;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.exception.exception.CustomFeedException;
 import org.websoso.WSSServer.repository.ReportedFeedRepository;
 
 @Service
@@ -16,10 +19,11 @@ public class ReportedFeedService {
     private final ReportedFeedRepository reportedFeedRepository;
 
     public void createReportedFeed(Feed feed, User user) {
-        ReportedFeed reportedFeed = reportedFeedRepository.findByFeed(feed)
-                .orElse(reportedFeedRepository.save(ReportedFeed.create(feed)));
+        if (reportedFeedRepository.existsByFeedAndUser(feed, user)) {
+            throw new CustomFeedException(ALREADY_REPORTED_FEED, "feed has already been reported by the user");
+        }
 
-        reportedFeed.incrementSpoilerCount();
+        reportedFeedRepository.save(ReportedFeed.create(feed, user));
     }
 
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#97 -> dev
- close #97

## Key Changes
<!-- 최대한 자세히 -->
### 소소피드와 소소피드 댓글의 신고 API 를 구현했습니다.

- 신고의 사유는 `스포일러 신고`와 `부적절한 표현 신고`로 총 두가지입니다.
- 3회 누적으로 같은 종류의 신고를 받는다면 해당 피드 또는 댓글은 숨김 처리가 됩니다.
- 사용자는 같은 피드 또는 댓글에 두가지 사유 모두 신고가 가능합니다.

### 신고 피드(ReportedFeed), 신고 댓글(ReportedComment) 엔티티 구조가 변경되었습니다.

- 기존 신고 엔티티 : 엔티티 ID와 각 신고 사유마다의 신고 횟수 컬럼으로 구성 (1:1 매핑으로 횟수를 증가시키는 방식)
- new 신고 엔티티 : 엔티티 ID와 신고 사유, 신고한 유저 컬럼으로 구성 (신고가 접수될 때마다 튜플+1)
  - 신고한 유저 컬럼이 추가된 이유 : 동일한 사용자의 동일한 피드, 댓글 중복 신고를 막기 위해

### 신고 접수 시 디스코드 알림 기능을 구현했습니다.

- 신고가 접수되면 무조건 지정된 디스코드 채널로 알림이 전송됩니다.
- 알림 내용은 `신고 사유, 신고된 글의 작성자 정보, 신고된 글의 내용` 으로 구성되어 있습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
아래 블로그 참고하여 디스코드 알림 구현했습니다
해당 PR 머지 전에 yml 파일에 디스코드 웹 훅 주소 업데이트 해놓겠습니다!

## References
<!-- 참고한 자료-->
https://developer-youn.tistory.com/151