### PR TITLE
[FIX] 소소피드 전체 조회 API 호출 시 받는 카테고리 관련 기능 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -120,7 +120,7 @@ public class FeedController {
 
     @GetMapping
     public ResponseEntity<FeedsGetResponse> getFeeds(Principal principal,
-                                                     @RequestParam("category") String category,
+                                                     @RequestParam(value = "category", required = false) String category,
                                                      @RequestParam("lastFeedId") Long lastFeedId,
                                                      @RequestParam("size") int size) {
         User user = principal == null ? null : userService.getUserOrException(Long.valueOf(principal.getName()));


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#153 -> dev
- close #153 

## Key Changes
<!-- 최대한 자세히 -->
해당 API를 기존에 개발할 때 실수를 해서, 소소피드 전체 조회 API 호출 시 받는 카테고리를 전체(default) 일 경우 `all` 로 보내줬어야 했는데,
받지 않을 수 있도록 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
