### PR TITLE
[FIX] 유저 등록 작품 수 조회 기능 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -133,7 +133,7 @@ public class UserController {
                 .build();
     }
 
-    @GetMapping("/user-novel-stats")
+    @GetMapping("/{userId}/user-novel-stats")
     public ResponseEntity<UserNovelCountGetResponse> getUserNovelStatistics(Principal principal) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -134,10 +134,10 @@ public class UserController {
     }
 
     @GetMapping("/{userId}/user-novel-stats")
-    public ResponseEntity<UserNovelCountGetResponse> getUserNovelStatistics() {
+    public ResponseEntity<UserNovelCountGetResponse> getUserNovelStatistics(@PathVariable("userId") Long userId) {
         return ResponseEntity
                 .status(OK)
-                .body(userNovelService.getUserNovelStatistics(user));
+                .body(userNovelService.getUserNovelStatistics(userId));
     }
 
     @GetMapping("/{userId}/novels")

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -134,8 +134,7 @@ public class UserController {
     }
 
     @GetMapping("/{userId}/user-novel-stats")
-    public ResponseEntity<UserNovelCountGetResponse> getUserNovelStatistics(Principal principal) {
-        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+    public ResponseEntity<UserNovelCountGetResponse> getUserNovelStatistics() {
         return ResponseEntity
                 .status(OK)
                 .body(userNovelService.getUserNovelStatistics(user));

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepository.java
@@ -10,7 +10,7 @@ import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
 
 public interface UserNovelCustomRepository {
 
-    UserNovelCountGetResponse findUserNovelStatistics(User user);
+    UserNovelCountGetResponse findUserNovelStatistics(Long userId);
 
     List<Long> findTodayPopularNovelsId(Pageable pageable);
 

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
@@ -30,7 +30,7 @@ public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository 
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public UserNovelCountGetResponse findUserNovelStatistics(User user) {
+    public UserNovelCountGetResponse findUserNovelStatistics(Long userId) {
         return jpaQueryFactory
                 .select(Projections.constructor(UserNovelCountGetResponse.class,
                         userNovel.isInterest
@@ -59,7 +59,7 @@ public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository 
                                 .coalesce(0)
                 ))
                 .from(userNovel)
-                .where(userNovel.user.eq(user))
+                .where(userNovel.user.userId.eq(userId))
                 .fetchOne();
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -228,8 +228,8 @@ public class UserNovelService {
     }
 
     @Transactional(readOnly = true)
-    public UserNovelCountGetResponse getUserNovelStatistics(User user) {
-        return userNovelRepository.findUserNovelStatistics(user);
+    public UserNovelCountGetResponse getUserNovelStatistics(Long ownerId) {
+        return userNovelRepository.findUserNovelStatistics(ownerId);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#202 -> dev
- close #202

## Key Changes
<!-- 최대한 자세히 -->
- 유저가 등록한 작품 수를 조회하는 엔드포인트를 변경했습니다.
  - 변경 전: /users/user-novel-stats
  - 변경 후: /users/{userId}/user-novel-stats
- 로그인 중인 유저의 정보를 가져올 필요가 없어서 Principal 관련 로직을 삭제했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- QA 중에 머지해서 죄송합니다..!
- 수정 중에 확인해보니 로그인 중인 유저의 정보를 가져오지 않아도 되는 경우가 많은 것 같습니다...!! 리팩터링이 필요할 듯 하네용