### PR TITLE
[FIX] 사용자 닉네임 검사 정규식 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
@@ -29,7 +29,6 @@ public class SecurityConfig {
 
     private final String[] permitAllPaths = {
             "/users/login",
-            "/users/nickname/check",
             "/actuator/health",
             "/novels",
             "/novels/{novelId}",

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
@@ -18,7 +18,7 @@ public enum CustomUserError implements ICustomError {
     INVALID_NICKNAME_BLANK("USER-002", "닉네임은 빈칸일 수 없습니다.", BAD_REQUEST),
     INVALID_NICKNAME_START_OR_END_WITH_BLANK("USER-003", "닉네임은 공백으로 시작하거나 끝날 수 없습니다.", BAD_REQUEST),
     INVALID_NICKNAME_LENGTH("USER-004", "닉네임의 길이가 2 ~ 10자가 아닙니다.", BAD_REQUEST),
-    INVALID_NICKNAME_PATTERN("USER-005", "닉네임은 한글, 영문, 숫자, 특수문자(-, _)로만 이루어져아 합니다.", BAD_REQUEST),
+    INVALID_NICKNAME_PATTERN("USER-005", "닉네임은 완성된 한글, 영문, 숫자로만 이루어져야 합니다.", BAD_REQUEST),
     USER_NOT_FOUND("USER-006", "해당 ID를 가진 사용자를 찾을 수 없습니다.", NOT_FOUND),
     INVALID_AUTHORIZED("USER-007", "사용자에게 권한이 없습니다.", FORBIDDEN),
     INVALID_USER_ID("USER-008", "유효하지 않은 ID입니다.", BAD_REQUEST),

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
@@ -16,7 +16,7 @@ public enum CustomUserError implements ICustomError {
 
     INVALID_NICKNAME_NULL("USER-001", "닉네임은 null일 수 없습니다.", BAD_REQUEST),
     INVALID_NICKNAME_BLANK("USER-002", "닉네임은 빈칸일 수 없습니다.", BAD_REQUEST),
-    INVALID_NICKNAME_START_OR_END_WITH_BLANK("USER-003", "닉네임은 공백으로 시작하거나 끝날 수 없습니다.", BAD_REQUEST),
+    INVALID_NICKNAME_CONTAINS_WHITESPACE("USER-003", "닉네임에 공백이 포함될 수 없습니다.", BAD_REQUEST),
     INVALID_NICKNAME_LENGTH("USER-004", "닉네임의 길이가 2 ~ 10자가 아닙니다.", BAD_REQUEST),
     INVALID_NICKNAME_PATTERN("USER-005", "닉네임은 완성된 한글, 영문, 숫자로만 이루어져야 합니다.", BAD_REQUEST),
     USER_NOT_FOUND("USER-006", "해당 ID를 가진 사용자를 찾을 수 없습니다.", NOT_FOUND),

--- a/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
+++ b/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
@@ -15,7 +15,7 @@ import org.websoso.WSSServer.exception.exception.CustomUserException;
 @Component
 public class NicknameValidator implements ConstraintValidator<NicknameConstraint, String> {
 
-    private static final Pattern NICKNAME_REGEX = Pattern.compile("^\\s*[가-힣a-zA-Z0-9-_]*\\s*$");
+    private static final Pattern NICKNAME_REGEX = Pattern.compile("^\\s*[가-힣a-zA-Z0-9]*\\s*$");
 
     @Override
     public void initialize(NicknameConstraint nickname) {

--- a/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
+++ b/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
@@ -10,6 +10,7 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
 
 @Component
@@ -29,7 +30,7 @@ public class NicknameValidator implements ConstraintValidator<NicknameConstraint
         if (nickname.isBlank()) {
             throw new CustomUserException(INVALID_NICKNAME_BLANK, "nickname cannot be blank");
         }
-        if (nickname.contains(" ")) {
+        if (StringUtils.containsWhitespace(nickname)) {
             throw new CustomUserException(INVALID_NICKNAME_CONTAINS_WHITESPACE, "nickname cannot contain whitespace");
         }
         if (!(nickname.length() >= 2 && nickname.length() <= 10)) {

--- a/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
+++ b/src/main/java/org/websoso/WSSServer/validation/NicknameValidator.java
@@ -1,10 +1,10 @@
 package org.websoso.WSSServer.validation;
 
 import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_NICKNAME_BLANK;
+import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_NICKNAME_CONTAINS_WHITESPACE;
 import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_NICKNAME_LENGTH;
 import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_NICKNAME_NULL;
 import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_NICKNAME_PATTERN;
-import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_NICKNAME_START_OR_END_WITH_BLANK;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
@@ -29,9 +29,8 @@ public class NicknameValidator implements ConstraintValidator<NicknameConstraint
         if (nickname.isBlank()) {
             throw new CustomUserException(INVALID_NICKNAME_BLANK, "nickname cannot be blank");
         }
-        if (nickname.startsWith(" ") || nickname.endsWith(" ")) {
-            throw new CustomUserException(INVALID_NICKNAME_START_OR_END_WITH_BLANK,
-                    "nickname cannot start or end with whitespace");
+        if (nickname.contains(" ")) {
+            throw new CustomUserException(INVALID_NICKNAME_CONTAINS_WHITESPACE, "nickname cannot contain whitespace");
         }
         if (!(nickname.length() >= 2 && nickname.length() <= 10)) {
             throw new CustomUserException(INVALID_NICKNAME_LENGTH, "nickname must be 2 to 10 characters long");


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#210 -> dev
- close #210

## Key Changes
<!-- 최대한 자세히 -->
이슈에 나와있는 것처럼 사용자 닉네임 정책이 변경되어 알맞게 사용자 닉네임 검사의 정규식및 관련 로직을 변경했습니다.

+닉네임 유효성 검사 API가 기존 유저 액세스 토큰을 필수로 받지 않도록 되어있어, 필수로 받도록 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
