### PR TITLE
[REFACTOR] 피드 엔티티 생성/수정 시간 기록 방식 수동으로 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -19,16 +20,16 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicInsert;
 import org.websoso.WSSServer.domain.common.Action;
-import org.websoso.WSSServer.domain.common.BaseEntity;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
 
 @Getter
 @DynamicInsert
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Feed extends BaseEntity {
+public class Feed {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -44,8 +45,16 @@ public class Feed extends BaseEntity {
     @Column
     private Long novelId;
 
-    @Column(columnDefinition = "Boolean default false", nullable = false)
+    @Column(nullable = false)
     private Boolean isSpoiler;
+
+    @CreationTimestamp
+    @Column(nullable = false)
+    private LocalDateTime createdDate;
+
+    @CreationTimestamp
+    @Column(nullable = false)
+    private LocalDateTime modifiedDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -75,6 +84,7 @@ public class Feed extends BaseEntity {
         this.feedContent = feedContent;
         this.isSpoiler = isSpoiler;
         this.novelId = novelId;
+        this.modifiedDate = LocalDateTime.now();
     }
 
     public void validateUserAuthorization(User user, Action action) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- refactor/#171 -> dev
- close #171

## Key Changes
<!-- 최대한 자세히 -->
기존 `Feed` 엔티티는 `BaseEntity` 클래스를 상속받아 생성시간과 수정시간을 자동으로 관리하고 있었는데, `isHidden` 과 같은 엔티티 부가 속성을 수정할 시 수정시간이 변경되는 논리 오류가 있어, `BaseEntity` 클래스 상속을 제거하고 수동으로 생성시간과 수정시간을 기록할 수 있도록 로직을 변경하였습니다.

기존 feed를 생성할 때는 `@CreationTimestamp` 어노테이션을 사용하여 자동으로 생성한 일시를 저장하게 했고,
수정시간인 `modifiedDate` 는 피드를 업데이트(즉, 내용 수정) 을 할 때만 그 당시 시간을 저장하도록 로직을 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
https://jeongkyun-it.tistory.com/178