### PR TITLE
[FEAT] 카카오 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -17,6 +17,7 @@ import org.websoso.WSSServer.dto.auth.AuthResponse;
 import org.websoso.WSSServer.dto.auth.LogoutRequest;
 import org.websoso.WSSServer.dto.auth.ReissueRequest;
 import org.websoso.WSSServer.dto.auth.ReissueResponse;
+import org.websoso.WSSServer.dto.user.WithdrawalRequest;
 import org.websoso.WSSServer.oauth2.service.AppleService;
 import org.websoso.WSSServer.oauth2.service.KakaoService;
 import org.websoso.WSSServer.service.AuthService;
@@ -65,7 +66,8 @@ public class AuthController {
     }
 
     @PostMapping("/auth/withdraw/kakao")
-    public ResponseEntity<Void> withdrawUser(Principal principal) {
+    public ResponseEntity<Void> withdrawUser(Principal principal,
+                                             @RequestBody WithdrawalRequest withdrawalRequest) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
                 .status(NO_CONTENT)

--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -69,7 +69,8 @@ public class AuthController {
     public ResponseEntity<Void> withdrawUser(Principal principal,
                                              @Valid @RequestBody WithdrawalRequest withdrawalRequest) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
-        kakaoService.unlinkFromKakao(user);
+        String refreshToken = withdrawalRequest.refreshToken();
+        kakaoService.unlinkFromKakao(user, refreshToken);
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();

--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -69,6 +69,7 @@ public class AuthController {
     public ResponseEntity<Void> withdrawUser(Principal principal,
                                              @Valid @RequestBody WithdrawalRequest withdrawalRequest) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        kakaoService.unlinkFromKakao(user);
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();

--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -65,7 +65,7 @@ public class AuthController {
                 .build();
     }
 
-    @PostMapping("/auth/withdraw/kakao")
+    @PostMapping("/auth/withdraw")
     public ResponseEntity<Void> withdrawUser(Principal principal,
                                              @Valid @RequestBody WithdrawalRequest withdrawalRequest) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));

--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -67,7 +67,7 @@ public class AuthController {
 
     @PostMapping("/auth/withdraw/kakao")
     public ResponseEntity<Void> withdrawUser(Principal principal,
-                                             @RequestBody WithdrawalRequest withdrawalRequest) {
+                                             @Valid @RequestBody WithdrawalRequest withdrawalRequest) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
                 .status(NO_CONTENT)

--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -63,4 +63,12 @@ public class AuthController {
                 .status(NO_CONTENT)
                 .build();
     }
+
+    @PostMapping("/auth/withdraw/kakao")
+    public ResponseEntity<Void> withdrawUser(Principal principal) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/user/WithdrawalRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/WithdrawalRequest.java
@@ -1,6 +1,9 @@
 package org.websoso.WSSServer.dto.user;
 
+import jakarta.validation.constraints.Size;
+
 public record WithdrawalRequest(
+        @Size(max = 80, message = "탈퇴 사유는 80자를 초과할 수 없습니다.")
         String reason,
 
         String refreshToken

--- a/src/main/java/org/websoso/WSSServer/dto/user/WithdrawalRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/WithdrawalRequest.java
@@ -1,11 +1,13 @@
 package org.websoso.WSSServer.dto.user;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record WithdrawalRequest(
         @Size(max = 80, message = "탈퇴 사유는 80자를 초과할 수 없습니다.")
         String reason,
 
+        @NotBlank
         String refreshToken
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/user/WithdrawalRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/WithdrawalRequest.java
@@ -1,0 +1,8 @@
+package org.websoso.WSSServer.dto.user;
+
+public record WithdrawalRequest(
+        String reason,
+
+        String refreshToken
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -40,6 +40,9 @@ public class KakaoService {
     @Value("${kakao.admin-key}")
     private String kakaoAdminKey;
 
+    @Value("${kakao.unlink-url}")
+    private String kakaoUnlinkUrl;
+
     public AuthResponse getUserInfoFromKakao(String kakaoAccessToken) {
         RestClient restClient = RestClient.create();
 

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -107,4 +107,8 @@ public class KakaoService {
                 })
                 .toBodilessEntity();
     }
+
+    public void unlinkFromKakao(User user) {
+        userRepository.delete(user);
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -127,6 +127,10 @@ public class KakaoService {
                 .header(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoAdminKey)
                 .body(withdrawInfoBodies)
                 .retrieve()
+                .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                    throw new CustomKakaoException(KAKAO_SERVER_ERROR,
+                            "Kakao server error during logout");
+                })
                 .toBodilessEntity();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -108,7 +108,8 @@ public class KakaoService {
                 .toBodilessEntity();
     }
 
-    public void unlinkFromKakao(User user) {
+    public void unlinkFromKakao(User user, String refreshToken) {
+        refreshTokenRepository.findByRefreshToken(refreshToken).ifPresent(refreshTokenRepository::delete);
+
         userRepository.delete(user);
-    }
 }

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -97,10 +97,6 @@ public class KakaoService {
                 .header(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoAdminKey)
                 .body(logoutInfoBodies)
                 .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
-                    throw new CustomKakaoException(INVALID_KAKAO_ACCESS_TOKEN,
-                            "Invalid access token for Kakao logout");
-                })
                 .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
                     throw new CustomKakaoException(KAKAO_SERVER_ERROR,
                             "Kakao server error during logout");

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -111,5 +111,22 @@ public class KakaoService {
     public void unlinkFromKakao(User user, String refreshToken) {
         refreshTokenRepository.findByRefreshToken(refreshToken).ifPresent(refreshTokenRepository::delete);
 
+        String socialId = user.getSocialId();
+        String kakaoUserInfoId = socialId.replaceFirst("kakao_", "");
+
         userRepository.delete(user);
+
+        MultiValueMap<String, String> withdrawInfoBodies = new LinkedMultiValueMap<>();
+        withdrawInfoBodies.add("target_id_type", "user_id");
+        withdrawInfoBodies.add("target_id", kakaoUserInfoId);
+
+        RestClient.create()
+                .post()
+                .uri(kakaoUnlinkUrl)
+                .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .header(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoAdminKey)
+                .body(withdrawInfoBodies)
+                .retrieve()
+                .toBodilessEntity();
+    }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#58 -> dev
- close #58

## Key Changes
<!-- 최대한 자세히 -->
- 회원 탈퇴 시
  - user 테이블에서 레코드 삭제 및 연관관계 orphanRemoval = true로 걸려있는 엔티티의 레코드들도 삭제
  - 카카오 unlink API 호출하여 연결 끊기
  - redis에서 refreshToken 삭제 

## References
<!-- 참고한 자료-->
- https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#unlink
