### PR TITLE
[FIX] 작품평가에서 키워드 개수 제한 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelCreateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelCreateRequest.java
@@ -31,7 +31,7 @@ public record UserNovelCreateRequest(
         List<String> attractivePoints,
 
         @NotNull(message = "키워드 id는 null일 수 없습니다.")
-        @Size(max = 10, message = "키워드는 최대 10개까지 가능합니다.")
+        @Size(max = 20, message = "키워드는 최대 20개까지 가능합니다.")
         List<Integer> keywordIds
 ) {
     @AssertTrue(message = "종료 날짜는 시작 날짜 이후여야 합니다.")

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelUpdateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelUpdateRequest.java
@@ -28,7 +28,7 @@ public record UserNovelUpdateRequest(
         List<String> attractivePoints,
 
         @NotNull(message = "키워드 id는 null일 수 없습니다.")
-        @Size(max = 10, message = "키워드는 최대 10개까지 가능합니다.")
+        @Size(max = 20, message = "키워드는 최대 20개까지 가능합니다.")
         List<Integer> keywordIds
 ) {
     @AssertTrue(message = "종료 날짜는 시작 날짜 이후여야 합니다.")


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#162 -> dev
- close #162 

## Key Changes
<!-- 최대한 자세히 -->
작품평가 키워드 개수 제한을 10개에서 20개로 수정합니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
