### PR TITLE
[FIX] 카카오 회원 탈퇴에 따른 리소스 수정 및 삭제 로직 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.domain;
 
+import static jakarta.persistence.CascadeType.ALL;
 import static org.websoso.WSSServer.domain.common.Gender.M;
 import static org.websoso.WSSServer.domain.common.Role.USER;
 
@@ -10,9 +11,12 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.Year;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -73,6 +77,12 @@ public class User {
     @Column(nullable = false)
     @ColumnDefault("'USER'")
     private Role role;
+
+    @OneToMany(mappedBy = "user", cascade = ALL, orphanRemoval = true)
+    private List<GenrePreference> genrePreferences = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = ALL, orphanRemoval = true)
+    private List<UserNovel> userNovels = new ArrayList<>();
 
     public void updateProfileStatus(Boolean profileStatus) {
         this.isProfilePublic = profileStatus;

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -112,6 +112,7 @@ public class KakaoService {
         String socialId = user.getSocialId();
         String kakaoUserInfoId = socialId.replaceFirst("kakao_", "");
 
+        feedRepository.updateUserToUnknown(user.getUserId());
         userRepository.delete(user);
 
         MultiValueMap<String, String> withdrawInfoBodies = new LinkedMultiValueMap<>();

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -113,6 +113,7 @@ public class KakaoService {
         String kakaoUserInfoId = socialId.replaceFirst("kakao_", "");
 
         feedRepository.updateUserToUnknown(user.getUserId());
+        commentRepository.updateUserToUnknown(user.getUserId());
         userRepository.delete(user);
 
         MultiValueMap<String, String> withdrawInfoBodies = new LinkedMultiValueMap<>();

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -19,6 +19,8 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.auth.AuthResponse;
 import org.websoso.WSSServer.exception.exception.CustomKakaoException;
 import org.websoso.WSSServer.oauth2.dto.KakaoUserInfo;
+import org.websoso.WSSServer.repository.CommentRepository;
+import org.websoso.WSSServer.repository.FeedRepository;
 import org.websoso.WSSServer.repository.RefreshTokenRepository;
 import org.websoso.WSSServer.repository.UserRepository;
 
@@ -28,6 +30,8 @@ import org.websoso.WSSServer.repository.UserRepository;
 public class KakaoService {
 
     private final UserRepository userRepository;
+    private final FeedRepository feedRepository;
+    private final CommentRepository commentRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
 

--- a/src/main/java/org/websoso/WSSServer/repository/CommentRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/CommentRepository.java
@@ -1,9 +1,17 @@
 package org.websoso.WSSServer.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Comment;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Transactional
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Comment c SET c.userId = -1 WHERE c.userId = :userId")
+    void updateUserToUnknown(Long userId);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
@@ -4,8 +4,10 @@ import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Feed;
 
 @Repository
@@ -31,4 +33,9 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedCustomRep
             + "OR f.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = :userId)) "
             + "ORDER BY f.feedId DESC")
     Slice<Feed> findFeedsByNovelId(Long novelId, Long lastFeedId, Long userId, PageRequest pageRequest);
+
+    @Transactional
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Feed f SET f.user.userId = -1 WHERE f.user.userId = :userId")
+    void updateUserToUnknown(Long userId);
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#224 -> dev
- close #224

## Key Changes
<!-- 최대한 자세히 -->
- User에 GenrePreference와 UserNovel 양방향 매핑 추가 -> cascade ALL, orphanRemoval true
- DB에 `알 수 없음` 유저를 하나 두고, bulk 연산으로 업데이트 해버리는 방식으로 구현했습니다.
  - comment와 feed에서 연결되는 user(user_id)를 null로 처리할까 싶었는데, null-check가 번거로울 것 같아서..!