### PR TITLE
[FIX] 피드 엔티티 생성 시 생성,수정 시간 저장 방식 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -20,7 +20,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicInsert;
 import org.websoso.WSSServer.domain.common.Action;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
@@ -48,11 +47,9 @@ public class Feed {
     @Column(nullable = false)
     private Boolean isSpoiler;
 
-    @CreationTimestamp
     @Column(nullable = false)
     private LocalDateTime createdDate;
 
-    @CreationTimestamp
     @Column(nullable = false)
     private LocalDateTime modifiedDate;
 
@@ -78,6 +75,8 @@ public class Feed {
         this.isSpoiler = isSpoiler;
         this.novelId = novelId;
         this.user = user;
+        this.createdDate = LocalDateTime.now();
+        this.modifiedDate = this.createdDate;
     }
 
     public void updateFeed(String feedContent, Boolean isSpoiler, Long novelId) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#199 -> dev
- close #199

## Key Changes
<!-- 최대한 자세히 -->
이슈에 나온대로, 피드 엔티티 생성 시 생성시간과 수정시간과 미세한 오차가 발생하여,
피드 엔티티 생성 시 생성,수정 시간의 저장 방식을 변경하였습니다. (`@CreationTimestamp` -> `직접 넣어주는 방식`)

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
