### PR TITLE
[FIX] 작품정보 조회(기본탭) 장르 전달 방식 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/common/GenreName.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/GenreName.java
@@ -7,16 +7,17 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum GenreName {
 
-    RF("romanceFantasy"),
-    RO("romance"),
-    FA("fantasy"),
-    MF("modernFantasy"),
-    DR("drama"),
-    LN("lightNovel"),
-    WU("wuxia"),
-    MY("mystery"),
-    BL("BL");
+    RF("romanceFantasy", "로판"),
+    RO("romance", "로맨스"),
+    FA("fantasy", "판타지"),
+    MF("modernFantasy", "현판"),
+    DR("drama", "드라마"),
+    LN("lightNovel", "라노벨"),
+    WU("wuxia", "무협"),
+    MY("mystery", "미스터리"),
+    BL("BL", "BL");
 
     private final String label;
+    private final String koreanLabel;
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -9,6 +9,7 @@ import static org.websoso.WSSServer.exception.error.CustomUserNovelError.ALREADY
 import static org.websoso.WSSServer.exception.error.CustomUserNovelError.NOT_INTERESTED;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +34,7 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.domain.UserNovelKeyword;
 import org.websoso.WSSServer.domain.common.AttractivePointName;
+import org.websoso.WSSServer.domain.common.GenreName;
 import org.websoso.WSSServer.dto.keyword.KeywordCountGetResponse;
 import org.websoso.WSSServer.dto.novel.FilteredNovelsGetResponse;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseBasic;
@@ -113,18 +115,12 @@ public class NovelService {
     }
 
     private String getKoreanGenreName(String englishGenreName) {
-        return switch (englishGenreName) {
-            case "romance" -> "로맨스";
-            case "romanceFantasy" -> "로판";
-            case "fantasy" -> "판타지";
-            case "modernFantasy" -> "현판";
-            case "wuxia" -> "무협";
-            case "drama" -> "드라마";
-            case "mystery" -> "미스터리";
-            case "lightNovel" -> "라노벨";
-            case "BL" -> "BL";
-            default -> throw new CustomGenreException(GENRE_NOT_FOUND, "genre with the given genreName is not found");
-        };
+        return Arrays.stream(GenreName.values())
+                .filter(genreName -> genreName.getLabel().equalsIgnoreCase(englishGenreName))
+                .findFirst()
+                .map(GenreName::getKoreanLabel)
+                .orElseThrow(
+                        () -> new CustomGenreException(GENRE_NOT_FOUND, "Genre with the given genreName is not found"));
     }
 
     private String getRandomNovelGenreImage(List<NovelGenre> novelGenres) {

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -3,6 +3,7 @@ package org.websoso.WSSServer.service;
 import static org.websoso.WSSServer.domain.common.ReadStatus.QUIT;
 import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHED;
 import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHING;
+import static org.websoso.WSSServer.exception.error.CustomGenreError.GENRE_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomNovelError.NOVEL_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomUserNovelError.ALREADY_INTERESTED;
 import static org.websoso.WSSServer.exception.error.CustomUserNovelError.NOT_INTERESTED;
@@ -43,6 +44,7 @@ import org.websoso.WSSServer.dto.popularNovel.PopularNovelGetResponse;
 import org.websoso.WSSServer.dto.popularNovel.PopularNovelsGetResponse;
 import org.websoso.WSSServer.dto.userNovel.TasteNovelGetResponse;
 import org.websoso.WSSServer.dto.userNovel.TasteNovelsGetResponse;
+import org.websoso.WSSServer.exception.exception.CustomGenreException;
 import org.websoso.WSSServer.exception.exception.CustomNovelException;
 import org.websoso.WSSServer.exception.exception.CustomUserNovelException;
 import org.websoso.WSSServer.repository.AvatarRepository;
@@ -106,8 +108,23 @@ public class NovelService {
 
     private String getNovelGenreNames(List<NovelGenre> novelGenres) {
         return novelGenres.stream()
-                .map(novelGenre -> novelGenre.getGenre().getGenreName())
+                .map(novelGenre -> getKoreanGenreName(novelGenre.getGenre().getGenreName()))
                 .collect(Collectors.joining("/"));
+    }
+
+    private String getKoreanGenreName(String englishGenreName) {
+        return switch (englishGenreName) {
+            case "romance" -> "로맨스";
+            case "romanceFantasy" -> "로판";
+            case "fantasy" -> "판타지";
+            case "modernFantasy" -> "현판";
+            case "wuxia" -> "무협";
+            case "drama" -> "드라마";
+            case "mystery" -> "미스터리";
+            case "lightNovel" -> "라노벨";
+            case "BL" -> "BL";
+            default -> throw new CustomGenreException(GENRE_NOT_FOUND, "genre with the given genreName is not found");
+        };
     }
 
     private String getRandomNovelGenreImage(List<NovelGenre> novelGenres) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#168 -> dev
- close #168 

## Key Changes
<!-- 최대한 자세히 -->
현재 api 명세서와 다르게 영어로 장르명을 전달 해 한국어로 변환하는 과정을 추가하였습니다.
ex) 기존: "romance/romanceFantasy" -> 수정 후: "로맨스/로판"

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
