### PR TITLE
[FEAT] 유저 장르 취향 조회 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
             "/feeds",
             "/feeds/popular",
             "/users/{userId}/feeds",
-            "/users/profile/{userId}"
+            "/users/profile/{userId}",
+            "/{userId}/preferences/genres"
     };
 
     @Bean

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -29,6 +29,7 @@ import org.websoso.WSSServer.dto.user.ProfileStatusResponse;
 import org.websoso.WSSServer.dto.user.RegisterUserInfoRequest;
 import org.websoso.WSSServer.dto.user.UpdateMyProfileRequest;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
+import org.websoso.WSSServer.dto.userNovel.UserGenrePreferencesGetResponse;
 import org.websoso.WSSServer.dto.userNovel.UserNovelAndNovelsGetResponse;
 import org.websoso.WSSServer.service.FeedService;
 import org.websoso.WSSServer.service.UserNovelService;
@@ -135,7 +136,7 @@ public class UserController {
                 .status(OK)
                 .body(userNovelService.getUserNovelStatistics(user));
     }
-  
+
     @GetMapping("/{userId}/novels")
     public ResponseEntity<UserNovelAndNovelsGetResponse> getUserNovelsAndNovels(Principal principal,
                                                                                 @PathVariable("userId") Long userId,
@@ -151,7 +152,7 @@ public class UserController {
                 .body(userNovelService.getUserNovelsAndNovels(
                         visitor, userId, readStatus, lastUserNovelId, size, sortType));
     }
-  
+
     @GetMapping("/{userId}/feeds")
     public ResponseEntity<UserFeedsGetResponse> getUserFeeds(Principal principal,
                                                              @PathVariable("userId") Long userId,
@@ -163,5 +164,16 @@ public class UserController {
         return ResponseEntity
                 .status(OK)
                 .body(feedService.getUserFeeds(visitor, userId, lastFeedId, size));
+    }
+
+    @GetMapping("/{userId}/preferences/genres")
+    public ResponseEntity<UserGenrePreferencesGetResponse> getUserGenrePreferences(Principal principal,
+                                                                                   @PathVariable("userId") Long ownerId) {
+        User visitor = principal == null
+                ? null
+                : userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(OK)
+                .body(userNovelService.getUserGenrePreferences(visitor, ownerId));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/UserGenrePreferenceGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/UserGenrePreferenceGetResponse.java
@@ -1,8 +1,18 @@
 package org.websoso.WSSServer.dto.userNovel;
 
+import org.websoso.WSSServer.domain.Genre;
+
 public record UserGenrePreferenceGetResponse(
         String genreName,
         String genreImage,
         Long genreCount
 ) {
+
+    public static UserGenrePreferenceGetResponse of(Genre genre, Long genreCount) {
+        return new UserGenrePreferenceGetResponse(
+                genre.getGenreName(),
+                genre.getGenreImage(),
+                genreCount
+        );
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/UserGenrePreferenceGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/UserGenrePreferenceGetResponse.java
@@ -1,0 +1,8 @@
+package org.websoso.WSSServer.dto.userNovel;
+
+public record UserGenrePreferenceGetResponse(
+        String genreName,
+        String genreImage,
+        Long genreCount
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/UserGenrePreferencesGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/UserGenrePreferencesGetResponse.java
@@ -1,0 +1,14 @@
+package org.websoso.WSSServer.dto.userNovel;
+
+import java.util.List;
+import org.websoso.WSSServer.domain.Genre;
+
+public record UserGenrePreferencesGetResponse(
+        List<UserGenrePreferenceGetResponse> genrePreferences
+) {
+
+    public static UserGenrePreferencesGetResponse of(
+            List<UserGenrePreferenceGetResponse> userGenrePreferenceGetResponses) {
+        return new UserGenrePreferencesGetResponse(userGenrePreferenceGetResponses);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/UserGenrePreferencesGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/UserGenrePreferencesGetResponse.java
@@ -1,7 +1,6 @@
 package org.websoso.WSSServer.dto.userNovel;
 
 import java.util.List;
-import org.websoso.WSSServer.domain.Genre;
 
 public record UserGenrePreferencesGetResponse(
         List<UserGenrePreferenceGetResponse> genrePreferences

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
@@ -26,5 +26,5 @@ public interface UserNovelRepository extends JpaRepository<UserNovel, Long>, Use
 
     List<UserNovel> findByUserAndIsInterestTrue(User user);
 
-    List<UserNovel> findNovelByUser(User user);
+    List<UserNovel> findUserNovelByUser(User user);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
@@ -25,4 +25,6 @@ public interface UserNovelRepository extends JpaRepository<UserNovel, Long>, Use
     Integer countByNovelAndUserNovelRatingNot(Novel novel, float ratingToExclude);
 
     List<UserNovel> findByUserAndIsInterestTrue(User user);
+
+    List<UserNovel> findNovelByUser(User user);
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -314,13 +314,13 @@ public class FeedService {
     @Transactional(readOnly = true)
     public UserFeedsGetResponse getUserFeeds(User visitor, Long ownerId, Long lastFeedId, int size) {
         User owner = userService.getUserOrException(ownerId);
-        boolean isOwner = visitor != null && visitor.getUserId().equals(ownerId);
         Long visitorId = visitor == null
                 ? null
                 : visitor.getUserId();
 
-        if (owner.getIsProfilePublic() || isOwner) {
-            List<Feed> feedsByNoOffsetPagination = feedRepository.findFeedsByNoOffsetPagination(owner, lastFeedId, size);
+        if (owner.getIsProfilePublic() || isOwner(visitor, ownerId)) {
+            List<Feed> feedsByNoOffsetPagination = feedRepository.findFeedsByNoOffsetPagination(owner, lastFeedId,
+                    size);
 
             List<Long> novelIds = feedsByNoOffsetPagination.stream()
                     .map(Feed::getNovelId)
@@ -340,5 +340,10 @@ public class FeedService {
         }
 
         throw new CustomUserException(PRIVATE_PROFILE_STATUS, "the profile status of the user is set to private");
+    }
+
+    private static boolean isOwner(User visitor, Long ownerId) {
+        //TODO 현재는 비로그인 회원인 경우
+        return visitor != null && visitor.getUserId().equals(ownerId);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -275,9 +275,7 @@ public class UserNovelService {
 
         if (owner.getIsProfilePublic() || isOwner(visitor, ownerId)) {
             //TODO genreMap은 Genre의 변화가 없다면 매번 repository에서 가져올 필요가 없음 -> 캐싱하여 사용하도록 리팩터링
-            Map<Genre, Long> genreCountMap = genreRepository.findAll()
-                    .stream()
-                    .collect(Collectors.toMap(genre -> genre, genre -> 0L));
+            List<Genre> allGenres = genreRepository.findAll();
 
             Map<Genre, Long> myGenreCountMap = userNovelRepository.findUserNovelByUser(owner)
                     .stream()
@@ -287,7 +285,7 @@ public class UserNovelService {
                     .map(NovelGenre::getGenre)
                     .collect(Collectors.groupingBy(genre -> genre, Collectors.counting()));
 
-            genreCountMap.forEach((genre, count) -> myGenreCountMap.putIfAbsent(genre, 0L));
+            allGenres.forEach(genre -> myGenreCountMap.putIfAbsent(genre, 0L));
 
             List<UserGenrePreferenceGetResponse> genrePreferences = myGenreCountMap.entrySet()
                     .stream()

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -23,6 +23,7 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.domain.UserNovelAttractivePoint;
 import org.websoso.WSSServer.domain.UserNovelKeyword;
+import org.websoso.WSSServer.domain.common.Gender;
 import org.websoso.WSSServer.dto.keyword.KeywordGetResponse;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
 import org.websoso.WSSServer.dto.userNovel.UserGenrePreferenceGetResponse;
@@ -287,9 +288,31 @@ public class UserNovelService {
 
             allGenres.forEach(genre -> myGenreCountMap.putIfAbsent(genre, 0L));
 
+            if (owner.getGender().equals(Gender.M)) {
+                List<Genre> priorityOrder = List.of(
+                                "fantasy", "modernFantasy", "wuxia", "drama", "mystery", "lightNovel", "romance", "romanceFantasy", "BL"
+                        ).stream()
+                        .map(name -> allGenres.stream()
+                                .filter(genre -> genre.getGenreName().equals(name))
+                                .findFirst()
+                                .orElseThrow(() -> new IllegalArgumentException("Invalid genre name: " + name))
+                        )
+                        .toList();
+            }
+            List<Genre> priorityOrder = List.of(
+                            "romance", "romanceFantasy", "fantasy", "modernFantasy", "wuxia", "drama", "mystery", "lightNovel", "BL"
+                    ).stream()
+                    .map(name -> allGenres.stream()
+                            .filter(genre -> genre.getGenreName().equals(name))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalArgumentException("Invalid genre name: " + name))
+                    )
+                    .toList();
+
             List<UserGenrePreferenceGetResponse> genrePreferences = myGenreCountMap.entrySet()
                     .stream()
-                    .sorted(Map.Entry.<Genre, Long>comparingByValue().reversed())
+                    .sorted(Map.Entry.<Genre, Long>comparingByValue().reversed()
+                            .thenComparing(entry -> priorityOrder.indexOf(entry.getKey())))
                     .map(preferGenre -> UserGenrePreferenceGetResponse.of(preferGenre.getKey(), preferGenre.getValue()))
                     .toList();
 
@@ -304,4 +327,3 @@ public class UserNovelService {
         return visitor != null && visitor.getUserId().equals(ownerId);
     }
 }
-

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -287,6 +287,8 @@ public class UserNovelService {
                     .map(NovelGenre::getGenre)
                     .collect(Collectors.groupingBy(genre -> genre, Collectors.counting()));
 
+            genreCountMap.forEach((genre, count) -> myGenreCountMap.putIfAbsent(genre, 0L));
+
         }
 
         throw new CustomUserException(PRIVATE_PROFILE_STATUS, "the profile status of the user is set to private");

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -22,6 +22,7 @@ import org.websoso.WSSServer.domain.UserNovelAttractivePoint;
 import org.websoso.WSSServer.domain.UserNovelKeyword;
 import org.websoso.WSSServer.dto.keyword.KeywordGetResponse;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
+import org.websoso.WSSServer.dto.userNovel.UserGenrePreferencesGetResponse;
 import org.websoso.WSSServer.dto.userNovel.UserNovelAndNovelGetResponse;
 import org.websoso.WSSServer.dto.userNovel.UserNovelAndNovelsGetResponse;
 import org.websoso.WSSServer.dto.userNovel.UserNovelCreateRequest;
@@ -30,6 +31,7 @@ import org.websoso.WSSServer.dto.userNovel.UserNovelUpdateRequest;
 import org.websoso.WSSServer.exception.exception.CustomNovelException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
 import org.websoso.WSSServer.exception.exception.CustomUserNovelException;
+import org.websoso.WSSServer.repository.GenreRepository;
 import org.websoso.WSSServer.repository.NovelRepository;
 import org.websoso.WSSServer.repository.UserNovelAttractivePointRepository;
 import org.websoso.WSSServer.repository.UserNovelKeywordRepository;
@@ -47,6 +49,7 @@ public class UserNovelService {
     private final UserNovelKeywordRepository userNovelKeywordRepository;
     private final AttractivePointService attractivePointService;
     private final UserService userService;
+    private final GenreRepository genreRepository;
 
     @Transactional(readOnly = true)
     public UserNovel getUserNovelOrException(User user, Novel novel) {
@@ -258,6 +261,18 @@ public class UserNovelService {
 
             return UserNovelAndNovelsGetResponse.of(userNovelCount, evaluatedUserNovelRating, isLoadable,
                     userNovelAndNovelGetResponses);
+        }
+
+        throw new CustomUserException(PRIVATE_PROFILE_STATUS, "the profile status of the user is set to private");
+    }
+
+    @Transactional(readOnly = true)
+    public UserGenrePreferencesGetResponse getUserGenrePreferences(User visitor, Long ownerId) {
+        User owner = userService.getUserOrException(ownerId);
+        boolean isOwner = visitor != null && visitor.getUserId().equals(ownerId);
+
+        if (owner.getIsProfilePublic() || isOwner) {
+
         }
 
         throw new CustomUserException(PRIVATE_PROFILE_STATUS, "the profile status of the user is set to private");

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.service;
 
+import static org.websoso.WSSServer.domain.common.Gender.*;
 import static org.websoso.WSSServer.exception.error.CustomGenreError.GENRE_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomNovelError.NOVEL_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomUserError.PRIVATE_PROFILE_STATUS;
@@ -318,7 +319,7 @@ public class UserNovelService {
     }
 
     private List<Genre> getPriorityOrderByGender(Gender gender, List<Genre> allGenres) {
-        List<String> priorityGenreNames = gender.equals(Gender.M)
+        List<String> priorityGenreNames = gender.equals(M)
                 ? priorityGenreNamesOfMale
                 : priorityGenreNamesOfFemale;
 

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -318,17 +318,11 @@ public class UserNovelService {
     }
 
     private List<Genre> getPriorityOrderByGender(Gender gender, List<Genre> allGenres) {
-        if (gender.equals(Gender.M)) {
-            return priorityGenreNamesOfMale.stream()
-                    .map(name -> allGenres.stream()
-                            .filter(genre -> genre.getGenreName().equals(name))
-                            .findFirst()
-                            .orElseThrow(() -> new CustomGenreException(GENRE_NOT_FOUND,
-                                    "genre with the given genreName is not found"))
-                    )
-                    .toList();
-        }
-        return priorityGenreNamesOfFemale.stream()
+        List<String> priorityGenreNames = gender.equals(Gender.M)
+                ? priorityGenreNamesOfMale
+                : priorityGenreNamesOfFemale;
+
+        return priorityGenreNames.stream()
                 .map(name -> allGenres.stream()
                         .filter(genre -> genre.getGenreName().equals(name))
                         .findFirst()

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -279,7 +279,7 @@ public class UserNovelService {
                     .stream()
                     .collect(Collectors.toMap(genre -> genre, genre -> 0L));
 
-            Map<Genre, Long> myGenreCountMap = userNovelRepository.findNovelByUser(owner)
+            Map<Genre, Long> myGenreCountMap = userNovelRepository.findUserNovelByUser(owner)
                     .stream()
                     .map(UserNovel::getNovel)
                     .map(Novel::getNovelGenres)

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -56,6 +56,13 @@ public class UserNovelService {
     private final UserService userService;
     private final GenreRepository genreRepository;
 
+    private static final List<String> priorityGenreNamesOfMale = List.of(
+            "fantasy", "modernFantasy", "wuxia", "drama", "mystery", "lightNovel", "romance", "romanceFantasy", "BL"
+    );
+    private static final List<String> priorityGenreNamesOfFemale = List.of(
+            "romance", "romanceFantasy", "fantasy", "modernFantasy", "wuxia", "drama", "mystery", "lightNovel", "BL"
+    );
+
     @Transactional(readOnly = true)
     public UserNovel getUserNovelOrException(User user, Novel novel) {
         return userNovelRepository.findByNovelAndUser(novel, user).orElseThrow(
@@ -289,9 +296,7 @@ public class UserNovelService {
             allGenres.forEach(genre -> myGenreCountMap.putIfAbsent(genre, 0L));
 
             if (owner.getGender().equals(Gender.M)) {
-                List<Genre> priorityOrder = List.of(
-                                "fantasy", "modernFantasy", "wuxia", "drama", "mystery", "lightNovel", "romance", "romanceFantasy", "BL"
-                        ).stream()
+                List<Genre> priorityOrder = priorityGenreNamesOfMale.stream()
                         .map(name -> allGenres.stream()
                                 .filter(genre -> genre.getGenreName().equals(name))
                                 .findFirst()
@@ -299,9 +304,7 @@ public class UserNovelService {
                         )
                         .toList();
             }
-            List<Genre> priorityOrder = List.of(
-                            "romance", "romanceFantasy", "fantasy", "modernFantasy", "wuxia", "drama", "mystery", "lightNovel", "BL"
-                    ).stream()
+            List<Genre> priorityOrder = priorityGenreNamesOfFemale.stream()
                     .map(name -> allGenres.stream()
                             .filter(genre -> genre.getGenreName().equals(name))
                             .findFirst()

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -18,6 +18,7 @@ import org.websoso.WSSServer.domain.AttractivePoint;
 import org.websoso.WSSServer.domain.Genre;
 import org.websoso.WSSServer.domain.Keyword;
 import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.NovelGenre;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.domain.UserNovelAttractivePoint;
@@ -277,6 +278,14 @@ public class UserNovelService {
             Map<Genre, Long> genreCountMap = genreRepository.findAll()
                     .stream()
                     .collect(Collectors.toMap(genre -> genre, genre -> 0L));
+
+            Map<Genre, Long> myGenreCountMap = userNovelRepository.findNovelByUser(owner)
+                    .stream()
+                    .map(UserNovel::getNovel)
+                    .map(Novel::getNovelGenres)
+                    .flatMap(List::stream)
+                    .map(NovelGenre::getGenre)
+                    .collect(Collectors.groupingBy(genre -> genre, Collectors.counting()));
 
         }
 

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -291,6 +291,7 @@ public class UserNovelService {
 
             List<UserGenrePreferenceGetResponse> genrePreferences = myGenreCountMap.entrySet()
                     .stream()
+                    .sorted(Map.Entry.<Genre, Long>comparingByValue().reversed())
                     .map(preferGenre -> UserGenrePreferenceGetResponse.of(preferGenre.getKey(), preferGenre.getValue()))
                     .toList();
 

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -274,6 +274,7 @@ public class UserNovelService {
         User owner = userService.getUserOrException(ownerId);
 
         if (owner.getIsProfilePublic() || isOwner(visitor, ownerId)) {
+            //TODO genreMap은 Genre의 변화가 없다면 매번 repository에서 가져올 필요가 없음 -> 캐싱하여 사용하도록 리팩터링
             Map<Genre, Long> genreCountMap = genreRepository.findAll()
                     .stream()
                     .collect(Collectors.toMap(genre -> genre, genre -> 0L));

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -8,12 +8,14 @@ import static org.websoso.WSSServer.exception.error.CustomUserNovelError.USER_NO
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.AttractivePoint;
+import org.websoso.WSSServer.domain.Genre;
 import org.websoso.WSSServer.domain.Keyword;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
@@ -272,6 +274,9 @@ public class UserNovelService {
         boolean isOwner = visitor != null && visitor.getUserId().equals(ownerId);
 
         if (owner.getIsProfilePublic() || isOwner) {
+            Map<Genre, Long> genreCountMap = genreRepository.findAll()
+                    .stream()
+                    .collect(Collectors.toMap(genre -> genre, genre -> 0L));
 
         }
 

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -25,6 +25,7 @@ import org.websoso.WSSServer.domain.UserNovelAttractivePoint;
 import org.websoso.WSSServer.domain.UserNovelKeyword;
 import org.websoso.WSSServer.dto.keyword.KeywordGetResponse;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
+import org.websoso.WSSServer.dto.userNovel.UserGenrePreferenceGetResponse;
 import org.websoso.WSSServer.dto.userNovel.UserGenrePreferencesGetResponse;
 import org.websoso.WSSServer.dto.userNovel.UserNovelAndNovelGetResponse;
 import org.websoso.WSSServer.dto.userNovel.UserNovelAndNovelsGetResponse;
@@ -288,6 +289,11 @@ public class UserNovelService {
                     .collect(Collectors.groupingBy(genre -> genre, Collectors.counting()));
 
             genreCountMap.forEach((genre, count) -> myGenreCountMap.putIfAbsent(genre, 0L));
+
+            List<UserGenrePreferenceGetResponse> genrePreferences = myGenreCountMap.entrySet()
+                    .stream()
+                    .map(preferGenre -> UserGenrePreferenceGetResponse.of(preferGenre.getKey(), preferGenre.getValue()))
+                    .toList();
 
         }
 

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -236,9 +236,8 @@ public class UserNovelService {
     public UserNovelAndNovelsGetResponse getUserNovelsAndNovels(User visitor, Long ownerId, String readStatus,
                                                                 Long lastUserNovelId, int size, String sortType) {
         User owner = userService.getUserOrException(ownerId);
-        boolean isOwner = visitor != null && visitor.getUserId().equals(ownerId);
 
-        if (owner.getIsProfilePublic() || isOwner) {
+        if (owner.getIsProfilePublic() || isOwner(visitor, ownerId)) {
             // TODO 성능 개선
             List<UserNovel> userNovelsByUserAndSortType =
                     userNovelRepository.findByUserAndReadStatus(owner, readStatus);
@@ -273,9 +272,8 @@ public class UserNovelService {
     @Transactional(readOnly = true)
     public UserGenrePreferencesGetResponse getUserGenrePreferences(User visitor, Long ownerId) {
         User owner = userService.getUserOrException(ownerId);
-        boolean isOwner = visitor != null && visitor.getUserId().equals(ownerId);
 
-        if (owner.getIsProfilePublic() || isOwner) {
+        if (owner.getIsProfilePublic() || isOwner(visitor, ownerId)) {
             Map<Genre, Long> genreCountMap = genreRepository.findAll()
                     .stream()
                     .collect(Collectors.toMap(genre -> genre, genre -> 0L));
@@ -299,6 +297,11 @@ public class UserNovelService {
         }
 
         throw new CustomUserException(PRIVATE_PROFILE_STATUS, "the profile status of the user is set to private");
+    }
+
+    private static boolean isOwner(User visitor, Long ownerId) {
+        //TODO 현재는 비로그인 회원인 경우
+        return visitor != null && visitor.getUserId().equals(ownerId);
     }
 }
 

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -295,6 +295,7 @@ public class UserNovelService {
                     .map(preferGenre -> UserGenrePreferenceGetResponse.of(preferGenre.getKey(), preferGenre.getValue()))
                     .toList();
 
+            return UserGenrePreferencesGetResponse.of(genrePreferences);
         }
 
         throw new CustomUserException(PRIVATE_PROFILE_STATUS, "the profile status of the user is set to private");

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -297,12 +297,12 @@ public class UserNovelService {
 
             allGenres.forEach(genre -> myGenreCountMap.putIfAbsent(genre, 0L));
 
-            List<Genre> priorityOrder = getPriorityOrderByGender(owner.getGender(), allGenres);
+            List<Genre> priorityOrderByGender = getPriorityOrderByGender(owner.getGender(), allGenres);
 
             List<UserGenrePreferenceGetResponse> genrePreferences = myGenreCountMap.entrySet()
                     .stream()
                     .sorted(Map.Entry.<Genre, Long>comparingByValue().reversed()
-                            .thenComparing(entry -> priorityOrder.indexOf(entry.getKey())))
+                            .thenComparing(entry -> priorityOrderByGender.indexOf(entry.getKey())))
                     .map(preferGenre -> UserGenrePreferenceGetResponse.of(preferGenre.getKey(), preferGenre.getValue()))
                     .toList();
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#143 -> dev
- close #143

## Key Changes
<!-- 최대한 자세히 -->
- 유저가 등록한 userNovel에 해당하는 genre의 취향을 조회하는 api입니다.
- userNovel 리포지토리에서 user에 해당하는 userNovel을 조회하여 가공합니다.
  - 정렬 조건은 1. count, 2. 성별에 따른 우선순위입니다.
  - 자세한 로직은 코드에 코멘트 달아두었습니다!
- Genre를 매번 리포지토리에서 조회하는 로직을 리팩토링 예정입니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- flatMap을 처음 써봤는데 신기하네요 ㅎㅎ