### PR TITLE
[FEAT] 카카오 로그아웃 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -52,7 +52,7 @@ public class AuthController {
                 .body(appleService.getUserInfoFromApple(request));
     }
 
-    @PostMapping("/logout")
+    @PostMapping("/auth/logout/kakao")
     public ResponseEntity<Void> kakaoLogout(Principal principal) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         kakaoService.kakaoLogout(user);

--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.controller;
 
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 import jakarta.validation.Valid;
@@ -47,5 +48,14 @@ public class AuthController {
         return ResponseEntity
                 .status(OK)
                 .body(appleService.getUserInfoFromApple(request));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> kakaoLogout() {
+
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
+        // TODO redis에서 refreshToken 삭제
     }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -62,6 +62,5 @@ public class AuthController {
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();
-        // TODO redis에서 refreshToken 삭제
     }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -4,12 +4,14 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 import jakarta.validation.Valid;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.auth.AppleLoginRequest;
 import org.websoso.WSSServer.dto.auth.AuthResponse;
 import org.websoso.WSSServer.dto.auth.ReissueRequest;
@@ -51,8 +53,9 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> kakaoLogout() {
-
+    public ResponseEntity<Void> kakaoLogout(Principal principal) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        kakaoService.kakaoLogout(user);
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();

--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -16,6 +16,7 @@ import org.websoso.WSSServer.dto.auth.ReissueResponse;
 import org.websoso.WSSServer.oauth2.service.AppleService;
 import org.websoso.WSSServer.oauth2.service.KakaoService;
 import org.websoso.WSSServer.service.AuthService;
+import org.websoso.WSSServer.service.UserService;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +25,7 @@ public class AuthController {
     private final AuthService authService;
     private final KakaoService kakaoService;
     private final AppleService appleService;
+    private final UserService userService;
 
     @PostMapping("/reissue")
     public ResponseEntity<ReissueResponse> reissue(@RequestBody ReissueRequest reissueRequest) {

--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.auth.AppleLoginRequest;
 import org.websoso.WSSServer.dto.auth.AuthResponse;
+import org.websoso.WSSServer.dto.auth.LogoutRequest;
 import org.websoso.WSSServer.dto.auth.ReissueRequest;
 import org.websoso.WSSServer.dto.auth.ReissueResponse;
 import org.websoso.WSSServer.oauth2.service.AppleService;
@@ -53,9 +54,11 @@ public class AuthController {
     }
 
     @PostMapping("/auth/logout/kakao")
-    public ResponseEntity<Void> kakaoLogout(Principal principal) {
+    public ResponseEntity<Void> kakaoLogout(Principal principal,
+                                            @RequestBody LogoutRequest logoutRequest) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
-        kakaoService.kakaoLogout(user);
+        String refreshToken = logoutRequest.refreshToken();
+        kakaoService.kakaoLogout(user, refreshToken);
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();

--- a/src/main/java/org/websoso/WSSServer/dto/auth/LogoutRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/auth/LogoutRequest.java
@@ -1,0 +1,6 @@
+package org.websoso.WSSServer.dto.auth;
+
+public record LogoutRequest(
+        String refreshToken
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -35,6 +35,9 @@ public class KakaoService {
     @Value("${kakao.logout-url}")
     private String kakaoLogoutUrl;
 
+    @Value("${kakao.admin-key}")
+    private String kakaoAdminKey;
+
     public AuthResponse getUserInfoFromKakao(String kakaoAccessToken) {
         RestClient restClient = RestClient.create();
 

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.websoso.WSSServer.config.jwt.JwtProvider;
 import org.websoso.WSSServer.config.jwt.UserAuthentication;
@@ -79,12 +81,16 @@ public class KakaoService {
         String socialId = user.getSocialId();
         String kakaoUserInfoId = socialId.replaceFirst("kakao_", "");
 
+        MultiValueMap<String, String> logoutInfoBodies = new LinkedMultiValueMap<>();
+        logoutInfoBodies.add("target_id_type", "user_id");
+        logoutInfoBodies.add("target_id", kakaoUserInfoId);
+
         RestClient restClient = RestClient.create();
         restClient.post()
                 .uri(kakaoLogoutUrl)
                 .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded")
                 .header(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoAdminKey)
-                .body("target_id_type=user_id&target_id=" + kakaoUserInfoId)
+                .body(logoutInfoBodies)
                 .retrieve()
                 .toBodilessEntity();
     }

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -77,7 +77,9 @@ public class KakaoService {
         return AuthResponse.of(accessToken, refreshToken, isRegister);
     }
 
-    public void kakaoLogout(User user) {
+    public void kakaoLogout(User user, String refreshToken) {
+        refreshTokenRepository.findByRefreshToken(refreshToken).ifPresent(refreshTokenRepository::delete);
+
         String socialId = user.getSocialId();
         String kakaoUserInfoId = socialId.replaceFirst("kakao_", "");
 

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -92,6 +92,10 @@ public class KakaoService {
                 .header(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoAdminKey)
                 .body(logoutInfoBodies)
                 .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+                    throw new CustomKakaoException(INVALID_KAKAO_ACCESS_TOKEN,
+                            "Invalid access token for Kakao logout");
+                })
                 .toBodilessEntity();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -74,4 +74,9 @@ public class KakaoService {
 
         return AuthResponse.of(accessToken, refreshToken, isRegister);
     }
+
+    public void kakaoLogout(User user) {
+        String socialId = user.getSocialId();
+        String kakaoUserInfoId = socialId.replaceFirst("kakao_", "");
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -32,6 +32,9 @@ public class KakaoService {
     @Value("${kakao.user-info-url}")
     private String kakaoUserInfoUrl;
 
+    @Value("${kakao.logout-url}")
+    private String kakaoLogoutUrl;
+
     public AuthResponse getUserInfoFromKakao(String kakaoAccessToken) {
         RestClient restClient = RestClient.create();
 

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -96,6 +96,10 @@ public class KakaoService {
                     throw new CustomKakaoException(INVALID_KAKAO_ACCESS_TOKEN,
                             "Invalid access token for Kakao logout");
                 })
+                .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                    throw new CustomKakaoException(KAKAO_SERVER_ERROR,
+                            "Kakao server error during logout");
+                })
                 .toBodilessEntity();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -78,5 +78,14 @@ public class KakaoService {
     public void kakaoLogout(User user) {
         String socialId = user.getSocialId();
         String kakaoUserInfoId = socialId.replaceFirst("kakao_", "");
+
+        RestClient restClient = RestClient.create();
+        restClient.post()
+                .uri(kakaoLogoutUrl)
+                .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .header(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoAdminKey)
+                .body("target_id_type=user_id&target_id=" + kakaoUserInfoId)
+                .retrieve()
+                .toBodilessEntity();
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#178 -> dev
- close #178

## Key Changes
<!-- 최대한 자세히 -->
- 카카오 API 통신으로 소셜 로그아웃
- 레디스에서 refresh token 삭제와 함께 웹소소 로그아웃