### PR TITLE
[FEAT] 본인 프로필 수정 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -24,6 +24,7 @@ import org.websoso.WSSServer.dto.user.MyProfileResponse;
 import org.websoso.WSSServer.dto.user.NicknameValidation;
 import org.websoso.WSSServer.dto.user.ProfileStatusResponse;
 import org.websoso.WSSServer.dto.user.RegisterUserInfoRequest;
+import org.websoso.WSSServer.dto.user.UpdateMyProfileRequest;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
 import org.websoso.WSSServer.service.UserNovelService;
 import org.websoso.WSSServer.service.UserService;
@@ -88,6 +89,16 @@ public class UserController {
         return ResponseEntity
                 .status(OK)
                 .body(userService.getMyProfileInfo(user));
+    }
+
+    @PatchMapping("/my-profile")
+    public ResponseEntity<Void> updateMyProfileInfo(Principal principal,
+                                                    @RequestBody @Valid UpdateMyProfileRequest updateMyProfileRequest) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        userService.updateMyProfileInfo(user, updateMyProfileRequest);
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
     }
 
     @PostMapping("/profile")

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -17,6 +17,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.websoso.WSSServer.domain.common.Gender;
 import org.websoso.WSSServer.domain.common.Role;
 import org.websoso.WSSServer.dto.user.RegisterUserInfoRequest;
+import org.websoso.WSSServer.dto.user.UpdateMyProfileRequest;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 
 @Entity
