### PR TITLE
[FIX] 애플 소셜 로그인 방식 수정

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -25,6 +25,13 @@ jobs:
           echo "${{ secrets.APPLICATION }}" > ./application.yml
           echo "${{ secrets.APPLICATION_PROD }}" > ./application-prod.yml
 
+    - name: Create apple login key file
+      env:
+        API_KEY: ${{ secrets.APPSTORE_API_KEY_ID }}
+      run: |
+        mkdir -p src/main/resources/static
+        echo "${{ secrets.APPLE_AUTH_KEY }}" > src/main/resources/static/AuthKey_$API_KEY.p8
+
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       shell: bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,6 +28,13 @@ jobs:
           echo "${{ secrets.APPLICATION }}" > ./application.yml
           echo "${{ secrets.APPLICATION_PROD }}" > ./application-prod.yml
 
+    - name: Create apple login key file
+      env:
+        API_KEY: ${{ secrets.APPSTORE_API_KEY_ID }}
+      run: |
+        mkdir -p src/main/resources/static
+        echo "${{ secrets.APPLE_AUTH_KEY }}" > src/main/resources/static/AuthKey_$API_KEY.p8
+
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 
 ## QClass ##
 src/main/generated/
+
+## Apple Login Key File ##
+*.p8

--- a/build.gradle
+++ b/build.gradle
@@ -65,9 +65,6 @@ dependencies {
     // spring data redis
     implementation 'org.springframework.data:spring-data-redis:3.3.2'
 
-    //Apple Login
-    implementation 'com.nimbusds:nimbus-jose-jwt:3.10'
-
     //Json
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
 
     //Json
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+
+    //Apple Login
+    implementation 'com.nimbusds:nimbus-jose-jwt:3.10'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/websoso/WSSServer/domain/UserAppleToken.java
+++ b/src/main/java/org/websoso/WSSServer/domain/UserAppleToken.java
@@ -1,0 +1,41 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserAppleToken {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long userAppleTokenId;
+
+    @Column(nullable = false)
+    private String appleRefreshToken;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private UserAppleToken(User user, String appleRefreshToken) {
+        this.user = user;
+        this.appleRefreshToken = appleRefreshToken;
+    }
+
+    public static UserAppleToken create(User user, String appleRefreshToken) {
+        return new UserAppleToken(user, appleRefreshToken);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/auth/AppleLoginRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/auth/AppleLoginRequest.java
@@ -1,14 +1,9 @@
 package org.websoso.WSSServer.dto.auth;
 
-import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 public record AppleLoginRequest(
-        @NotBlank(message = "사용자 고유 식별자는 null 이거나, 공백일 수 없습니다.")
-        String userIdentifier,
-        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
-        @Nullable
-        String email
+        @NotBlank(message = "애플 토큰 값은 null 이거나, 공백일 수 없습니다.")
+        String appleToken
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/auth/AppleLoginRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/auth/AppleLoginRequest.java
@@ -3,7 +3,9 @@ package org.websoso.WSSServer.dto.auth;
 import jakarta.validation.constraints.NotBlank;
 
 public record AppleLoginRequest(
-        @NotBlank(message = "애플 토큰 값은 null 이거나, 공백일 수 없습니다.")
-        String appleToken
+        @NotBlank(message = "애플 인증 코드 값은 null 이거나, 공백일 수 없습니다.")
+        String authorizationCode,
+        @NotBlank(message = "애플 ID 토큰 값은 null 이거나, 공백일 수 없습니다.")
+        String idToken
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/auth/ApplePublicKey.java
+++ b/src/main/java/org/websoso/WSSServer/dto/auth/ApplePublicKey.java
@@ -1,0 +1,37 @@
+package org.websoso.WSSServer.dto.auth;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ApplePublicKey(
+        String kty,
+        String kid,
+        String use,
+        String alg,
+        String n,
+        String e
+) {
+
+    public boolean isSameAlg(final String alg) {
+        return this.alg.equals(alg);
+    }
+
+    public boolean isSameKid(final String kid) {
+        return this.kid.equals(kid);
+    }
+
+    @JsonCreator
+    public ApplePublicKey(@JsonProperty("kty") final String kty,
+                          @JsonProperty("kid") final String kid,
+                          @JsonProperty("use") final String use,
+                          @JsonProperty("alg") final String alg,
+                          @JsonProperty("n") final String n,
+                          @JsonProperty("e") final String e) {
+        this.kty = kty;
+        this.kid = kid;
+        this.use = use;
+        this.alg = alg;
+        this.n = n;
+        this.e = e;
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/auth/ApplePublicKeys.java
+++ b/src/main/java/org/websoso/WSSServer/dto/auth/ApplePublicKeys.java
@@ -1,0 +1,15 @@
+package org.websoso.WSSServer.dto.auth;
+
+import java.util.List;
+
+public record ApplePublicKeys(
+        List<ApplePublicKey> keys
+) {
+
+    public ApplePublicKey getMatchingKey(final String alg, final String kid) {
+        return keys.stream()
+                .filter(key -> key.isSameAlg(alg) && key.isSameKid(kid))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("잘못된 토큰 형태입니다.")); // TODO : 커스텀 예외 수정
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/auth/ApplePublicKeys.java
+++ b/src/main/java/org/websoso/WSSServer/dto/auth/ApplePublicKeys.java
@@ -1,6 +1,9 @@
 package org.websoso.WSSServer.dto.auth;
 
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.INVALID_APPLE_KEY;
+
 import java.util.List;
+import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
 
 public record ApplePublicKeys(
         List<ApplePublicKey> keys
@@ -10,6 +13,6 @@ public record ApplePublicKeys(
         return keys.stream()
                 .filter(key -> key.isSameAlg(alg) && key.isSameKid(kid))
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException("잘못된 토큰 형태입니다.")); // TODO : 커스텀 예외 수정
+                .orElseThrow(() -> new CustomAppleLoginException(INVALID_APPLE_KEY, "invalid apple key"));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/auth/AppleTokenResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/auth/AppleTokenResponse.java
@@ -1,0 +1,23 @@
+package org.websoso.WSSServer.dto.auth;
+
+public record AppleTokenResponse(
+        String access_token,
+        String expires_in,
+        String id_token,
+        String refresh_token,
+        String token_type,
+        String error
+) {
+    
+    public String getAccessToken() {
+        return access_token;
+    }
+
+    public String getIdToken() {
+        return id_token;
+    }
+
+    public String getRefreshToken() {
+        return refresh_token;
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomAppleLoginError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomAppleLoginError.java
@@ -2,7 +2,6 @@ package org.websoso.WSSServer.exception.error;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,12 +12,15 @@ import org.websoso.WSSServer.exception.common.ICustomError;
 @Getter
 public enum CustomAppleLoginError implements ICustomError {
 
-    MISSING_AUTHORIZATION_CODE("APPLE-001", "인증 코드를 입력하지 않았습니다.", BAD_REQUEST),
-    TOKEN_REQUEST_FAILED("APPLE-003", "Apple 서버로부터 토큰을 받아오지 못했습니다.", INTERNAL_SERVER_ERROR),
-    ID_TOKEN_PARSE_FAILED("APPLE-004", "Apple ID 토큰을 파싱하지 못했습니다.", INTERNAL_SERVER_ERROR),
-    USER_INFO_RETRIEVAL_FAILED("APPLE-005", "Apple에서 사용자 정보를 가져오지 못했습니다.", NOT_FOUND),
-    CLIENT_SECRET_CREATION_FAILED("APPLE-006", "클라이언트 시크릿을 생성하는 데 실패했습니다.", INTERNAL_SERVER_ERROR),
-    PRIVATE_KEY_READ_FAILED("APPLE-007", "프라이빗 키를 읽는 데 실패했습니다.", INTERNAL_SERVER_ERROR);
+    TOKEN_REQUEST_FAILED("APPLE-001", "Apple 서버로부터 토큰을 받아오지 못했습니다.", INTERNAL_SERVER_ERROR),
+    CLIENT_SECRET_CREATION_FAILED("APPLE-002", "클라이언트 시크릿을 생성하는 데 실패했습니다.", INTERNAL_SERVER_ERROR),
+    PRIVATE_KEY_READ_FAILED("APPLE-003", "프라이빗 키를 읽는 데 실패했습니다.", INTERNAL_SERVER_ERROR),
+    INVALID_APPLE_TOKEN_FORMAT("APPLE-004", "idToken 값이 jwt 형식인지 확인이 필요합니다.", BAD_REQUEST),
+    HEADER_PARSING_FAILED("APPLE-005", "디코드된 헤더를 Map 형태로 변환할 수 없습니다.", INTERNAL_SERVER_ERROR),
+    UNSUPPORTED_JWT_TYPE("APPLE-006", "지원되지 않는 jwt 타입입니다.", BAD_REQUEST),
+    EMPTY_JWT("APPLE-007", "비어있는 jwt입니다.", BAD_REQUEST),
+    JWT_VERIFICATION_FAILED("APPLE-008", "jwt 검증 또는 분석에 실패했습니다.", INTERNAL_SERVER_ERROR),
+    INVALID_APPLE_KEY("APPLE-009", "잘못된 애플 키입니다.", INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
@@ -232,7 +232,6 @@ public class AppleService {
                     .retrieve()
                     .body(AppleTokenResponse.class);
         } catch (Exception e) {
-            System.out.println(e.getMessage());
             throw new CustomAppleLoginException(TOKEN_REQUEST_FAILED, "failed to get token from Apple server");
         }
     }

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
@@ -1,22 +1,121 @@
 package org.websoso.WSSServer.oauth2.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.UnsupportedJwtException;
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
 import org.websoso.WSSServer.dto.auth.AppleLoginRequest;
+import org.websoso.WSSServer.dto.auth.ApplePublicKey;
+import org.websoso.WSSServer.dto.auth.ApplePublicKeys;
 import org.websoso.WSSServer.dto.auth.AuthResponse;
 import org.websoso.WSSServer.service.UserService;
 
 @Service
 @RequiredArgsConstructor
-public class AppleService {
+public class AppleService { // TODO : 커스텀 예외로 수정
 
     private static final String APPLE_PREFIX = "apple";
+    private static final String CLAIM_EMAIL = "email";
+    private static final String CLAIM_SUB = "sub";
+    private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";
+    private static final int HEADER_INDEX = 0;
+    private static final String SIGN_ALGORITHM_HEADER = "alg";
+    private static final String KEY_ID_HEADER = "kid";
+    private static final int POSITIVE_SIGN_NUMBER = 1;
+    private final ObjectMapper objectMapper;
     private final UserService userService;
 
-    public AuthResponse getUserInfoFromApple(AppleLoginRequest request) {
-        String customSocialId = APPLE_PREFIX + "_" + request.userIdentifier();
-        String defaultNickname = APPLE_PREFIX.charAt(0) + "*" + request.userIdentifier().substring(7, 15);
+    @Value("${apple.public-keys-url}")
+    private String APPLE_PUBLIC_KEYS_URL;
 
-        return userService.authenticateWithApple(customSocialId, request.email(), defaultNickname);
+    public AuthResponse getUserInfoFromApple(final AppleLoginRequest request) {
+        final String appleToken = request.appleToken();
+        final Map<String, String> appleTokenHeader = parseAppleTokenHeader(appleToken);
+        final ApplePublicKeys applePublicKeys = getApplePublicKeys();
+        final PublicKey publicKey = generatePublicKeyFromHeaders(appleTokenHeader, applePublicKeys);
+        final Claims claims = extractClaims(appleToken, publicKey);
+
+        final String email = claims.get(CLAIM_EMAIL, String.class);
+        final String userIdentifier = claims.get(CLAIM_SUB, String.class);
+        String customSocialId = APPLE_PREFIX + "_" + userIdentifier;
+        String defaultNickname = APPLE_PREFIX.charAt(0) + "*" + userIdentifier.substring(7, 15);
+
+        return userService.authenticateWithApple(customSocialId, email, defaultNickname);
+    }
+
+    private Map<String, String> parseAppleTokenHeader(final String appleToken) {
+        try {
+            final String encodedHeader = appleToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
+            final String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
+            return objectMapper.readValue(decodedHeader, Map.class);
+        } catch (JsonMappingException e) {
+            throw new RuntimeException("appleToken 값이 jwt 형식인지, 값이 정상적인지 확인해주세요.");
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("디코드된 헤더를 Map 형태로 분류할 수 없습니다. 헤더를 확인해주세요.");
+        }
+    }
+
+    private ApplePublicKeys getApplePublicKeys() {
+        RestClient restClient = RestClient.create();
+        return restClient.get()
+                .uri(APPLE_PUBLIC_KEYS_URL)
+                .retrieve()
+                .body(ApplePublicKeys.class);
+    }
+
+    private PublicKey generatePublicKeyFromHeaders(final Map<String, String> headers,
+                                                   final ApplePublicKeys publicKeys) {
+        final ApplePublicKey applePublicKey = publicKeys.getMatchingKey(
+                headers.get(SIGN_ALGORITHM_HEADER),
+                headers.get(KEY_ID_HEADER)
+        );
+        return generatePublicKey(applePublicKey);
+    }
+
+    private PublicKey generatePublicKey(final ApplePublicKey applePublicKey) {
+        final byte[] nBytes = Base64.getUrlDecoder().decode(applePublicKey.n());
+        final byte[] eBytes = Base64.getUrlDecoder().decode(applePublicKey.e());
+
+        final BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
+        final BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
+        final RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(n, e);
+
+        try {
+            final KeyFactory keyFactory = KeyFactory.getInstance(applePublicKey.kty());
+            return keyFactory.generatePublic(rsaPublicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            throw new RuntimeException("잘못된 애플 키"); // TODO : 커스텀 예외로 수정
+        }
+    }
+
+    private Claims extractClaims(final String appleToken, final PublicKey publicKey) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(appleToken)
+                    .getBody();
+        } catch (UnsupportedJwtException e) {
+            throw new UnsupportedJwtException("지원되지 않는 jwt 타입");
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("비어있는 jwt");
+        } catch (JwtException e) {
+            throw new JwtException("jwt 검증 or 분석 오류");
+        }
     }
 }

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
@@ -183,7 +183,7 @@ public class AppleService {
 
             return jwt.serialize();
         } catch (Exception e) {
-            throw new CustomAppleLoginException(CLIENT_SECRET_CREATION_FAILED, "Failed to generate client secret");
+            throw new CustomAppleLoginException(CLIENT_SECRET_CREATION_FAILED, "failed to generate client secret");
         }
     }
 
@@ -208,7 +208,7 @@ public class AppleService {
             JWSSigner signer = new ECDSASigner(ecPrivateKey.getS());
             jwt.sign(signer);
         } catch (Exception e) {
-            throw new CustomAppleLoginException(CLIENT_SECRET_CREATION_FAILED, "Failed to create client secret");
+            throw new CustomAppleLoginException(CLIENT_SECRET_CREATION_FAILED, "failed to create client secret");
         }
     }
 
@@ -218,7 +218,7 @@ public class AppleService {
             PemObject pemObject = pemReader.readPemObject();
             return pemObject.getContent();
         } catch (IOException e) {
-            throw new CustomAppleLoginException(PRIVATE_KEY_READ_FAILED, "Failed to read private key");
+            throw new CustomAppleLoginException(PRIVATE_KEY_READ_FAILED, "failed to read private key");
         }
     }
 
@@ -232,7 +232,8 @@ public class AppleService {
                     .retrieve()
                     .body(AppleTokenResponse.class);
         } catch (Exception e) {
-            throw new CustomAppleLoginException(TOKEN_REQUEST_FAILED, "Failed to get token from Apple server");
+            System.out.println(e.getMessage());
+            throw new CustomAppleLoginException(TOKEN_REQUEST_FAILED, "failed to get token from Apple server");
         }
     }
 

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
@@ -100,14 +100,15 @@ public class AppleService {
         PublicKey publicKey = generatePublicKeyFromHeaders(appleTokenHeader, applePublicKeys);
         Claims claims = extractClaims(appleToken, publicKey);
 
-        requestAppleToken(request.authorizationCode(), createClientSecret());
+        AppleTokenResponse appleTokenResponse = requestAppleToken(request.authorizationCode(), createClientSecret());
 
         String email = claims.get(CLAIM_EMAIL, String.class);
         String userIdentifier = claims.get(CLAIM_SUB, String.class);
         String customSocialId = APPLE_PREFIX + "_" + userIdentifier;
         String defaultNickname = APPLE_PREFIX.charAt(0) + "*" + userIdentifier.substring(7, 15);
 
-        return userService.authenticateWithApple(customSocialId, email, defaultNickname);
+        return userService.authenticateWithApple(customSocialId, email, defaultNickname,
+                appleTokenResponse.getRefreshToken());
     }
 
     private Map<String, String> parseAppleTokenHeader(String appleToken) {

--- a/src/main/java/org/websoso/WSSServer/repository/UserAppleTokenRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserAppleTokenRepository.java
@@ -1,0 +1,9 @@
+package org.websoso.WSSServer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.UserAppleToken;
+
+@Repository
+public interface UserAppleTokenRepository extends JpaRepository<UserAppleToken, Long> {
+}

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -20,6 +20,7 @@ import org.websoso.WSSServer.domain.Genre;
 import org.websoso.WSSServer.domain.GenrePreference;
 import org.websoso.WSSServer.domain.RefreshToken;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserAppleToken;
 import org.websoso.WSSServer.dto.auth.AuthResponse;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
@@ -41,6 +42,7 @@ import org.websoso.WSSServer.repository.AvatarRepository;
 import org.websoso.WSSServer.repository.GenrePreferenceRepository;
 import org.websoso.WSSServer.repository.GenreRepository;
 import org.websoso.WSSServer.repository.RefreshTokenRepository;
+import org.websoso.WSSServer.repository.UserAppleTokenRepository;
 import org.websoso.WSSServer.repository.UserRepository;
 
 @Service
@@ -54,6 +56,7 @@ public class UserService {
     private final GenrePreferenceRepository genrePreferenceRepository;
     private final GenreRepository genreRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final UserAppleTokenRepository userAppleTokenRepository;
     private final KakaoService kakaoService;
     private static final String KAKAO_PREFIX = "kakao";
 
@@ -152,11 +155,13 @@ public class UserService {
         genrePreferenceRepository.saveAll(preferGenres);
     }
 
-    public AuthResponse authenticateWithApple(String socialId, String email, String nickname) {
+    public AuthResponse authenticateWithApple(String socialId, String email, String nickname,
+                                              String appleRefreshToken) {
         User user = userRepository.findBySocialId(socialId);
 
         if (user == null) {
             user = userRepository.save(User.createBySocial(socialId, nickname, email));
+            userAppleTokenRepository.save(UserAppleToken.create(user, appleRefreshToken));
         }
 
         UserAuthentication userAuthentication = new UserAuthentication(user.getUserId(), null, null);


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#220 -> dev
- close #220

## Key Changes
<!-- 최대한 자세히 -->
*연결된 이슈에 과정이 알기 쉽게 나와있습니다!

과정을 간단히 나타내면,
1. 클라이언트에서 애플 로그인 진행 -> id토큰, 인증코드 발급 후 서버에 전달
2. 서버는 애플 서버에서 여러 공개키들을 가져와서 id토큰이 이 중 어떤 키로 암호화되었는지를 찾아냅니다. (일일히 매칭 비교)
3. 찾아낸 공개키와 id토큰으로 애플 계정 정보를 받아올 수 있습니다.
4. 1번에서 받은 인증코드로 해당 애플 사용자의 토큰(액세스, 리프레시)을 발급하고, 만료기간이 따로 없는 리프레시 토큰을 사용자 탈퇴 시 사용하기 위해 데이터베이스에 저장합니다!

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
나머지 로직이 작동됨은 확인했지만, 마지막 애플의 액세스, 리프레시 토큰 발급 과정이 로컬에서 실행이 불가하여 (도메인으로만 가능) 머지 후 정상작동 확인하려고 합니다..!

## References
<!-- 참고한 자료-->
