### PR TITLE
[FIX] 소소피드 댓글 목록 필터링 로직 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/Comment.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Comment.java
@@ -41,6 +41,9 @@ public class Comment extends BaseEntity {
     @Column(nullable = false)
     private Long userId;
 
+    @Column(columnDefinition = "Boolean default false", nullable = false)
+    private Boolean isSpoiler;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_id", nullable = false)
     private Feed feed;
@@ -75,5 +78,9 @@ public class Comment extends BaseEntity {
 
     public void hideComment() {
         this.isHidden = true;
+    }
+
+    public void spoiler() {
+        this.isSpoiler = true;
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
@@ -22,12 +22,18 @@ public record CommentGetResponse(
     public static CommentGetResponse of(UserBasicInfo userBasicInfo, Comment comment, Boolean isMyComment,
                                         Boolean isSpoiler, Boolean isBlocked, Boolean isHidden) {
         return new CommentGetResponse(
-                isBlocked ? null : userBasicInfo.userId(),
-                isBlocked ? null : userBasicInfo.nickname(),
+                isBlocked
+                        ? null
+                        : userBasicInfo.userId(),
+                isBlocked
+                        ? null
+                        : userBasicInfo.nickname(),
                 userBasicInfo.avatarImage(),
                 comment.getCommentId(),
                 comment.getCreatedDate().toLocalDate(),
-                isBlocked || isHidden ? null : comment.getCommentContent(),
+                isBlocked || isHidden
+                        ? null
+                        : comment.getCommentContent(),
                 !comment.getCreatedDate().equals(comment.getModifiedDate()),
                 isMyComment,
                 isSpoiler,

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
@@ -22,9 +22,9 @@ public record CommentGetResponse(
     public static CommentGetResponse of(UserBasicInfo userBasicInfo, Comment comment, Boolean isMyComment,
                                         Boolean isSpoiler, Boolean isBlocked, Boolean isHidden) {
         return new CommentGetResponse(
-                isBlocked ? 0 : userBasicInfo.userId(),
-                isBlocked ? "none" : userBasicInfo.nickname(),
-                isBlocked ? "none" : userBasicInfo.avatarImage(),
+                isBlocked ? null : userBasicInfo.userId(),
+                isBlocked ? null : userBasicInfo.nickname(),
+                isBlocked ? null : userBasicInfo.avatarImage(),
                 comment.getCommentId(),
                 comment.getCreatedDate().toLocalDate(),
                 comment.getCommentContent(),

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
@@ -27,7 +27,7 @@ public record CommentGetResponse(
                 userBasicInfo.avatarImage(),
                 comment.getCommentId(),
                 comment.getCreatedDate().toLocalDate(),
-                comment.getCommentContent(),
+                isBlocked || isHidden ? null : comment.getCommentContent(),
                 !comment.getCreatedDate().equals(comment.getModifiedDate()),
                 isMyComment,
                 isSpoiler,

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
@@ -14,18 +14,25 @@ public record CommentGetResponse(
         LocalDate createdDate,
         String commentContent,
         Boolean isModified,
-        Boolean isMyComment
+        Boolean isMyComment,
+        Boolean isSpoiler,
+        Boolean isBlocked,
+        Boolean isHidden
 ) {
-    public static CommentGetResponse of(UserBasicInfo userBasicInfo, Comment comment, Boolean isMyComment) {
+    public static CommentGetResponse of(UserBasicInfo userBasicInfo, Comment comment, Boolean isMyComment,
+                                        Boolean isSpoiler, Boolean isBlocked, Boolean isHidden) {
         return new CommentGetResponse(
-                userBasicInfo.userId(),
-                userBasicInfo.nickname(),
-                userBasicInfo.avatarImage(),
+                isBlocked ? 0 : userBasicInfo.userId(),
+                isBlocked ? "none" : userBasicInfo.nickname(),
+                isBlocked ? "none" : userBasicInfo.avatarImage(),
                 comment.getCommentId(),
                 comment.getCreatedDate().toLocalDate(),
                 comment.getCommentContent(),
                 !comment.getCreatedDate().equals(comment.getModifiedDate()),
-                isMyComment
+                isMyComment,
+                isSpoiler,
+                isBlocked,
+                isHidden
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
@@ -24,7 +24,7 @@ public record CommentGetResponse(
         return new CommentGetResponse(
                 isBlocked ? null : userBasicInfo.userId(),
                 isBlocked ? null : userBasicInfo.nickname(),
-                isBlocked ? null : userBasicInfo.avatarImage(),
+                userBasicInfo.avatarImage(),
                 comment.getCommentId(),
                 comment.getCreatedDate().toLocalDate(),
                 comment.getCommentContent(),

--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentsGetResponse.java
@@ -6,9 +6,9 @@ public record CommentsGetResponse(
         Integer commentsCount,
         List<CommentGetResponse> comments
 ) {
-    public static CommentsGetResponse of(Integer commentsCount, List<CommentGetResponse> comments) {
+    public static CommentsGetResponse of(final List<CommentGetResponse> comments) {
         return new CommentsGetResponse(
-                commentsCount,
+                comments.size(),
                 comments
         );
     }

--- a/src/main/java/org/websoso/WSSServer/service/BlockService.java
+++ b/src/main/java/org/websoso/WSSServer/service/BlockService.java
@@ -73,4 +73,8 @@ public class BlockService {
         return blockRepository.existsByTwoUserId(firstUserId, secondUserId);
     }
 
+    public boolean isBlocked(Long blockingId, Long blockedId) {
+        return blockRepository.existsByBlockingIdAndBlockedId(blockingId, blockedId);
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -64,7 +64,7 @@ public class CommentService {
                         entry.getKey(),
                         isUserCommentOwner(entry.getValue(), user),
                         entry.getKey().getIsSpoiler(),
-                        isBlocked(entry.getValue(), user),
+                        isBlocked(user, entry.getValue()),
                         entry.getKey().getIsHidden()))
                 .toList();
 
@@ -116,7 +116,8 @@ public class CommentService {
         return createdUser.equals(user);
     }
 
-    private Boolean isBlocked(User createdFeedUser, User user) {
-        return blockService.isBlockedRelationship(user.getUserId(), createdFeedUser.getUserId());
+    private Boolean isBlocked(User user, User createdFeedUser) {
+        return blockService.isBlocked(user.getUserId(), createdFeedUser.getUserId());
     }
+
 }

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -2,6 +2,8 @@ package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.domain.common.Action.DELETE;
 import static org.websoso.WSSServer.domain.common.Action.UPDATE;
+import static org.websoso.WSSServer.domain.common.ReportedType.IMPERTINENCE;
+import static org.websoso.WSSServer.domain.common.ReportedType.SPOILER;
 import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomCommentError.SELF_REPORT_NOT_ALLOWED;
 
@@ -53,21 +55,20 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public CommentsGetResponse getComments(User user, Feed feed) {
-        List<Comment> comments = feed.getComments();
-
-        List<CommentGetResponse> responses = comments
+        List<CommentGetResponse> responses = feed.getComments()
                 .stream()
                 .map(comment -> new AbstractMap.SimpleEntry<>(
-                        comment, userService.getUserOrException(comment.getUserId())
-                ))
-                .filter(entry -> !entry.getKey().getIsHidden() && !isBlocked(entry.getValue(), user))
+                        comment, userService.getUserOrException(comment.getUserId())))
                 .map(entry -> CommentGetResponse.of(
                         getUserBasicInfo(entry.getValue()),
                         entry.getKey(),
-                        isUserCommentOwner(entry.getValue(), user)))
+                        isUserCommentOwner(entry.getValue(), user),
+                        entry.getKey().getIsSpoiler(),
+                        isBlocked(entry.getValue(), user),
+                        entry.getKey().getIsHidden()))
                 .toList();
 
-        return CommentsGetResponse.of(comments.size(), responses);
+        return CommentsGetResponse.of(responses);
     }
 
     public void createReportedComment(Feed feed, Long commentId, User user, ReportedType reportedType) {
@@ -87,7 +88,11 @@ public class CommentService {
         boolean shouldHide = reportedCount >= 3;
 
         if (shouldHide) {
-            comment.hideComment();
+            if (reportedType.equals(SPOILER)) {
+                comment.spoiler();
+            } else if (reportedType.equals(IMPERTINENCE)) {
+                comment.hideComment();
+            }
         }
 
         messageService.sendDiscordWebhookMessage(

--- a/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
@@ -1,5 +1,8 @@
 package org.websoso.WSSServer.service;
 
+import static org.websoso.WSSServer.domain.common.ReportedType.IMPERTINENCE;
+import static org.websoso.WSSServer.domain.common.ReportedType.SPOILER;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import org.websoso.WSSServer.domain.Comment;
@@ -47,7 +50,14 @@ public class MessageFormatter {
 
     public static String formatCommentReportMessage(Comment comment, ReportedType reportedType, User user,
                                                     int reportedCount, boolean isHidden) {
-        String hiddenMessage = isHidden ? "해당 댓글은 숨김 처리되었습니다." : "해당 댓글는 숨김 처리되지 않았습니다.";
+        String hiddenMessage = "해당 댓글은 현재 숨김 처리되지 않은 상태입니다.";
+        if (isHidden) {
+            if (reportedType.equals(SPOILER)) {
+                hiddenMessage = "해당 댓글은 스포일러 댓글로 지정되었습니다.";
+            } else if (reportedType.equals(IMPERTINENCE)) {
+                hiddenMessage = "해당 댓글은 부적절한 내용으로 인해 숨김 처리되었습니다.";
+            }
+        }
 
         return String.format(
                 COMMENT_REPORT_MESSAGE,


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#182 -> dev
- close #182

## Key Changes
<!-- 최대한 자세히 -->
이슈 내용과 같이 요구사항이 변경되어, 소소피드 댓글의 필터링 로직을 수정했습니다.

### 주요 변경사항
- `comment` 엔티티에 `isSpoiler` 속성이 추가됨.  -> 피드와 동일하게 `스포일러 댓글` 정책이 추가되었기 때문입니다.
- 피드의 댓글을 조회할 때, 특정 조건에 따라 댓글을 응답에서 제외하지 않고 모든 댓글을 응답하도록 변경됨. -> 특정 조건(차단, 숨김, 스포일러)을 만족하는 댓글을 아예 안보이는 것이 아닌, 가려놓는 식으로 요구사항이 변경되었기 때문입니다.
<br>

**변경된 댓글 목록 필터링 요구사항**
- 내가 차단한 유저의 댓글은 유저 정보와 댓글 내용을 가린다.(프로필 이미지 제외)
- 스포일러가 포함된 댓글은 isSpoiler 컬럼을 통해 댓글 내용을 1번 숨긴다.
- 부적절 신고의 누적으로 숨김 처리된 댓글은 댓글 내용을 가린다.


## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
x

## References
<!-- 참고한 자료-->
x