### PR TITLE
[FEAT] 신고 숨김 처리 시 디스코드 알람 발송 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -83,13 +83,17 @@ public class CommentService {
 
         reportedCommentService.createReportedComment(comment, user, reportedType);
 
-        if (reportedCommentService.shouldHideComment(comment, reportedType)) {
+        int reportedCount = reportedCommentService.getReportedCountByReportedType(comment, reportedType);
+        boolean shouldHide = reportedCount >= 3;
+
+        if (shouldHide) {
             comment.hideComment();
         }
 
         messageService.sendDiscordWebhookMessage(
                 DiscordWebhookMessage.of(
-                        MessageFormatter.formatCommentReportMessage(comment, reportedType, commentCreatedUser)));
+                        MessageFormatter.formatCommentReportMessage(comment, reportedType, commentCreatedUser,
+                                reportedCount, shouldHide)));
     }
 
     private Comment getCommentOrException(Long commentId) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -185,12 +185,16 @@ public class FeedService {
 
         reportedFeedService.createReportedFeed(feed, user, reportedType);
 
-        if (reportedFeedService.shouldHideFeed(feed, reportedType)) {
+        int reportedCount = reportedFeedService.getReportedCountByReportedType(feed, reportedType);
+        boolean shouldHide = reportedCount >= 3;
+
+        if (shouldHide) {
             feed.hideFeed();
         }
 
         messageService.sendDiscordWebhookMessage(
-                DiscordWebhookMessage.of(MessageFormatter.formatFeedReportMessage(feed, reportedType)));
+                DiscordWebhookMessage.of(
+                        MessageFormatter.formatFeedReportMessage(feed, reportedType, reportedCount, shouldHide)));
     }
 
     public void reportComment(User user, Long feedId, Long commentId, ReportedType reportedType) {

--- a/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
@@ -16,34 +16,48 @@ public class MessageFormatter {
                     "[신고된 피드 작성자]\n" +
                     "유저 아이디 : %d\n" +
                     "유저 닉네임 : %s\n\n" +
-                    "[신고된 피드 내용]\n%s\n```";
+                    "[신고된 피드 내용]\n%s\n\n" +
+                    "[신고 횟수]\n총 신고 횟수 %d회.\n" +
+                    "%s\n```";
 
     private static final String COMMENT_REPORT_MESSAGE =
             "```[%s] 피드 댓글 %s 신고가 접수되었습니다.\n\n" +
                     "[신고된 댓글 작성자]\n" +
                     "유저 아이디 : %d\n" +
                     "유저 닉네임 : %s\n\n" +
-                    "[신고된 댓글 내용]\n%s\n```";
+                    "[신고된 댓글 내용]\n%s\n\n" +
+                    "[신고 횟수]\n총 신고 횟수 %d회.\n" +
+                    "%s\n```";
 
-    public static String formatFeedReportMessage(Feed feed, ReportedType reportedType) {
+    public static String formatFeedReportMessage(Feed feed, ReportedType reportedType, int reportedCount,
+                                                 boolean isHidden) {
+        String hiddenMessage = isHidden ? "해당 피드는 숨김 처리되었습니다." : "해당 피드는 숨김 처리되지 않았습니다.";
+
         return String.format(
                 FEED_REPORT_MESSAGE,
                 LocalDateTime.now().format(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT)),
                 reportedType.getDescription(),
                 feed.getUser().getUserId(),
                 feed.getUser().getNickname(),
-                feed.getFeedContent()
+                feed.getFeedContent(),
+                reportedCount,
+                hiddenMessage
         );
     }
 
-    public static String formatCommentReportMessage(Comment comment, ReportedType reportedType, User user) {
+    public static String formatCommentReportMessage(Comment comment, ReportedType reportedType, User user,
+                                                    int reportedCount, boolean isHidden) {
+        String hiddenMessage = isHidden ? "해당 댓글은 숨김 처리되었습니다." : "해당 댓글는 숨김 처리되지 않았습니다.";
+
         return String.format(
                 COMMENT_REPORT_MESSAGE,
                 LocalDateTime.now().format(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT)),
                 reportedType.getDescription(),
                 user.getUserId(),
                 user.getNickname(),
-                comment.getCommentContent()
+                comment.getCommentContent(),
+                reportedCount,
+                hiddenMessage
         );
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/ReportedCommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/ReportedCommentService.java
@@ -27,8 +27,8 @@ public class ReportedCommentService {
         reportedCommentRepository.save(ReportedComment.create(comment, user, reportedType));
     }
 
-    public boolean shouldHideComment(Comment comment, ReportedType reportedType) {
-        return reportedCommentRepository.countByCommentAndReportedType(comment, reportedType) >= 3;
+    public int getReportedCountByReportedType(Comment comment, ReportedType reportedType) {
+        return reportedCommentRepository.countByCommentAndReportedType(comment, reportedType);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/service/ReportedFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/ReportedFeedService.java
@@ -27,8 +27,8 @@ public class ReportedFeedService {
         reportedFeedRepository.save(ReportedFeed.create(feed, user, reportedType));
     }
 
-    public boolean shouldHideFeed(Feed feed, ReportedType reportedType) {
-        return reportedFeedRepository.countByFeedAndReportedType(feed, reportedType) >= 3;
+    public int getReportedCountByReportedType(Feed feed, ReportedType reportedType) {
+        return reportedFeedRepository.countByFeedAndReportedType(feed, reportedType);
     }
 
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#170 -> dev
- close #170

## Key Changes
<!-- 최대한 자세히 -->
피드 글과 댓글에 대해 신고 누적 3회가 접수되었을 시 해당 글/댓글을 숨김 처리하고,
해당 숨김에 대해 디스코드 알람 발송에 대한 요구사항이 있어, 해당 기능 구현하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
