### PR TITLE
[FIX] QueryDsl 쿼리에서 발생한 NPE 해결

### DIFF
--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
@@ -153,7 +153,7 @@ public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository 
                 .limit(10)
                 .fetch()
                 .stream()
-                .map(tuple -> tuple.get(novel))
+                .map(tuple -> tuple.get(userNovel.novel))
                 .toList();
     }
 }


### PR DESCRIPTION
Tuple에서 userNovel.novel로 명확하게 path 명시

## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#160 -> dev
- close #160

## Key Changes
<!-- 최대한 자세히 -->
- `UserNovelCustomRepositoryImpl`의 `findTasteNovels()` 메서드에서 QueryDsl을 사용하여 List 조회할 때, 쿼리 결과로 반환된 Tuple 객체에서 Novel 객체를 참조하는 부분에서 NPE 발생
- `userNovel.novel`로 path 명시해줌으로써 NPE 해결