### PR TITLE
[FIX] 애플 로그인 API 수정 (Email 관련)

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -52,7 +52,7 @@ public class User {
     @Column(columnDefinition = "varchar(60) default '안녕하세요'", nullable = false)
     private String intro;
 
-    @Column(columnDefinition = "varchar(320)", nullable = false)
+    @Column(columnDefinition = "varchar(320)")
     private String email;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/websoso/WSSServer/dto/auth/AppleLoginRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/auth/AppleLoginRequest.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.dto.auth;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
@@ -7,6 +8,7 @@ public record AppleLoginRequest(
         @NotBlank(message = "사용자 고유 식별자는 null 이거나, 공백일 수 없습니다.")
         String userIdentifier,
         @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
+        @Nullable
         String email
 ) {
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#214 -> dev
- close #214

## Key Changes
<!-- 최대한 자세히 -->
- `User` 엔티티의 `email` 필드의 속성을 nullable로 변경
- 애플 소셜 로그인 시 이메일이 없는 사용자가 있을 수 있어, 애플 소셜 로그인 Request DTO의 `email` 필드의 속성을 nullable로 변경
  - 이메일이 없는 경우 `email` 필드를 null로 저장합니다.
  - 기획과의 논의 결과, 해당 상황에서 이메일이 나오는 UI는 이메일이 아예 표시되지 않도록 결정되었습니다~!

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
