### PR TITLE
[FEAT] 유저 피드 조회 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
             "/soso-picks",
             "/novels/popular",
             "/feeds",
-            "/feeds/popular"
+            "/feeds/popular",
+            "/users/{userId}/feeds"
     };
 
     @Bean

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -11,12 +11,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.dto.feed.UserFeedsGetResponse;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
 import org.websoso.WSSServer.dto.user.EmailGetResponse;
 import org.websoso.WSSServer.dto.user.LoginResponse;
@@ -25,6 +27,7 @@ import org.websoso.WSSServer.dto.user.NicknameValidation;
 import org.websoso.WSSServer.dto.user.ProfileStatusResponse;
 import org.websoso.WSSServer.dto.user.RegisterUserInfoRequest;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
+import org.websoso.WSSServer.service.FeedService;
 import org.websoso.WSSServer.service.UserNovelService;
 import org.websoso.WSSServer.service.UserService;
 import org.websoso.WSSServer.validation.NicknameConstraint;
@@ -37,6 +40,7 @@ public class UserController {
 
     private final UserService userService;
     private final UserNovelService userNovelService;
+    private final FeedService feedService;
 
     @GetMapping("/nickname/check")
     public ResponseEntity<NicknameValidation> checkNicknameAvailability(Principal principal,
@@ -106,5 +110,18 @@ public class UserController {
         return ResponseEntity
                 .status(OK)
                 .body(userNovelService.getUserNovelStatistics(user));
+    }
+
+    @GetMapping("/{userId}/feeds")
+    public ResponseEntity<UserFeedsGetResponse> getUserFeeds(Principal principal,
+                                                             @PathVariable("userId") Long userId,
+                                                             @RequestParam("lastFeedId") Long lastFeedId,
+                                                             @RequestParam("size") int size) {
+        User visitor = principal == null
+                ? null
+                : userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(OK)
+                .body(feedService.getUserFeeds(visitor, userId, lastFeedId, size));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -26,7 +26,7 @@ public record UserFeedGetResponse(
                 feed.getFeedContent(),
                 feed.getCreatedDate().toLocalDate(),
                 feed.getIsSpoiler(),
-                feed.getCreatedDate().equals(feed.getModifiedDate())
+                !feed.getCreatedDate().equals(feed.getModifiedDate())
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -1,0 +1,32 @@
+package org.websoso.WSSServer.dto.feed;
+
+import java.time.LocalDate;
+import org.websoso.WSSServer.domain.Feed;
+
+public record UserFeedGetResponse(
+        Long feedId,
+        String feedContent,
+        LocalDate createdDate,
+        Boolean isSpoiler,
+        Boolean isModified
+//        List<Long> likerUsers,
+//        Integer likeCount,
+//        Integer commentCount,
+//        Long novelId,
+//        String title,
+//        Float novelRating,
+//        Long novelRatingCount
+//        List<String> relevantCategories
+) {
+
+    public static UserFeedGetResponse of(Feed feed) {
+
+        return new UserFeedGetResponse(
+                feed.getFeedId(),
+                feed.getFeedContent(),
+                feed.getCreatedDate().toLocalDate(),
+                feed.getIsSpoiler(),
+                feed.getCreatedDate().equals(feed.getModifiedDate())
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -14,7 +14,7 @@ public record UserFeedGetResponse(
         Boolean isSpoiler,
         Boolean isModified,
         List<Long> likerUsers,
-//        Boolean isLiked,
+        Boolean isLiked,
         Integer likeCount,
         Integer commentCount,
         Long novelId,
@@ -24,11 +24,12 @@ public record UserFeedGetResponse(
 //        List<String> relevantCategories
 ) {
 
-    public static UserFeedGetResponse of(Feed feed, Novel novel) {
+    public static UserFeedGetResponse of(Feed feed, Novel novel, Long visitorId) {
         boolean isModified = !feed.getCreatedDate().equals(feed.getModifiedDate());
         Long novelRatingCount = getNovelRatingCount(novel);
         Float novelRating = getNovelRating(novel, novelRatingCount);
         List<Long> likeUsers = getLikeUsers(feed);
+        boolean isLiked = likeUsers.contains(visitorId);
 
         return new UserFeedGetResponse(
                 feed.getFeedId(),
@@ -37,6 +38,7 @@ public record UserFeedGetResponse(
                 feed.getIsSpoiler(),
                 isModified,
                 likeUsers,
+                isLiked,
                 feed.getLikes().size(),
                 feed.getComments().size(),
                 novel.getNovelId(),

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -3,6 +3,7 @@ package org.websoso.WSSServer.dto.feed;
 import java.time.LocalDate;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.UserNovel;
 
 public record UserFeedGetResponse(
         Long feedId,
@@ -33,5 +34,26 @@ public record UserFeedGetResponse(
                 novel.getNovelId(),
                 novel.getTitle()
         );
+    }
+
+    private static Long getNovelRatingCount(Novel novel) {
+        return novel.getUserNovels()
+                .stream()
+                .filter(userNovel -> userNovel.getUserNovelRating() != 0.0f)
+                .count();
+    }
+
+    private static Float getNovelRatingSum(Novel novel) {
+        return (float) novel.getUserNovels()
+                .stream()
+                .filter(userNovel -> userNovel.getUserNovelRating() != 0.0f)
+                .mapToDouble(UserNovel::getUserNovelRating)
+                .sum();
+    }
+
+    private static float getNovelRating(Novel novel, Long novelRatingCount) {
+        return novelRatingCount > 0
+                ? getNovelRatingSum(novel) / novelRatingCount
+                : 0.0f;
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -15,15 +15,16 @@ public record UserFeedGetResponse(
 //        Integer likeCount,
 //        Integer commentCount,
         Long novelId,
-        String title
-//        Float novelRating,
-//        Long novelRatingCount
+        String title,
+        Float novelRating,
+        Long novelRatingCount
 //        List<String> relevantCategories
 ) {
 
     public static UserFeedGetResponse of(Feed feed, Novel novel) {
-
         boolean isModified = !feed.getCreatedDate().equals(feed.getModifiedDate());
+        Long novelRatingCount = getNovelRatingCount(novel);
+        Float novelRating = getNovelRating(novel, novelRatingCount);
 
         return new UserFeedGetResponse(
                 feed.getFeedId(),
@@ -32,7 +33,9 @@ public record UserFeedGetResponse(
                 feed.getIsSpoiler(),
                 isModified,
                 novel.getNovelId(),
-                novel.getTitle()
+                novel.getTitle(),
+                novelRating,
+                novelRatingCount
         );
     }
 

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -21,12 +21,14 @@ public record UserFeedGetResponse(
 
     public static UserFeedGetResponse of(Feed feed) {
 
+        boolean isModified = !feed.getCreatedDate().equals(feed.getModifiedDate());
+
         return new UserFeedGetResponse(
                 feed.getFeedId(),
                 feed.getFeedContent(),
                 feed.getCreatedDate().toLocalDate(),
                 feed.getIsSpoiler(),
-                !feed.getCreatedDate().equals(feed.getModifiedDate())
+                isModified
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -2,24 +2,25 @@ package org.websoso.WSSServer.dto.feed;
 
 import java.time.LocalDate;
 import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.Novel;
 
 public record UserFeedGetResponse(
         Long feedId,
         String feedContent,
         LocalDate createdDate,
         Boolean isSpoiler,
-        Boolean isModified
+        Boolean isModified,
 //        List<Long> likerUsers,
 //        Integer likeCount,
 //        Integer commentCount,
-//        Long novelId,
-//        String title,
+        Long novelId,
+        String title
 //        Float novelRating,
 //        Long novelRatingCount
 //        List<String> relevantCategories
 ) {
 
-    public static UserFeedGetResponse of(Feed feed) {
+    public static UserFeedGetResponse of(Feed feed, Novel novel) {
 
         boolean isModified = !feed.getCreatedDate().equals(feed.getModifiedDate());
 
@@ -28,7 +29,9 @@ public record UserFeedGetResponse(
                 feed.getFeedContent(),
                 feed.getCreatedDate().toLocalDate(),
                 feed.getIsSpoiler(),
-                isModified
+                isModified,
+                novel.getNovelId(),
+                novel.getTitle()
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -64,7 +64,7 @@ public record UserFeedGetResponse(
     private static List<Long> getLikeUsers(Feed feed) {
         return feed.getLikes()
                 .stream()
-                .map(Like::getLikeId)
+                .map(Like::getUserId)
                 .toList();
     }
 

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -2,7 +2,9 @@ package org.websoso.WSSServer.dto.feed;
 
 import java.time.LocalDate;
 import java.util.List;
+import org.websoso.WSSServer.domain.Category;
 import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.FeedCategory;
 import org.websoso.WSSServer.domain.Like;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.UserNovel;
@@ -20,8 +22,8 @@ public record UserFeedGetResponse(
         Long novelId,
         String title,
         Float novelRating,
-        Long novelRatingCount
-//        List<String> relevantCategories
+        Long novelRatingCount,
+        List<String> relevantCategories
 ) {
 
     public static UserFeedGetResponse of(Feed feed, Novel novel, Long visitorId) {
@@ -30,6 +32,7 @@ public record UserFeedGetResponse(
         Float novelRating = getNovelRating(novel, novelRatingCount);
         List<Long> likeUsers = getLikeUsers(feed);
         boolean isLiked = likeUsers.contains(visitorId);
+        List<String> relevantCategories = getFeedCategories(feed);
 
         return new UserFeedGetResponse(
                 feed.getFeedId(),
@@ -44,8 +47,18 @@ public record UserFeedGetResponse(
                 novel.getNovelId(),
                 novel.getTitle(),
                 novelRating,
-                novelRatingCount
+                novelRatingCount,
+                relevantCategories
         );
+    }
+
+    private static List<String> getFeedCategories(Feed feed) {
+        return feed.getFeedCategories()
+                .stream()
+                .map(FeedCategory::getCategory)
+                .map(Category::getCategoryName)
+                .map(Enum::name)
+                .toList();
     }
 
     private static List<Long> getLikeUsers(Feed feed) {

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -1,7 +1,9 @@
 package org.websoso.WSSServer.dto.feed;
 
 import java.time.LocalDate;
+import java.util.List;
 import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.Like;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.UserNovel;
 
@@ -11,9 +13,10 @@ public record UserFeedGetResponse(
         LocalDate createdDate,
         Boolean isSpoiler,
         Boolean isModified,
-//        List<Long> likerUsers,
-//        Integer likeCount,
-//        Integer commentCount,
+        List<Long> likerUsers,
+//        Boolean isLiked,
+        Integer likeCount,
+        Integer commentCount,
         Long novelId,
         String title,
         Float novelRating,
@@ -25,6 +28,7 @@ public record UserFeedGetResponse(
         boolean isModified = !feed.getCreatedDate().equals(feed.getModifiedDate());
         Long novelRatingCount = getNovelRatingCount(novel);
         Float novelRating = getNovelRating(novel, novelRatingCount);
+        List<Long> likeUsers = getLikeUsers(feed);
 
         return new UserFeedGetResponse(
                 feed.getFeedId(),
@@ -32,11 +36,21 @@ public record UserFeedGetResponse(
                 feed.getCreatedDate().toLocalDate(),
                 feed.getIsSpoiler(),
                 isModified,
+                likeUsers,
+                feed.getLikes().size(),
+                feed.getComments().size(),
                 novel.getNovelId(),
                 novel.getTitle(),
                 novelRating,
                 novelRatingCount
         );
+    }
+
+    private static List<Long> getLikeUsers(Feed feed) {
+        return feed.getLikes()
+                .stream()
+                .map(Like::getLikeId)
+                .toList();
     }
 
     private static Long getNovelRatingCount(Novel novel) {

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedsGetResponse.java
@@ -1,0 +1,9 @@
+package org.websoso.WSSServer.dto.feed;
+
+import java.util.List;
+
+public record UserFeedsGetResponse(
+        Boolean isLoadable,
+        List<UserFeedGetResponse> feeds
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedsGetResponse.java
@@ -6,4 +6,8 @@ public record UserFeedsGetResponse(
         Boolean isLoadable,
         List<UserFeedGetResponse> feeds
 ) {
+
+    public static UserFeedsGetResponse of(Boolean isLoadable, List<UserFeedGetResponse> userFeedGetResponses) {
+        return new UserFeedsGetResponse(isLoadable, userFeedGetResponses);
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
@@ -27,7 +27,8 @@ public enum CustomUserError implements ICustomError {
     INVALID_GENDER("USER-011", "성별은 M 또는 F여야 합니다.", BAD_REQUEST),
     INVALID_GENDER_NULL("USER-012", "성별은 null일 수 없습니다.", BAD_REQUEST),
     INVALID_GENDER_BLANK("USER-013", "성별은 빈칸일 수 없습니다.", BAD_REQUEST),
-    ALREADY_SET_NICKNAME("USER-014", "닉네임은 이미 설정된 닉네임과 동일합니다.", BAD_REQUEST);
+    ALREADY_SET_NICKNAME("USER-014", "닉네임은 이미 설정된 닉네임과 동일합니다.", BAD_REQUEST),
+    PRIVATE_PROFILE_STATUS("USER-015", "프로필 공개 설정이 비공개이므로 접근할 수 없습니다.", FORBIDDEN);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
@@ -2,8 +2,11 @@ package org.websoso.WSSServer.repository;
 
 import java.util.List;
 import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.User;
 
 public interface FeedCustomRepository {
 
     List<Feed> findPopularFeedsByNovelIds(List<Long> novelIds);
+
+    List<Feed> getFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
@@ -8,5 +8,5 @@ public interface FeedCustomRepository {
 
     List<Feed> findPopularFeedsByNovelIds(List<Long> novelIds);
 
-    List<Feed> getFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size);
+    List<Feed> findFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -35,7 +35,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
     }
 
     @Override
-    public List<Feed> getFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size) {
+    public List<Feed> findFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size) {
         return jpaQueryFactory
                 .selectFrom(feed)
                 .where(

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ package org.websoso.WSSServer.repository;
 import static org.websoso.WSSServer.domain.QFeed.feed;
 import static org.websoso.WSSServer.domain.QLike.like;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Objects;
@@ -11,6 +12,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.User;
 
 @Repository
 @RequiredArgsConstructor
@@ -30,5 +32,25 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
                         .fetchFirst())
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Feed> getFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size) {
+        return jpaQueryFactory
+                .selectFrom(feed)
+                .where(
+                        feed.user.eq(owner),
+                        ltFeedId(lastFeedId)
+                )
+                .orderBy(feed.feedId.desc())
+                .limit(size)
+                .fetch();
+    }
+
+    private BooleanExpression ltFeedId(Long lastFeedId) {
+        if (lastFeedId == 0) {
+            return null;
+        }
+        return feed.feedId.lt(lastFeedId);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -291,9 +291,7 @@ public class FeedService {
                     .collect(Collectors.toMap(Novel::getNovelId, novel -> novel));
 
             List<UserFeedGetResponse> userFeedGetResponseList = feedsByNoOffsetPagination.stream()
-                    .map(feed -> {
-                        return UserFeedGetResponse.of(feed, novelMap.get(feed.getNovelId()), visitorId);
-                    })
+                    .map(feed -> UserFeedGetResponse.of(feed, novelMap.get(feed.getNovelId()), visitorId))
                     .toList();
         }
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -281,7 +281,7 @@ public class FeedService {
                 : visitor.getUserId();
 
         if (owner.getIsProfilePublic() || isOwner) {
-            List<Feed> feedsByNoOffsetPagination = feedRepository.getFeedsByNoOffsetPagination(owner, lastFeedId, size);
+            List<Feed> feedsByNoOffsetPagination = feedRepository.findFeedsByNoOffsetPagination(owner, lastFeedId, size);
 
             List<Long> novelIds = feedsByNoOffsetPagination.stream()
                     .map(Feed::getNovelId)

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -289,7 +289,7 @@ public class FeedService {
 
             List<UserFeedGetResponse> userFeedGetResponseList = feedsByNoOffsetPagination.stream()
                     .map(feed -> {
-                        return UserFeedGetResponse.of(feed);
+                        return UserFeedGetResponse.of(feed, novelMap.get(feed.getNovelId()));
                     })
                     .toList();
         }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -9,6 +9,8 @@ import static org.websoso.WSSServer.exception.error.CustomFeedError.SELF_REPORT_
 import static org.websoso.WSSServer.exception.error.CustomUserError.PRIVATE_PROFILE_STATUS;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -277,6 +279,12 @@ public class FeedService {
         if (owner.getIsProfilePublic() || isOwner) {
             List<Feed> feedsByNoOffsetPagination = feedRepository.getFeedsByNoOffsetPagination(owner, lastFeedId, size);
 
+            List<Long> novelIds = feedsByNoOffsetPagination.stream()
+                    .map(Feed::getNovelId)
+                    .collect(Collectors.toList());
+            Map<Long, Novel> novelMap = novelRepository.findAllById(novelIds)
+                    .stream()
+                    .collect(Collectors.toMap(Novel::getNovelId, novel -> novel));
         }
 
         throw new CustomUserException(PRIVATE_PROFILE_STATUS, "the profile status of the user is set to private");

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -294,6 +294,7 @@ public class FeedService {
                     .map(feed -> UserFeedGetResponse.of(feed, novelMap.get(feed.getNovelId()), visitorId))
                     .toList();
 
+            // TODO Slice의 hasNext()로 판단하도록 수정
             Boolean isLoadable = feedsByNoOffsetPagination.size() == size;
 
             return UserFeedsGetResponse.of(isLoadable, userFeedGetResponseList);

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -275,6 +275,7 @@ public class FeedService {
         boolean isOwner = visitor != null && visitor.getUserId().equals(ownerId);
 
         if (owner.getIsProfilePublic() || isOwner) {
+            List<Feed> feedsByNoOffsetPagination = feedRepository.getFeedsByNoOffsetPagination(owner, lastFeedId, size);
 
         }
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -276,6 +276,9 @@ public class FeedService {
     public UserFeedsGetResponse getUserFeeds(User visitor, Long ownerId, Long lastFeedId, int size) {
         User owner = userService.getUserOrException(ownerId);
         boolean isOwner = visitor != null && visitor.getUserId().equals(ownerId);
+        Long visitorId = visitor == null
+                ? null
+                : visitor.getUserId();
 
         if (owner.getIsProfilePublic() || isOwner) {
             List<Feed> feedsByNoOffsetPagination = feedRepository.getFeedsByNoOffsetPagination(owner, lastFeedId, size);
@@ -289,7 +292,7 @@ public class FeedService {
 
             List<UserFeedGetResponse> userFeedGetResponseList = feedsByNoOffsetPagination.stream()
                     .map(feed -> {
-                        return UserFeedGetResponse.of(feed, novelMap.get(feed.getNovelId()));
+                        return UserFeedGetResponse.of(feed, novelMap.get(feed.getNovelId()), visitorId);
                     })
                     .toList();
         }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -29,6 +29,7 @@ import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedInfo;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 import org.websoso.WSSServer.dto.feed.FeedsGetResponse;
+import org.websoso.WSSServer.dto.feed.UserFeedGetResponse;
 import org.websoso.WSSServer.dto.feed.UserFeedsGetResponse;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseFeedTab;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
@@ -285,6 +286,12 @@ public class FeedService {
             Map<Long, Novel> novelMap = novelRepository.findAllById(novelIds)
                     .stream()
                     .collect(Collectors.toMap(Novel::getNovelId, novel -> novel));
+
+            List<UserFeedGetResponse> userFeedGetResponseList = feedsByNoOffsetPagination.stream()
+                    .map(feed -> {
+                        return UserFeedGetResponse.of(feed);
+                    })
+                    .toList();
         }
 
         throw new CustomUserException(PRIVATE_PROFILE_STATUS, "the profile status of the user is set to private");

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -294,7 +294,9 @@ public class FeedService {
                     .map(feed -> UserFeedGetResponse.of(feed, novelMap.get(feed.getNovelId()), visitorId))
                     .toList();
 
-            return UserFeedsGetResponse.of(userFeedGetResponseList);
+            Boolean isLoadable = feedsByNoOffsetPagination.size() == size;
+
+            return UserFeedsGetResponse.of(isLoadable, userFeedGetResponseList);
         }
 
         throw new CustomUserException(PRIVATE_PROFILE_STATUS, "the profile status of the user is set to private");

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -293,6 +293,8 @@ public class FeedService {
             List<UserFeedGetResponse> userFeedGetResponseList = feedsByNoOffsetPagination.stream()
                     .map(feed -> UserFeedGetResponse.of(feed, novelMap.get(feed.getNovelId()), visitorId))
                     .toList();
+
+            return UserFeedsGetResponse.of(userFeedGetResponseList);
         }
 
         throw new CustomUserException(PRIVATE_PROFILE_STATUS, "the profile status of the user is set to private");

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -6,6 +6,7 @@ import static org.websoso.WSSServer.exception.error.CustomFeedError.BLOCKED_USER
 import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.HIDDEN_FEED_ACCESS;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.SELF_REPORT_NOT_ALLOWED;
+import static org.websoso.WSSServer.exception.error.CustomUserError.PRIVATE_PROFILE_STATUS;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,10 +27,13 @@ import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedInfo;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 import org.websoso.WSSServer.dto.feed.FeedsGetResponse;
+import org.websoso.WSSServer.dto.feed.UserFeedsGetResponse;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseFeedTab;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
+import org.websoso.WSSServer.exception.exception.CustomUserException;
 import org.websoso.WSSServer.repository.FeedRepository;
+import org.websoso.WSSServer.repository.NovelRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -48,6 +52,8 @@ public class FeedService {
     private final CommentService commentService;
     private final ReportedFeedService reportedFeedService;
     private final MessageService messageService;
+    private final UserService userService;
+    private final NovelRepository novelRepository;
 
     public void createFeed(User user, FeedCreateRequest request) {
         if (request.novelId() != null) {
@@ -263,4 +269,15 @@ public class FeedService {
         checkBlockedRelationship(feed.getUser(), user);
     }
 
+    @Transactional(readOnly = true)
+    public UserFeedsGetResponse getUserFeeds(User visitor, Long ownerId, Long lastFeedId, int size) {
+        User owner = userService.getUserOrException(ownerId);
+        boolean isOwner = visitor != null && visitor.getUserId().equals(ownerId);
+
+        if (owner.getIsProfilePublic() || isOwner) {
+
+        }
+
+        throw new CustomUserException(PRIVATE_PROFILE_STATUS, "the profile status of the user is set to private");
+    }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#137 -> dev
- close #137

## Key Changes
<!-- 최대한 자세히 -->
- 유저가 등록한 모든 피드를 no-offset 방식 페이지네이션으로 내려주는 방식입니다.
- 유저가 작성한 피드(feed)를 페이지네이션으로 가져오고, Novel 요소에 빠르게 접근하기 위해 map(novelMap)을 이용했습니다.
- 더 load할 수 있는지를 나타내는 flag인 isLoadable은 client가 요청하는 size와 페이지네이션의 size를 비교하여 판단합니다.
- 페이지네이션 방식은 querydsl로 구현했습니다.