### PR TITLE
[FIX] 유저 피드 조회 시 발생하는 NPE 해결

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -44,8 +44,10 @@ public record UserFeedGetResponse(
                 isLiked,
                 feed.getLikes().size(),
                 feed.getComments().size(),
-                novel.getNovelId(),
-                novel.getTitle(),
+                novel == null ?
+                        null : novel.getNovelId(),
+                novel == null ?
+                        null : novel.getTitle(),
                 novelRating,
                 novelRatingCount,
                 relevantCategories
@@ -69,6 +71,9 @@ public record UserFeedGetResponse(
     }
 
     private static Long getNovelRatingCount(Novel novel) {
+        if (novel == null) {
+            return null;
+        }
         return novel.getUserNovels()
                 .stream()
                 .filter(userNovel -> userNovel.getUserNovelRating() != 0.0f)
@@ -76,6 +81,10 @@ public record UserFeedGetResponse(
     }
 
     private static Float getNovelRatingSum(Novel novel) {
+        if (novel == null) {
+            return null;
+        }
+
         return (float) novel.getUserNovels()
                 .stream()
                 .filter(userNovel -> userNovel.getUserNovelRating() != 0.0f)
@@ -83,7 +92,10 @@ public record UserFeedGetResponse(
                 .sum();
     }
 
-    private static float getNovelRating(Novel novel, Long novelRatingCount) {
+    private static Float getNovelRating(Novel novel, Long novelRatingCount) {
+        if (novel == null) {
+            return null;
+        }
         return novelRatingCount > 0
                 ? getNovelRatingSum(novel) / novelRatingCount
                 : 0.0f;

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -333,8 +333,8 @@ public class FeedService {
                 : visitor.getUserId();
 
         if (owner.getIsProfilePublic() || isOwner(visitor, ownerId)) {
-            List<Feed> feedsByNoOffsetPagination = feedRepository.findFeedsByNoOffsetPagination(owner, lastFeedId,
-                    size);
+            List<Feed> feedsByNoOffsetPagination =
+                    feedRepository.findFeedsByNoOffsetPagination(owner, lastFeedId, size);
 
             List<Long> novelIds = feedsByNoOffsetPagination.stream()
                     .map(Feed::getNovelId)

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -338,6 +339,7 @@ public class FeedService {
 
             List<Long> novelIds = feedsByNoOffsetPagination.stream()
                     .map(Feed::getNovelId)
+                    .filter(Objects::nonNull)
                     .collect(Collectors.toList());
             Map<Long, Novel> novelMap = novelRepository.findAllById(novelIds)
                     .stream()


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#187 -> dev
- close #187

## Key Changes
<!-- 최대한 자세히 -->
- 유저의 feed에 연결된 novel이 없을 때, novel = null인데, 이때 novel에 접근하여 발생하는 NPE를 해결했습니다.
- 추가로 feed에 연결된 novel 정보를 임시 저장하기 위해 얻어낸 novelIds에 null을 제외했습니다. (굳이 필요없기 때문)