### PR TITLE
[FIX] 피드 댓글 조회 API nullable 컴포넌트 제거

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
@@ -22,18 +22,12 @@ public record CommentGetResponse(
     public static CommentGetResponse of(UserBasicInfo userBasicInfo, Comment comment, Boolean isMyComment,
                                         Boolean isSpoiler, Boolean isBlocked, Boolean isHidden) {
         return new CommentGetResponse(
-                isBlocked
-                        ? null
-                        : userBasicInfo.userId(),
-                isBlocked
-                        ? null
-                        : userBasicInfo.nickname(),
+                userBasicInfo.userId(),
+                userBasicInfo.nickname(),
                 userBasicInfo.avatarImage(),
                 comment.getCommentId(),
                 comment.getCreatedDate().toLocalDate(),
-                isBlocked || isHidden
-                        ? null
-                        : comment.getCommentContent(),
+                comment.getCommentContent(),
                 !comment.getCreatedDate().equals(comment.getModifiedDate()),
                 isMyComment,
                 isSpoiler,


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#204 -> dev
- close #204

## Key Changes
<!-- 최대한 자세히 -->
피드 댓글 조회 API 응답값 중 차단, 숨김 여부에 따라 컴포넌트에 null 값이 들어갈 경우가 있었는데,
안드 클라이언트 측에서 해당 null값에 대한 사이드 이펙트 발생 문제를 말씀해주셔서 해당 컴포넌트들을 non-nullable 하게 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
