### PR TITLE
[FEAT] 관심글 조회 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -22,6 +22,7 @@ import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 import org.websoso.WSSServer.dto.feed.FeedsGetResponse;
+import org.websoso.WSSServer.dto.feed.InterestFeedsGetResponse;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
 import org.websoso.WSSServer.service.FeedService;
 import org.websoso.WSSServer.service.PopularFeedService;
@@ -123,5 +124,14 @@ public class FeedController {
                 .status(OK)
                 .body(feedService.getFeeds(user, category, lastFeedId, size));
     }
-  
+
+    @GetMapping("/interest")
+    public ResponseEntity<InterestFeedsGetResponse> getInterestFeeds(Principal principal) {
+        User user = principal == null
+                ? null
+                : userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(OK)
+                .body(feedService.getInterestFeeds(user));
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedGetResponse.java
@@ -19,9 +19,7 @@ public record InterestFeedGetResponse(
 
     public static InterestFeedGetResponse of(Novel novel, User user, Feed feed, Avatar avatar) {
         Long novelRatingCount = getNovelRatingCount(novel);
-        Float novelRating = novelRatingCount > 0
-                ? getNovelRatingSum(novel) / novelRatingCount
-                : 0.0f;
+        Float novelRating = getNovelRating(novel, novelRatingCount);
 
         return new InterestFeedGetResponse(
                 novel.getNovelId(),
@@ -41,6 +39,12 @@ public record InterestFeedGetResponse(
                 .filter(userNovel -> userNovel.getUserNovelRating() != 0.0f)
                 .mapToDouble(UserNovel::getUserNovelRating)
                 .sum();
+    }
+
+    private static float getNovelRating(Novel novel, Long novelRatingCount) {
+        return novelRatingCount > 0
+                ? getNovelRatingSum(novel) / novelRatingCount
+                : 0.0f;
     }
 
     private static Long getNovelRatingCount(Novel novel) {

--- a/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedGetResponse.java
@@ -1,0 +1,52 @@
+package org.websoso.WSSServer.dto.feed;
+
+import org.websoso.WSSServer.domain.Avatar;
+import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserNovel;
+
+public record InterestFeedGetResponse(
+        Long novelId,
+        String novelTitle,
+        String novelImage,
+        Float novelRating,
+        Long novelRatingCount,
+        String nickname,
+        String avatarImage,
+        String feedContent
+) {
+
+    public static InterestFeedGetResponse of(Novel novel, User user, Feed feed, Avatar avatar) {
+        Long novelRatingCount = getNovelRatingCount(novel);
+        Float novelRating = novelRatingCount > 0
+                ? getNovelRatingSum(novel) / novelRatingCount
+                : 0.0f;
+
+        return new InterestFeedGetResponse(
+                novel.getNovelId(),
+                novel.getTitle(),
+                novel.getNovelImage(),
+                novelRating,
+                novelRatingCount,
+                user.getNickname(),
+                avatar.getAvatarImage(),
+                feed.getFeedContent()
+        );
+    }
+
+    private static Float getNovelRatingSum(Novel novel) {
+        return (float) novel.getUserNovels()
+                .stream()
+                .filter(userNovel -> userNovel.getUserNovelRating() != 0.0f)
+                .mapToDouble(UserNovel::getUserNovelRating)
+                .sum();
+    }
+
+    private static Long getNovelRatingCount(Novel novel) {
+        return novel.getUserNovels()
+                .stream()
+                .filter(userNovel -> userNovel.getUserNovelRating() != 0.0f)
+                .count();
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedGetResponse.java
@@ -33,6 +33,13 @@ public record InterestFeedGetResponse(
         );
     }
 
+    private static Long getNovelRatingCount(Novel novel) {
+        return novel.getUserNovels()
+                .stream()
+                .filter(userNovel -> userNovel.getUserNovelRating() != 0.0f)
+                .count();
+    }
+
     private static Float getNovelRatingSum(Novel novel) {
         return (float) novel.getUserNovels()
                 .stream()
@@ -45,12 +52,5 @@ public record InterestFeedGetResponse(
         return novelRatingCount > 0
                 ? getNovelRatingSum(novel) / novelRatingCount
                 : 0.0f;
-    }
-
-    private static Long getNovelRatingCount(Novel novel) {
-        return novel.getUserNovels()
-                .stream()
-                .filter(userNovel -> userNovel.getUserNovelRating() != 0.0f)
-                .count();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedsGetResponse.java
@@ -1,0 +1,12 @@
+package org.websoso.WSSServer.dto.feed;
+
+import java.util.List;
+
+public record InterestFeedsGetResponse(
+        List<InterestFeedGetResponse> recommendFeeds
+) {
+
+    public static InterestFeedsGetResponse of(List<InterestFeedGetResponse> interestFeedGetResponses) {
+        return new InterestFeedsGetResponse(interestFeedGetResponses);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
@@ -22,6 +22,5 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedCustomRep
             + "ORDER BY f.feedId DESC")
     Slice<Feed> findFeeds(Long lastFeedId, Long userId, PageRequest pageRequest);
 
-    @Query("SELECT f FROM Feed f WHERE f.novelId IN :novelIds ORDER BY f.feedId DESC")
-    List<Feed> findTop10ByNovelIdIn(List<Long> novelIds);
+    List<Feed> findTop10ByNovelIdInOrderByFeedIdDesc(List<Long> novelIds);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.repository;
 
+import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,4 +21,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedCustomRep
             + "AND f.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = :userId)) "
             + "ORDER BY f.feedId DESC")
     Slice<Feed> findFeeds(Long lastFeedId, Long userId, PageRequest pageRequest);
+
+    @Query("SELECT f FROM Feed f WHERE f.novelId IN :novelIds ORDER BY f.feedId DESC")
+    List<Feed> findTop10ByNovelIdIn(List<Long> novelIds);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -22,4 +23,6 @@ public interface UserNovelRepository extends JpaRepository<UserNovel, Long>, Use
     Float sumUserNovelRatingByNovel(Novel novel);
 
     Integer countByNovelAndUserNovelRatingNot(Novel novel, float ratingToExclude);
+
+    List<UserNovel> findByUserAndIsInterestTrue(User user);
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -9,6 +9,7 @@ import static org.websoso.WSSServer.exception.error.CustomFeedError.HIDDEN_FEED_
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -212,10 +213,9 @@ public class FeedService {
         List<Long> interestNovelIds = new ArrayList<>(novelMap.keySet());
 
         List<Feed> interestFeeds = feedRepository.findTop10ByNovelIdInOrderByFeedIdDesc(interestNovelIds);
-        List<Byte> avatarIds = interestFeeds.stream()
+        Set<Byte> avatarIds = interestFeeds.stream()
                 .map(feed -> feed.getUser().getAvatarId())
-                .distinct()
-                .toList();
+                .collect(Collectors.toSet());
         Map<Byte, Avatar> avatarMap = avatarRepository.findAllById(avatarIds)
                 .stream()
                 .collect(Collectors.toMap(Avatar::getAvatarId, avatar -> avatar));

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -211,7 +211,7 @@ public class FeedService {
                 .collect(Collectors.toMap(Novel::getNovelId, novel -> novel));
         List<Long> interestNovelIds = new ArrayList<>(novelMap.keySet());
 
-        List<Feed> interestFeeds = feedRepository.findTop10ByNovelIdIn(interestNovelIds);
+        List<Feed> interestFeeds = feedRepository.findTop10ByNovelIdInOrderByFeedIdDesc(interestNovelIds);
         List<Byte> avatarIds = interestFeeds.stream()
                 .map(feed -> feed.getUser().getAvatarId())
                 .distinct()

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -7,6 +7,8 @@ import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOU
 import static org.websoso.WSSServer.exception.error.CustomFeedError.HIDDEN_FEED_ACCESS;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -200,5 +202,9 @@ public class FeedService {
                 .stream()
                 .map(UserNovel::getNovel)
                 .toList();
+
+        Map<Long, Novel> novelMap = interestNovels
+                .stream()
+                .collect(Collectors.toMap(Novel::getNovelId, novel -> novel));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -6,6 +6,7 @@ import static org.websoso.WSSServer.exception.error.CustomFeedError.BLOCKED_USER
 import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.HIDDEN_FEED_ACCESS;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -206,5 +207,7 @@ public class FeedService {
         Map<Long, Novel> novelMap = interestNovels
                 .stream()
                 .collect(Collectors.toMap(Novel::getNovelId, novel -> novel));
+        List<Long> interestNovelIds = new ArrayList<>(novelMap.keySet());
+
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -220,13 +220,13 @@ public class FeedService {
                 .stream()
                 .collect(Collectors.toMap(Avatar::getAvatarId, avatar -> avatar));
 
-        List<InterestFeedGetResponse> interestFeedGetResponseList = interestFeeds.stream()
+        List<InterestFeedGetResponse> interestFeedGetResponses = interestFeeds.stream()
                 .map(feed -> {
                     Novel novel = novelMap.get(feed.getNovelId());
                     Avatar avatar = avatarMap.get(feed.getUser().getAvatarId());
                     return InterestFeedGetResponse.of(novel, feed.getUser(), feed, avatar);
                 })
                 .toList();
-        return InterestFeedsGetResponse.of(interestFeedGetResponseList);
+        return InterestFeedsGetResponse.of(interestFeedGetResponses);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.domain.Avatar;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
@@ -214,5 +215,9 @@ public class FeedService {
                 .map(feed -> feed.getUser().getAvatarId())
                 .distinct()
                 .toList();
+        Map<Byte, Avatar> avatarMap = avatarRepository.findAllById(avatarIds)
+                .stream()
+                .collect(Collectors.toMap(Avatar::getAvatarId, avatar -> avatar));
+
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.domain.Avatar;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
@@ -24,6 +25,7 @@ import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedInfo;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 import org.websoso.WSSServer.dto.feed.FeedsGetResponse;
+import org.websoso.WSSServer.dto.feed.InterestFeedGetResponse;
 import org.websoso.WSSServer.dto.feed.InterestFeedsGetResponse;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
@@ -209,5 +211,6 @@ public class FeedService {
                 .collect(Collectors.toMap(Novel::getNovelId, novel -> novel));
         List<Long> interestNovelIds = new ArrayList<>(novelMap.keySet());
 
+        List<Feed> interestFeeds = feedRepository.findTop10ByNovelIdIn(interestNovelIds);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -15,7 +15,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.websoso.WSSServer.domain.Avatar;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
@@ -25,7 +24,6 @@ import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedInfo;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 import org.websoso.WSSServer.dto.feed.FeedsGetResponse;
-import org.websoso.WSSServer.dto.feed.InterestFeedGetResponse;
 import org.websoso.WSSServer.dto.feed.InterestFeedsGetResponse;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
@@ -212,5 +210,9 @@ public class FeedService {
         List<Long> interestNovelIds = new ArrayList<>(novelMap.keySet());
 
         List<Feed> interestFeeds = feedRepository.findTop10ByNovelIdIn(interestNovelIds);
+        List<Byte> avatarIds = interestFeeds.stream()
+                .map(feed -> feed.getUser().getAvatarId())
+                .distinct()
+                .toList();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -25,6 +25,7 @@ import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedInfo;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 import org.websoso.WSSServer.dto.feed.FeedsGetResponse;
+import org.websoso.WSSServer.dto.feed.InterestFeedGetResponse;
 import org.websoso.WSSServer.dto.feed.InterestFeedsGetResponse;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
@@ -219,5 +220,13 @@ public class FeedService {
                 .stream()
                 .collect(Collectors.toMap(Avatar::getAvatarId, avatar -> avatar));
 
+        List<InterestFeedGetResponse> interestFeedGetResponseList = interestFeeds.stream()
+                .map(feed -> {
+                    Novel novel = novelMap.get(feed.getNovelId());
+                    Avatar avatar = avatarMap.get(feed.getUser().getAvatarId());
+                    return InterestFeedGetResponse.of(novel, feed.getUser(), feed, avatar);
+                })
+                .toList();
+        return InterestFeedsGetResponse.of(interestFeedGetResponseList);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -15,14 +15,18 @@ import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedInfo;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 import org.websoso.WSSServer.dto.feed.FeedsGetResponse;
+import org.websoso.WSSServer.dto.feed.InterestFeedsGetResponse;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
+import org.websoso.WSSServer.repository.AvatarRepository;
 import org.websoso.WSSServer.repository.FeedRepository;
+import org.websoso.WSSServer.repository.UserNovelRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +42,8 @@ public class FeedService {
     private final BlockService blockService;
     private final LikeService likeService;
     private final PopularFeedService popularFeedService;
+    private final UserNovelRepository userNovelRepository;
+    private final AvatarRepository avatarRepository;
 
     public void createFeed(User user, FeedCreateRequest request) {
         if (request.novelId() != null) {
@@ -189,4 +195,10 @@ public class FeedService {
         return feedCategoryService.getFeedsByCategoryLabel(category, lastFeedId, userId, pageRequest);
     }
 
+    public InterestFeedsGetResponse getInterestFeeds(User user) {
+        List<Novel> interestNovels = userNovelRepository.findByUserAndIsInterestTrue(user)
+                .stream()
+                .map(UserNovel::getNovel)
+                .toList();
+    }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#135 -> dev
- close #135

## Key Changes
<!-- 최대한 자세히 -->
- `유저(user)`가 `관심으로 등록(isInterest = true)`한 `작품(novel)`들에 대해 가장 최근에 등록한 `피드(feed)` 10개를 제공하는 API입니다.
- `유저(user)`의 `아바타(avatar)`나 `소설(novel)`에 대한 정보를 가져올 때 DB 접근을 최소화하기 위해 `map(novelMap, avatarMap)`을 사용하여 캐싱하였습니다.
