### PR TITLE
[FIX] 취향 추천 작품 조회 시 novel 중복 제거

### DIFF
--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
@@ -144,16 +144,16 @@ public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository 
     public List<Novel> findTasteNovels(List<Genre> preferGenres) {
         return jpaQueryFactory
                 .select(userNovel.novel, userNovel.userNovelId)
-                .distinct()
                 .from(userNovel)
                 .join(userNovel.novel, novel)
                 .join(novelGenre).on(novelGenre.novel.eq(novel))
                 .where(novelGenre.genre.in(preferGenres))
                 .orderBy(userNovel.userNovelId.desc())
-                .limit(10)
                 .fetch()
                 .stream()
                 .map(tuple -> tuple.get(userNovel.novel))
+                .distinct()
+                .limit(10)
                 .toList();
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#174 -> dev
- close #174

## Key Changes
<!-- 최대한 자세히 -->
- 선호 장르에 해당하는 소설 중 최신순 10개를 중복없이 가져와야 했지만 distinct 순서때문에 중복해서 가져오는 오류를 수정
  - distinct를 jpa에서 stream으로 이동하여 해결했습니다.