### PR TITLE
[FIX] 관심글 조회 API 케이스 분류

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedsGetResponse.java
@@ -1,14 +1,10 @@
 package org.websoso.WSSServer.dto.feed;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 
 public record InterestFeedsGetResponse(
         List<InterestFeedGetResponse> recommendFeeds,
 
-        @JsonInclude(NON_NULL)
         String message
 ) {
 

--- a/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedsGetResponse.java
@@ -8,10 +8,6 @@ public record InterestFeedsGetResponse(
         String message
 ) {
 
-    public static InterestFeedsGetResponse of(List<InterestFeedGetResponse> interestFeedGetResponses) {
-        return new InterestFeedsGetResponse(interestFeedGetResponses, null);
-    }
-
     public static InterestFeedsGetResponse of(List<InterestFeedGetResponse> interestFeedGetResponses, String message) {
         return new InterestFeedsGetResponse(interestFeedGetResponses, message);
     }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedsGetResponse.java
@@ -1,9 +1,13 @@
 package org.websoso.WSSServer.dto.feed;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.List;
 
 public record InterestFeedsGetResponse(
         List<InterestFeedGetResponse> recommendFeeds,
+
+        @JsonInclude(Include.NON_NULL)
         String message
 ) {
 

--- a/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedsGetResponse.java
@@ -3,10 +3,15 @@ package org.websoso.WSSServer.dto.feed;
 import java.util.List;
 
 public record InterestFeedsGetResponse(
-        List<InterestFeedGetResponse> recommendFeeds
+        List<InterestFeedGetResponse> recommendFeeds,
+        String message
 ) {
 
     public static InterestFeedsGetResponse of(List<InterestFeedGetResponse> interestFeedGetResponses) {
-        return new InterestFeedsGetResponse(interestFeedGetResponses);
+        return new InterestFeedsGetResponse(interestFeedGetResponses, null);
+    }
+
+    public static InterestFeedsGetResponse of(List<InterestFeedGetResponse> interestFeedGetResponses, String message) {
+        return new InterestFeedsGetResponse(interestFeedGetResponses, message);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedsGetResponse.java
@@ -1,13 +1,14 @@
 package org.websoso.WSSServer.dto.feed;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.List;
 
 public record InterestFeedsGetResponse(
         List<InterestFeedGetResponse> recommendFeeds,
 
-        @JsonInclude(Include.NON_NULL)
+        @JsonInclude(NON_NULL)
         String message
 ) {
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -280,6 +280,11 @@ public class FeedService {
         List<Long> interestNovelIds = new ArrayList<>(novelMap.keySet());
 
         List<Feed> interestFeeds = feedRepository.findTop10ByNovelIdInOrderByFeedIdDesc(interestNovelIds);
+
+        if (interestFeeds.isEmpty()) {
+            return InterestFeedsGetResponse.of(Collections.emptyList(), "NO_ASSOCIATED_FEEDS");
+        }
+
         Set<Byte> avatarIds = interestFeeds.stream()
                 .map(feed -> feed.getUser().getAvatarId())
                 .collect(Collectors.toSet());

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -299,7 +299,7 @@ public class FeedService {
                     return InterestFeedGetResponse.of(novel, feed.getUser(), feed, avatar);
                 })
                 .toList();
-        return InterestFeedsGetResponse.of(interestFeedGetResponses);
+        return InterestFeedsGetResponse.of(interestFeedGetResponses, "");
     }
 
     public NovelGetResponseFeedTab getFeedsByNovel(User user, Long novelId, Long lastFeedId, int size) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -9,6 +9,7 @@ import static org.websoso.WSSServer.exception.error.CustomFeedError.SELF_REPORT_
 import static org.websoso.WSSServer.exception.error.CustomUserError.PRIVATE_PROFILE_STATUS;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -268,6 +269,10 @@ public class FeedService {
                 .stream()
                 .map(UserNovel::getNovel)
                 .toList();
+
+        if (interestNovels.isEmpty()) {
+            return InterestFeedsGetResponse.of(Collections.emptyList(), "NO_INTEREST_NOVELS");
+        }
 
         Map<Long, Novel> novelMap = interestNovels
                 .stream()


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#176 -> dev
- close #176

## Key Changes
<!-- 최대한 자세히 -->
- 관심글 조회 시, 빈 배열을 내려주는 경우가 2가지인데, 케이스별로 응답을 분리했습니다.
  - 관심 소설이 없는 경우
  - 관심 소설은 있지만, 연관된 피드가 없는 경우

---
<img width="395" alt="스크린샷 2024-09-12 14 10 43" src="https://github.com/user-attachments/assets/598ec2d2-2e99-4169-83c7-93923f159987">
