### PR TITLE
[FIX] 닉네임 유효성 검사 API 응답 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -52,7 +52,6 @@ public class UserService {
     public NicknameValidation isNicknameAvailable(User user, String nickname) {
         checkIfAlreadySetOrThrow(user.getNickname(), nickname,
                 ALREADY_SET_NICKNAME, "nickname with given is already set");
-        checkNicknameIfAlreadyExist(nickname);
         if (userRepository.existsByNickname(nickname)) {
             NicknameValidation.of(false);
         }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -53,6 +53,9 @@ public class UserService {
         checkIfAlreadySetOrThrow(user.getNickname(), nickname,
                 ALREADY_SET_NICKNAME, "nickname with given is already set");
         checkNicknameIfAlreadyExist(nickname);
+        if (userRepository.existsByNickname(nickname)) {
+            NicknameValidation.of(false);
+        }
 
         return NicknameValidation.of(true);
     }
@@ -116,7 +119,7 @@ public class UserService {
 
         user.updateUserProfile(updateMyProfileRequest);
     }
-  
+
     @Transactional(readOnly = true)
     public ProfileGetResponse getProfileInfo(User visitor, Long ownerId) {
         User owner = getUserOrException(ownerId);


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#147 -> dev
- close #147

## Key Changes
<!-- 최대한 자세히 -->
nickname validation에서 타인 nickname과 중복일 경우 response 변경

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
닉네임 유효성 검사 API에서

1. wooki가 wooki로 유효성 검사하는 경우 -> 400 Bad Request
2. wooki가 이미 존재하는 nickname인 tuna로 유효성 검사하는 경우 -> 409 Conflict
였는데

`2.` 는 유효성을 검사하는 것일 뿐이지 해당 리소스로 put patch post하는 것이 아니기 때문에 409보다는 200이 좋을 것 같다는 클라의 제안에 수정할 예정입니닷