@@ -65,6 +66,18 @@ public class User {
 
     public void updateProfileStatus(Boolean profileStatus) {
         this.isProfilePublic = profileStatus;
+    }
+
+    public void updateUserProfile(UpdateMyProfileRequest updateMyProfileRequest) {
+        if (updateMyProfileRequest.avatarId() != null) {
+            this.avatarId = updateMyProfileRequest.avatarId();
+        }
+        if (updateMyProfileRequest.nickname() != null) {
+            this.nickname = updateMyProfileRequest.nickname();
+        }
+        if (updateMyProfileRequest.intro() != null) {
+            this.intro = updateMyProfileRequest.intro();
+        }
     }
 
     public void updateUserInfo(RegisterUserInfoRequest registerUserInfoRequest) {

--- a/src/main/java/org/websoso/WSSServer/dto/user/UpdateMyProfileRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/UpdateMyProfileRequest.java
@@ -1,6 +1,8 @@
 package org.websoso.WSSServer.dto.user;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 import org.websoso.WSSServer.validation.NullAllowedNicknameConstraint;
 
 public record UpdateMyProfileRequest(
@@ -10,6 +12,9 @@ public record UpdateMyProfileRequest(
         String nickname,
 
         @Size(max = 60, message = "소개글은 60자를 초과할 수 없습니다.")
-        String intro
+        String intro,
+
+        @NotNull(message = "선호 장르는 null일 수 없습니다.")
+        List<String> genrePreferences
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/user/UpdateMyProfileRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/UpdateMyProfileRequest.java
@@ -1,0 +1,15 @@
+package org.websoso.WSSServer.dto.user;
+
+import jakarta.validation.constraints.Size;
+import org.websoso.WSSServer.validation.NicknameConstraint;
+
+public record UpdateMyProfileRequest(
+        Byte avatarId,
+
+        @NicknameConstraint
+        String nickname,
+
+        @Size(max = 60, message = "intro는 60자를 초과할 수 없습니다.")
+        String intro
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/dto/user/UpdateMyProfileRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/UpdateMyProfileRequest.java
@@ -9,7 +9,7 @@ public record UpdateMyProfileRequest(
         @NicknameConstraint
         String nickname,
 
-        @Size(max = 60, message = "intro는 60자를 초과할 수 없습니다.")
+        @Size(max = 60, message = "소개글은 60자를 초과할 수 없습니다.")
         String intro
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/user/UpdateMyProfileRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/UpdateMyProfileRequest.java
@@ -1,12 +1,12 @@
 package org.websoso.WSSServer.dto.user;
 
 import jakarta.validation.constraints.Size;
-import org.websoso.WSSServer.validation.NicknameConstraint;
+import org.websoso.WSSServer.validation.NullAllowedNicknameConstraint;
 
 public record UpdateMyProfileRequest(
         Byte avatarId,
 
-        @NicknameConstraint
+        @NullAllowedNicknameConstraint
         String nickname,
 
         @Size(max = 60, message = "소개글은 60자를 초과할 수 없습니다.")

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
@@ -27,7 +27,9 @@ public enum CustomUserError implements ICustomError {
     INVALID_GENDER("USER-011", "성별은 M 또는 F여야 합니다.", BAD_REQUEST),
     INVALID_GENDER_NULL("USER-012", "성별은 null일 수 없습니다.", BAD_REQUEST),
     INVALID_GENDER_BLANK("USER-013", "성별은 빈칸일 수 없습니다.", BAD_REQUEST),
-    ALREADY_SET_NICKNAME("USER-014", "닉네임은 이미 설정된 닉네임과 동일합니다.", BAD_REQUEST);
+    ALREADY_SET_NICKNAME("USER-014", "닉네임은 이미 설정된 닉네임과 동일합니다.", BAD_REQUEST),
+    ALREADY_SET_AVATAR("USER-015", "아바타는 이미 설정된 아바타와 동일합니다.", BAD_REQUEST),
+    ALREADY_SET_INTRO("USER-016", "소개글은 이미 설정된 소개글 동일합니다.", BAD_REQUEST);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
@@ -29,7 +29,7 @@ public enum CustomUserError implements ICustomError {
     INVALID_GENDER_BLANK("USER-013", "성별은 빈칸일 수 없습니다.", BAD_REQUEST),
     ALREADY_SET_NICKNAME("USER-014", "닉네임은 이미 설정된 닉네임과 동일합니다.", BAD_REQUEST),
     ALREADY_SET_AVATAR("USER-015", "아바타는 이미 설정된 아바타와 동일합니다.", BAD_REQUEST),
-    ALREADY_SET_INTRO("USER-016", "소개글은 이미 설정된 소개글 동일합니다.", BAD_REQUEST);
+    ALREADY_SET_INTRO("USER-016", "소개글은 이미 설정된 소개글과 동일합니다.", BAD_REQUEST);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/repository/GenrePreferenceRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/GenrePreferenceRepository.java
@@ -10,4 +10,6 @@ import org.websoso.WSSServer.domain.User;
 public interface GenrePreferenceRepository extends JpaRepository<GenrePreference, Long> {
 
     List<GenrePreference> findByUser(User user);
+
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -51,9 +51,7 @@ public class UserService {
         if (user.getNickname() != null && user.getNickname().equals(nickname)) {
             throw new CustomUserException(ALREADY_SET_NICKNAME, "nickname with given is already set");
         }
-        if (userRepository.existsByNickname(nickname)) {
-            throw new CustomUserException(DUPLICATED_NICKNAME, "nickname is duplicated.");
-        }
+        checkNicknameIfAlreadyExist(nickname);
         return NicknameValidation.of(true);
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -49,10 +49,10 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public NicknameValidation isNicknameAvailable(User user, String nickname) {
-        if (user.getNickname() != null && user.getNickname().equals(nickname)) {
-            throw new CustomUserException(ALREADY_SET_NICKNAME, "nickname with given is already set");
-        }
+        checkIfAlreadySetOrThrow(user.getNickname(), nickname,
+                ALREADY_SET_NICKNAME, "nickname with given is already set");
         checkNicknameIfAlreadyExist(nickname);
+
         return NicknameValidation.of(true);
     }
 
@@ -77,9 +77,9 @@ public class UserService {
     }
 
     public void editProfileStatus(User user, EditProfileStatusRequest editProfileStatusRequest) {
-        if (user.getIsProfilePublic().equals(editProfileStatusRequest.isProfilePublic())) {
-            throw new CustomUserException(ALREADY_SET_PROFILE_STATUS, "profile status with given is already set");
-        }
+        checkIfAlreadySetOrThrow(user.getIsProfilePublic(), editProfileStatusRequest.isProfilePublic(),
+                ALREADY_SET_PROFILE_STATUS, "profile status with given is already set");
+
         user.updateProfileStatus(editProfileStatusRequest.isProfilePublic());
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -105,7 +105,7 @@ public class UserService {
             throw new CustomUserException(ALREADY_SET_AVATAR, "avatarId with given is already set");
         }
 
-        validateNickname(updateMyProfileRequest.nickname());
+        checkNicknameIfAlreadyExist(updateMyProfileRequest.nickname());
         if (user.getNickname() != null && user.getNickname().equals(updateMyProfileRequest.nickname())) {
             throw new CustomUserException(ALREADY_SET_NICKNAME, "nickname with given is already set");
         }
@@ -119,13 +119,13 @@ public class UserService {
     }
 
     public void registerUserInfo(User user, RegisterUserInfoRequest registerUserInfoRequest) {
-        validateNickname(registerUserInfoRequest.nickname());
+        checkNicknameIfAlreadyExist(registerUserInfoRequest.nickname());
         user.updateUserInfo(registerUserInfoRequest);
         List<GenrePreference> preferGenres = createGenrePreferences(user, registerUserInfoRequest.genrePreferences());
         genrePreferenceRepository.saveAll(preferGenres);
     }
 
-    private void validateNickname(String nickname) {
+    private void checkNicknameIfAlreadyExist(String nickname) {
         if (userRepository.existsByNickname(nickname)) {
             throw new CustomUserException(DUPLICATED_NICKNAME, "nickname is duplicated.");
         }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -116,7 +116,6 @@ public class UserService {
         genrePreferenceRepository.saveAll(newPreferGenres);
 
         user.updateUserProfile(updateMyProfileRequest);
-        userRepository.save(user);
     }
 
     public void registerUserInfo(User user, RegisterUserInfoRequest registerUserInfoRequest) {

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -110,6 +110,11 @@ public class UserService {
         checkIfAlreadySetOrThrow(user.getIntro(), updateMyProfileRequest.intro(),
                 ALREADY_SET_INTRO, "intro with given is already set");
 
+        List<GenrePreference> currentPreferGenres = genrePreferenceRepository.findByUser(user);
+        List<GenrePreference> newPreferGenres = createGenrePreferences(user, updateMyProfileRequest.genrePreferences());
+        genrePreferenceRepository.deleteAll(currentPreferGenres);
+        genrePreferenceRepository.saveAll(newPreferGenres);
+
         user.updateUserProfile(updateMyProfileRequest);
         userRepository.save(user);
     }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -103,9 +103,9 @@ public class UserService {
         checkIfAlreadySetOrThrow(user.getAvatarId(), updateMyProfileRequest.avatarId(),
                 ALREADY_SET_AVATAR, "avatarId with given is already set");
 
-        checkNicknameIfAlreadyExist(updateMyProfileRequest.nickname());
         checkIfAlreadySetOrThrow(user.getNickname(), updateMyProfileRequest.nickname(),
                 ALREADY_SET_NICKNAME, "nickname with given is already set");
+        checkNicknameIfAlreadyExist(updateMyProfileRequest.nickname());
 
         checkIfAlreadySetOrThrow(user.getIntro(), updateMyProfileRequest.intro(),
                 ALREADY_SET_INTRO, "intro with given is already set");

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -27,6 +27,7 @@ import org.websoso.WSSServer.dto.user.NicknameValidation;
 import org.websoso.WSSServer.dto.user.ProfileStatusResponse;
 import org.websoso.WSSServer.dto.user.RegisterUserInfoRequest;
 import org.websoso.WSSServer.dto.user.UpdateMyProfileRequest;
+import org.websoso.WSSServer.exception.error.CustomUserError;
 import org.websoso.WSSServer.exception.exception.CustomAvatarException;
 import org.websoso.WSSServer.exception.exception.CustomGenreException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
@@ -99,18 +100,15 @@ public class UserService {
     }
 
     public void updateMyProfileInfo(User user, UpdateMyProfileRequest updateMyProfileRequest) {
-        if (user.getAvatarId() != null && user.getAvatarId().equals(updateMyProfileRequest.avatarId())) {
-            throw new CustomUserException(ALREADY_SET_AVATAR, "avatarId with given is already set");
-        }
+        checkIfAlreadySetOrThrow(user.getAvatarId(), updateMyProfileRequest.avatarId(),
+                ALREADY_SET_AVATAR, "avatarId with given is already set");
 
         checkNicknameIfAlreadyExist(updateMyProfileRequest.nickname());
-        if (user.getNickname() != null && user.getNickname().equals(updateMyProfileRequest.nickname())) {
-            throw new CustomUserException(ALREADY_SET_NICKNAME, "nickname with given is already set");
-        }
+        checkIfAlreadySetOrThrow(user.getNickname(), updateMyProfileRequest.nickname(),
+                ALREADY_SET_NICKNAME, "nickname with given is already set");
 
-        if (user.getIntro() != null && user.getIntro().equals(updateMyProfileRequest.intro())) {
-            throw new CustomUserException(ALREADY_SET_INTRO, "intro with given is already set");
-        }
+        checkIfAlreadySetOrThrow(user.getIntro(), updateMyProfileRequest.intro(),
+                ALREADY_SET_INTRO, "intro with given is already set");
 
         user.updateUserProfile(updateMyProfileRequest);
         userRepository.save(user);
@@ -126,6 +124,13 @@ public class UserService {
     private void checkNicknameIfAlreadyExist(String nickname) {
         if (userRepository.existsByNickname(nickname)) {
             throw new CustomUserException(DUPLICATED_NICKNAME, "nickname is duplicated.");
+        }
+    }
+
+    private <T> void checkIfAlreadySetOrThrow(T currentValue, T newValue,
+                                              CustomUserError customUserError, String message) {
+        if (newValue != null && newValue.equals(currentValue)) {
+            throw new CustomUserException(customUserError, message);
         }
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -2,6 +2,8 @@ package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.exception.error.CustomAvatarError.AVATAR_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomGenreError.GENRE_NOT_FOUND;
+import static org.websoso.WSSServer.exception.error.CustomUserError.ALREADY_SET_AVATAR;
+import static org.websoso.WSSServer.exception.error.CustomUserError.ALREADY_SET_INTRO;
 import static org.websoso.WSSServer.exception.error.CustomUserError.ALREADY_SET_NICKNAME;
 import static org.websoso.WSSServer.exception.error.CustomUserError.ALREADY_SET_PROFILE_STATUS;
 import static org.websoso.WSSServer.exception.error.CustomUserError.DUPLICATED_NICKNAME;
@@ -24,6 +26,7 @@ import org.websoso.WSSServer.dto.user.MyProfileResponse;
 import org.websoso.WSSServer.dto.user.NicknameValidation;
 import org.websoso.WSSServer.dto.user.ProfileStatusResponse;
 import org.websoso.WSSServer.dto.user.RegisterUserInfoRequest;
+import org.websoso.WSSServer.dto.user.UpdateMyProfileRequest;
 import org.websoso.WSSServer.exception.exception.CustomAvatarException;
 import org.websoso.WSSServer.exception.exception.CustomGenreException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
@@ -95,6 +98,24 @@ public class UserService {
                         () -> new CustomAvatarException(AVATAR_NOT_FOUND, "avatar with the given id was not found"));
         List<GenrePreference> genrePreferences = genrePreferenceRepository.findByUser(user);
         return MyProfileResponse.of(user, avatar, genrePreferences);
+    }
+
+    public void updateMyProfileInfo(User user, UpdateMyProfileRequest updateMyProfileRequest) {
+        if (user.getAvatarId() != null && user.getAvatarId().equals(updateMyProfileRequest.avatarId())) {
+            throw new CustomUserException(ALREADY_SET_AVATAR, "avatarId with given is already set");
+        }
+
+        validateNickname(updateMyProfileRequest.nickname());
+        if (user.getNickname() != null && user.getNickname().equals(updateMyProfileRequest.nickname())) {
+            throw new CustomUserException(ALREADY_SET_NICKNAME, "nickname with given is already set");
+        }
+
+        if (user.getIntro() != null && user.getIntro().equals(updateMyProfileRequest.intro())) {
+            throw new CustomUserException(ALREADY_SET_INTRO, "intro with given is already set");
+        }
+
+        user.updateUserProfile(updateMyProfileRequest);
+        userRepository.save(user);
     }
 
     public void registerUserInfo(User user, RegisterUserInfoRequest registerUserInfoRequest) {

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -110,9 +110,9 @@ public class UserService {
         checkIfAlreadySetOrThrow(user.getIntro(), updateMyProfileRequest.intro(),
                 ALREADY_SET_INTRO, "intro with given is already set");
 
-        List<GenrePreference> currentPreferGenres = genrePreferenceRepository.findByUser(user);
+        genrePreferenceRepository.deleteAllByUser(user);
+
         List<GenrePreference> newPreferGenres = createGenrePreferences(user, updateMyProfileRequest.genrePreferences());
-        genrePreferenceRepository.deleteAll(currentPreferGenres);
         genrePreferenceRepository.saveAll(newPreferGenres);
 
         user.updateUserProfile(updateMyProfileRequest);

--- a/src/main/java/org/websoso/WSSServer/validation/NullAllowedNicknameConstraint.java
+++ b/src/main/java/org/websoso/WSSServer/validation/NullAllowedNicknameConstraint.java
@@ -1,0 +1,24 @@
+package org.websoso.WSSServer.validation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = NullAllowedNicknameValidator.class)
+@Target({PARAMETER, FIELD})
+@Retention(RUNTIME)
+public @interface NullAllowedNicknameConstraint {
+
+    String message() default "invalid nickname";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/websoso/WSSServer/validation/NullAllowedNicknameValidator.java
+++ b/src/main/java/org/websoso/WSSServer/validation/NullAllowedNicknameValidator.java
@@ -1,0 +1,25 @@
+package org.websoso.WSSServer.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NullAllowedNicknameValidator implements ConstraintValidator<NullAllowedNicknameConstraint, String> {
+
+    private final NicknameValidator nicknameValidator;
+
+    @Override
+    public void initialize(NullAllowedNicknameConstraint nickname) {
+    }
+
+    @Override
+    public boolean isValid(String nickname, ConstraintValidatorContext constraintValidatorContext) {
+        if (nickname == null) {
+            return true;
+        }
+        return nicknameValidator.isValid(nickname, constraintValidatorContext);
+    }
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#111 -> dev
- close #111

## Key Changes
<!-- 최대한 자세히 -->
- 본인 프로필을 수정하는 API입니다.
- avatarId, nickname, intro, genrePreferences를 프로퍼티로 받는데, 스펙이 PATCH이기 때문에 List 타입인 genrePreferences 제외하고는 null을 허용하도록 했습니다.
  - avatarId, nickname, intro
    - 기존에 설정되어 있는 값과 동일한지 검증합니다.
    - 제네릭을 사용하여 검증 메서드로 분리했습니다. (`checkIfAlreadySetOrThrow()`)
    - nickname을 검증하는 `NicknameConstraint`는 null check를 하기 때문에 `NullAllowedNicknameConstraint`를 정의했습니다. 
    - -> null인 경우(변경하지 않으니 프로퍼티를 보내지 않을 때)는 valid하도록, null이 아닌 경우(변경하기 위해 프로퍼티를 보낼 때)는 `NicknameConstraint`의 validator인 `NicknameValidator`에 validation을 위임합니다.
  - genrePreferences
    - 기존에 설정되어 있는 값과 동일한지 검증하지 않고, 변경하고자 하는 genre들을 모두 받습니다.
    - 기존 값 deleteAll, 변경하고자 하는 값 saveAll로 작동합니다.
