### PR TITLE
[FEAT] 취향 추천 작품 조회 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -16,6 +16,7 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseBasic;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseInfoTab;
 import org.websoso.WSSServer.dto.popularNovel.PopularNovelsGetResponse;
+import org.websoso.WSSServer.dto.userNovel.TasteNovelsGetResponse;
 import org.websoso.WSSServer.service.NovelService;
 import org.websoso.WSSServer.service.UserService;
 
@@ -77,5 +78,13 @@ public class NovelController {
         return ResponseEntity
                 .status(OK)
                 .body(novelService.getTodayPopularNovels());
+    }
+
+    @GetMapping("/taste")
+    public ResponseEntity<TasteNovelsGetResponse> getTasteNovels(Principal principal) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(OK)
+                .body(novelService.getTasteNovels(user));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
@@ -7,8 +7,8 @@ public record TasteNovelGetResponse(
         Long novelId,
         String title,
         String author,
-        String novelImage
-//        Integer interestCount,
+        String novelImage,
+        Integer interestCount
 //        Float novelRating,
 //        Integer novelRatingCount
 ) {
@@ -18,7 +18,8 @@ public record TasteNovelGetResponse(
                 tasteNovel.getNovelId(),
                 tasteNovel.getTitle(),
                 tasteNovel.getAuthor(),
-                tasteNovel.getNovelImage()
+                tasteNovel.getNovelImage(),
+                getInterestCount(tasteNovel)
         );
     }
 

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
@@ -8,18 +8,23 @@ public record TasteNovelGetResponse(
         String title,
         String author,
         String novelImage,
-        Long interestCount
-//        Float novelRating,
-//        Integer novelRatingCount
+        Long interestCount,
+        Float novelRating,
+        Integer novelRatingCount
 ) {
 
     public static TasteNovelGetResponse of(Novel tasteNovel) {
+        Long novelRatingCount = getNovelRatingCount(tasteNovel);
+        Float novelRating = getNovelRating(tasteNovel, novelRatingCount);
+
         return new TasteNovelGetResponse(
                 tasteNovel.getNovelId(),
                 tasteNovel.getTitle(),
                 tasteNovel.getAuthor(),
                 tasteNovel.getNovelImage(),
-                getInterestCount(tasteNovel)
+                getInterestCount(tasteNovel),
+                novelRating,
+                novelRatingCount
         );
     }
 

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.dto.userNovel;
 
 import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.UserNovel;
 
 public record TasteNovelGetResponse(
         Long novelId,
@@ -19,5 +20,12 @@ public record TasteNovelGetResponse(
                 tasteNovel.getAuthor(),
                 tasteNovel.getNovelImage()
         );
+    }
+
+    private static Long getInterestCount(Novel tasteNovel) {
+        return tasteNovel.getUserNovels()
+                .stream()
+                .map(UserNovel::getIsInterest)
+                .count();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
@@ -29,4 +29,25 @@ public record TasteNovelGetResponse(
                 .map(UserNovel::getIsInterest)
                 .count();
     }
+
+    private static Long getNovelRatingCount(Novel tasteNovel) {
+        return tasteNovel.getUserNovels()
+                .stream()
+                .filter(userNovel -> userNovel.getUserNovelRating() != 0.0f)
+                .count();
+    }
+
+    private static Float getNovelRatingSum(Novel tasteNovel) {
+        return (float) tasteNovel.getUserNovels()
+                .stream()
+                .filter(userNovel -> userNovel.getUserNovelRating() != 0.0f)
+                .mapToDouble(UserNovel::getUserNovelRating)
+                .sum();
+    }
+
+    private static float getNovelRating(Novel tasteNovel, Long novelRatingCount) {
+        return novelRatingCount > 0
+                ? getNovelRatingSum(tasteNovel) / novelRatingCount
+                : 0.0f;
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
@@ -1,12 +1,23 @@
 package org.websoso.WSSServer.dto.userNovel;
 
+import org.websoso.WSSServer.domain.Novel;
+
 public record TasteNovelGetResponse(
         Long novelId,
         String title,
         String author,
-        String novelImage,
-        Integer interestCount,
-        Float novelRating,
-        Integer novelRatingCount
+        String novelImage
+//        Integer interestCount,
+//        Float novelRating,
+//        Integer novelRatingCount
 ) {
+
+    public static TasteNovelGetResponse of(Novel tasteNovel) {
+        return new TasteNovelGetResponse(
+                tasteNovel.getNovelId(),
+                tasteNovel.getTitle(),
+                tasteNovel.getAuthor(),
+                tasteNovel.getNovelImage()
+        );
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
@@ -1,0 +1,12 @@
+package org.websoso.WSSServer.dto.userNovel;
+
+public record TasteNovelGetResponse(
+        Long novelId,
+        String title,
+        String author,
+        String novelImage,
+        Integer interestCount,
+        Float novelRating,
+        Integer novelRatingCount
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
@@ -10,7 +10,7 @@ public record TasteNovelGetResponse(
         String novelImage,
         Long interestCount,
         Float novelRating,
-        Integer novelRatingCount
+        Long novelRatingCount
 ) {
 
     public static TasteNovelGetResponse of(Novel tasteNovel) {

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
@@ -8,7 +8,7 @@ public record TasteNovelGetResponse(
         String title,
         String author,
         String novelImage,
-        Integer interestCount
+        Long interestCount
 //        Float novelRating,
 //        Integer novelRatingCount
 ) {

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelsGetResponse.java
@@ -1,0 +1,12 @@
+package org.websoso.WSSServer.dto.userNovel;
+
+import java.util.List;
+
+public record TasteNovelsGetResponse(
+        List<TasteNovelGetResponse> tasteNovels
+) {
+
+    public static TasteNovelsGetResponse of(List<TasteNovelGetResponse> tasteNovelGetResponses) {
+        return new TasteNovelsGetResponse(tasteNovelGetResponses);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepository.java
@@ -2,6 +2,8 @@ package org.websoso.WSSServer.repository;
 
 import java.util.List;
 import org.springframework.data.domain.Pageable;
+import org.websoso.WSSServer.domain.Genre;
+import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
 
@@ -10,4 +12,6 @@ public interface UserNovelCustomRepository {
     UserNovelCountGetResponse findUserNovelStatistics(User user);
 
     List<Long> findTodayPopularNovelsId(Pageable pageable);
+
+    List<Novel> findTasteNovels(List<Genre> preferGenres);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
@@ -67,9 +67,9 @@ public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository 
         return jpaQueryFactory
                 .select(userNovel.novel.novelId)
                 .from(userNovel)
-                .where(userNovel.status.eq(ReadStatus.WATCHING)
+                .where((userNovel.status.eq(ReadStatus.WATCHING)
                         .or(userNovel.status.eq(ReadStatus.WATCHED))
-                        .or(userNovel.isInterest.isTrue())
+                        .or(userNovel.isInterest.isTrue()))
                         .and(userNovel.createdDate.after(sevenDaysAgo.atStartOfDay())))
                 .groupBy(userNovel.novel.novelId)
                 .orderBy(userNovel.count().desc())

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
@@ -23,24 +23,6 @@ public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository 
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<Long> findTodayPopularNovelsId(Pageable pageable) {
-        LocalDate sevenDaysAgo = LocalDate.now().minusDays(7);
-
-        return jpaQueryFactory
-                .select(userNovel.novel.novelId)
-                .from(userNovel)
-                .where(userNovel.status.eq(ReadStatus.WATCHING)
-                        .or(userNovel.status.eq(ReadStatus.WATCHED))
-                        .or(userNovel.isInterest.isTrue())
-                        .and(userNovel.createdDate.after(sevenDaysAgo.atStartOfDay())))
-                .groupBy(userNovel.novel.novelId)
-                .orderBy(userNovel.count().desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-    }
-
-    @Override
     public UserNovelCountGetResponse findUserNovelStatistics(User user) {
         return jpaQueryFactory
                 .select(Projections.constructor(UserNovelCountGetResponse.class,
@@ -72,5 +54,23 @@ public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository 
                 .from(userNovel)
                 .where(userNovel.user.eq(user))
                 .fetchOne();
+    }
+
+    @Override
+    public List<Long> findTodayPopularNovelsId(Pageable pageable) {
+        LocalDate sevenDaysAgo = LocalDate.now().minusDays(7);
+
+        return jpaQueryFactory
+                .select(userNovel.novel.novelId)
+                .from(userNovel)
+                .where(userNovel.status.eq(ReadStatus.WATCHING)
+                        .or(userNovel.status.eq(ReadStatus.WATCHED))
+                        .or(userNovel.isInterest.isTrue())
+                        .and(userNovel.createdDate.after(sevenDaysAgo.atStartOfDay())))
+                .groupBy(userNovel.novel.novelId)
+                .orderBy(userNovel.count().desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
@@ -1,5 +1,7 @@
 package org.websoso.WSSServer.repository;
 
+import static org.websoso.WSSServer.domain.QNovel.novel;
+import static org.websoso.WSSServer.domain.QNovelGenre.novelGenre;
 import static org.websoso.WSSServer.domain.QUserNovel.userNovel;
 import static org.websoso.WSSServer.domain.common.ReadStatus.QUIT;
 import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHED;
@@ -12,6 +14,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.Genre;
+import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.common.ReadStatus;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
@@ -73,4 +77,22 @@ public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository 
                 .limit(pageable.getPageSize())
                 .fetch();
     }
+
+    @Override
+    public List<Novel> findTasteNovels(List<Genre> preferGenres) {
+        return jpaQueryFactory
+                .select(userNovel.novel, userNovel.userNovelId)
+                .distinct()
+                .from(userNovel)
+                .join(userNovel.novel, novel)
+                .join(novelGenre).on(novelGenre.novel.eq(novel))
+                .where(novelGenre.genre.in(preferGenres))
+                .orderBy(userNovel.userNovelId.desc())
+                .limit(10)
+                .fetch()
+                .stream()
+                .map(tuple -> tuple.get(novel))
+                .toList();
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -319,10 +319,10 @@ public class NovelService {
 
         List<Novel> tasteNovels = userNovelRepository.findTasteNovels(preferGenres);
 
-        List<TasteNovelGetResponse> tasteNovelGetResponseList = tasteNovels.stream()
+        List<TasteNovelGetResponse> tasteNovelGetResponses = tasteNovels.stream()
                 .map(TasteNovelGetResponse::of)
                 .toList();
 
-        return TasteNovelsGetResponse.of(tasteNovelGetResponseList);
+        return TasteNovelsGetResponse.of(tasteNovelGetResponses);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -36,6 +36,7 @@ import org.websoso.WSSServer.dto.novel.NovelGetResponseInfoTab;
 import org.websoso.WSSServer.dto.platform.PlatformGetResponse;
 import org.websoso.WSSServer.dto.popularNovel.PopularNovelGetResponse;
 import org.websoso.WSSServer.dto.popularNovel.PopularNovelsGetResponse;
+import org.websoso.WSSServer.dto.userNovel.TasteNovelGetResponse;
 import org.websoso.WSSServer.dto.userNovel.TasteNovelsGetResponse;
 import org.websoso.WSSServer.exception.exception.CustomNovelException;
 import org.websoso.WSSServer.exception.exception.CustomUserNovelException;
@@ -317,6 +318,10 @@ public class NovelService {
                 .toList();
 
         List<Novel> tasteNovels = userNovelRepository.findTasteNovels(preferGenres);
+
+        List<TasteNovelGetResponse> tasteNovelGetResponseList = tasteNovels.stream()
+                .map(TasteNovelGetResponse::of)
+                .toList();
 
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -316,5 +316,7 @@ public class NovelService {
                 .map(GenrePreference::getGenre)
                 .toList();
 
+        List<Novel> tasteNovels = userNovelRepository.findTasteNovels(preferGenres);
+
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -323,5 +323,6 @@ public class NovelService {
                 .map(TasteNovelGetResponse::of)
                 .toList();
 
+        return TasteNovelsGetResponse.of(tasteNovelGetResponseList);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -20,6 +20,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Avatar;
 import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.Genre;
+import org.websoso.WSSServer.domain.GenrePreference;
 import org.websoso.WSSServer.domain.Keyword;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.NovelGenre;
@@ -34,10 +36,12 @@ import org.websoso.WSSServer.dto.novel.NovelGetResponseInfoTab;
 import org.websoso.WSSServer.dto.platform.PlatformGetResponse;
 import org.websoso.WSSServer.dto.popularNovel.PopularNovelGetResponse;
 import org.websoso.WSSServer.dto.popularNovel.PopularNovelsGetResponse;
+import org.websoso.WSSServer.dto.userNovel.TasteNovelsGetResponse;
 import org.websoso.WSSServer.exception.exception.CustomNovelException;
 import org.websoso.WSSServer.exception.exception.CustomUserNovelException;
 import org.websoso.WSSServer.repository.AvatarRepository;
 import org.websoso.WSSServer.repository.FeedRepository;
+import org.websoso.WSSServer.repository.GenrePreferenceRepository;
 import org.websoso.WSSServer.repository.NovelGenreRepository;
 import org.websoso.WSSServer.repository.NovelPlatformRepository;
 import org.websoso.WSSServer.repository.NovelRepository;
@@ -64,6 +68,7 @@ public class NovelService {
     private final UserNovelKeywordRepository userNovelKeywordRepository;
     private final PopularNovelRepository popularNovelRepository;
     private final AvatarRepository avatarRepository;
+    private final GenrePreferenceRepository genrePreferenceRepository;
 
     @Transactional(readOnly = true)
     public Novel getNovelOrException(Long novelId) {
@@ -302,5 +307,14 @@ public class NovelService {
                 })
                 .toList();
         return new PopularNovelsGetResponse(popularNovelResponses);
+    }
+
+    @Transactional(readOnly = true)
+    public TasteNovelsGetResponse getTasteNovels(User user) {
+        List<Genre> preferGenres = genrePreferenceRepository.findByUser(user)
+                .stream()
+                .map(GenrePreference::getGenre)
+                .toList();
+
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#134 -> dev
- close #134

## Key Changes
<!-- 최대한 자세히 -->
- 유저의 취향 장르에 해당하는 소설 중, 가장 최근에 userNovel로 저장된 10개를 내려주는 API입니다.
- DTO에서 novel에 해당하는 userNovel에 대해 처리하는 로직에 중복이 많습니다. 추후 리팩토링하겠습니다..!