### PR TITLE
[FIX] 관심으로 userNovel 등록 시 작품정보 기본탭 조회 오류 해결

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponseBasic.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponseBasic.java
@@ -58,7 +58,7 @@ public record NovelGetResponseBasic(
                 novelRatingCount,
                 feedCount,
                 userNovel.getUserNovelRating(),
-                userNovel.getStatus().name(),
+                userNovel.getStatus() == null ? null : userNovel.getStatus().name(),
                 userNovel.getStartDate() != null ? userNovel.getStartDate().toString() : null,
                 userNovel.getEndDate() != null ? userNovel.getEndDate().toString() : null,
                 userNovel.getIsInterest()

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponseBasic.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelGetResponseBasic.java
@@ -59,8 +59,8 @@ public record NovelGetResponseBasic(
                 feedCount,
                 userNovel.getUserNovelRating(),
                 userNovel.getStatus() == null ? null : userNovel.getStatus().name(),
-                userNovel.getStartDate() != null ? userNovel.getStartDate().toString() : null,
-                userNovel.getEndDate() != null ? userNovel.getEndDate().toString() : null,
+                userNovel.getStartDate() == null ? null : userNovel.getStartDate().toString(),
+                userNovel.getEndDate() == null ? null : userNovel.getEndDate().toString(),
                 userNovel.getIsInterest()
         );
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#184 -> dev
- close #184 

## Key Changes
<!-- 최대한 자세히 -->
관심만으로 userNovel을 등록할 시 작품정보 기본탭 조회의 `userNovel.getStatus().name()` 부분에서 NullPointerException이 처져서 해결하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
