### PR TITLE
[FEAT] 애플 소셜 탈퇴 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -70,7 +70,7 @@ public class AuthController {
                                              @Valid @RequestBody WithdrawalRequest withdrawalRequest) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         String refreshToken = withdrawalRequest.refreshToken();
-        kakaoService.unlinkFromKakao(user, refreshToken);
+        userService.withdrawUser(user, refreshToken);
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();

--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -69,8 +69,7 @@ public class AuthController {
     public ResponseEntity<Void> withdrawUser(Principal principal,
                                              @Valid @RequestBody WithdrawalRequest withdrawalRequest) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
-        String refreshToken = withdrawalRequest.refreshToken();
-        userService.withdrawUser(user, refreshToken);
+        userService.withdrawUser(user, withdrawalRequest);
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -84,6 +84,12 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = ALL, orphanRemoval = true)
     private List<UserNovel> userNovels = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = ALL, orphanRemoval = true)
+    private List<ReportedFeed> reportedFeeds = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = ALL, orphanRemoval = true)
+    private List<ReportedComment> reportedComments = new ArrayList<>();
+
     public void updateProfileStatus(Boolean profileStatus) {
         this.isProfilePublic = profileStatus;
     }

--- a/src/main/java/org/websoso/WSSServer/domain/WithdrawalReason.java
+++ b/src/main/java/org/websoso/WSSServer/domain/WithdrawalReason.java
@@ -1,0 +1,33 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WithdrawalReason {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Long withdrawalReasonId;
+
+    @Column(columnDefinition = "varchar(80)", nullable = false)
+    private String withdrawalReasonContent;
+
+    private WithdrawalReason(String withdrawalReasonContent) {
+        this.withdrawalReasonContent = withdrawalReasonContent;
+    }
+
+    public static WithdrawalReason create(String withdrawalReasonContent) {
+        return new WithdrawalReason(withdrawalReasonContent);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/domain/common/DiscordWebhookMessage.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/DiscordWebhookMessage.java
@@ -2,10 +2,10 @@ package org.websoso.WSSServer.domain.common;
 
 public record DiscordWebhookMessage(
         String content,
-        String type
+        DiscordWebhookMessageType type
 ) {
-    
-    public static DiscordWebhookMessage of(String content, String type) {
+
+    public static DiscordWebhookMessage of(String content, DiscordWebhookMessageType type) {
         if (content.length() >= 2000) {
             content = content.substring(0, 1993) + "\n...```";
         }

--- a/src/main/java/org/websoso/WSSServer/domain/common/DiscordWebhookMessage.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/DiscordWebhookMessage.java
@@ -1,13 +1,14 @@
 package org.websoso.WSSServer.domain.common;
 
 public record DiscordWebhookMessage(
-        String content
+        String content,
+        String type
 ) {
-    public static DiscordWebhookMessage of(String content) {
+    
+    public static DiscordWebhookMessage of(String content, String type) {
         if (content.length() >= 2000) {
             content = content.substring(0, 1993) + "\n...```";
         }
-        return new DiscordWebhookMessage(content);
+        return new DiscordWebhookMessage(content, type);
     }
-
 }

--- a/src/main/java/org/websoso/WSSServer/domain/common/DiscordWebhookMessageType.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/DiscordWebhookMessageType.java
@@ -1,0 +1,5 @@
+package org.websoso.WSSServer.domain.common;
+
+public enum DiscordWebhookMessageType {
+    WITHDRAW, REPORT
+}

--- a/src/main/java/org/websoso/WSSServer/dto/user/WithdrawalRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/WithdrawalRequest.java
@@ -6,8 +6,7 @@ import jakarta.validation.constraints.Size;
 public record WithdrawalRequest(
         @Size(max = 80, message = "탈퇴 사유는 80자를 초과할 수 없습니다.")
         String reason,
-
-        @NotBlank
+        @NotBlank(message = "리프레시 토큰은 null 이거나, 공백일 수 없습니다.")
         String refreshToken
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomAppleLoginError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomAppleLoginError.java
@@ -2,6 +2,7 @@ package org.websoso.WSSServer.exception.error;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,7 +21,8 @@ public enum CustomAppleLoginError implements ICustomError {
     UNSUPPORTED_JWT_TYPE("APPLE-006", "지원되지 않는 jwt 타입입니다.", BAD_REQUEST),
     EMPTY_JWT("APPLE-007", "비어있는 jwt입니다.", BAD_REQUEST),
     JWT_VERIFICATION_FAILED("APPLE-008", "jwt 검증 또는 분석에 실패했습니다.", INTERNAL_SERVER_ERROR),
-    INVALID_APPLE_KEY("APPLE-009", "잘못된 애플 키입니다.", INTERNAL_SERVER_ERROR);
+    INVALID_APPLE_KEY("APPLE-009", "잘못된 애플 키입니다.", INTERNAL_SERVER_ERROR),
+    USER_APPLE_REFRESH_TOKEN_NOT_FOUND("APPLE-010", "유저의 애플 리프레시 토큰을 찾을 수 없습니다.", NOT_FOUND);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
@@ -299,30 +299,6 @@ public class AppleService {
         return AuthResponse.of(accessToken, refreshToken, isRegister);
     }
 
-    private AppleTokenResponse requestAppleTokenByRefreshToken(String appleRefreshToken, String clientSecret) {
-        try {
-            RestClient restClient = RestClient.create();
-            return restClient.post()
-                    .uri(appleAuthUrl + "/auth/token")
-                    .headers(headers -> headers.add("Content-Type", "application/x-www-form-urlencoded"))
-                    .body(createTokenRequestParamsByRefreshToken(appleRefreshToken, clientSecret))
-                    .retrieve()
-                    .body(AppleTokenResponse.class);
-        } catch (Exception e) {
-            throw new CustomAppleLoginException(TOKEN_REQUEST_FAILED, "failed to get token from Apple server");
-        }
-    }
-
-    private MultiValueMap<String, String> createTokenRequestParamsByRefreshToken(String appleRefreshToken,
-                                                                                 String clientSecret) {
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", appleClientId);
-        params.add("client_secret", clientSecret);
-        params.add("refresh_token", appleRefreshToken);
-        return params;
-    }
-
     private MultiValueMap<String, String> createUserRevokeParams(String clientSecret, String appleRefreshToken) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "refresh_token");

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
@@ -9,6 +9,7 @@ import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.JWT_VE
 import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.PRIVATE_KEY_READ_FAILED;
 import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.TOKEN_REQUEST_FAILED;
 import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.UNSUPPORTED_JWT_TYPE;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.USER_APPLE_REFRESH_TOKEN_NOT_FOUND;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -43,9 +44,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
+import org.websoso.WSSServer.config.jwt.JwtProvider;
+import org.websoso.WSSServer.config.jwt.UserAuthentication;
+import org.websoso.WSSServer.domain.RefreshToken;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserAppleToken;
 import org.websoso.WSSServer.dto.auth.AppleLoginRequest;
 import org.websoso.WSSServer.dto.auth.ApplePublicKey;
 import org.websoso.WSSServer.dto.auth.ApplePublicKeys;
@@ -53,8 +60,10 @@ import org.websoso.WSSServer.dto.auth.AppleTokenResponse;
 import org.websoso.WSSServer.dto.auth.AuthResponse;
 import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
 import org.websoso.WSSServer.repository.RefreshTokenRepository;
-import org.websoso.WSSServer.service.UserService;
+import org.websoso.WSSServer.repository.UserAppleTokenRepository;
+import org.websoso.WSSServer.repository.UserRepository;
 
+@Transactional
 @Service
 @RequiredArgsConstructor
 public class AppleService {
@@ -68,8 +77,10 @@ public class AppleService {
     private static final String KEY_ID_HEADER = "kid";
     private static final int POSITIVE_SIGN_NUMBER = 1;
     private final ObjectMapper objectMapper;
-    private final UserService userService;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final UserAppleTokenRepository userAppleTokenRepository;
+    private final JwtProvider jwtProvider;
 
     @Value("${apple.public-keys-url}")
     private String applePublicKeysUrl;
@@ -109,13 +120,17 @@ public class AppleService {
         String customSocialId = APPLE_PREFIX + "_" + userIdentifier;
         String defaultNickname = APPLE_PREFIX.charAt(0) + "*" + userIdentifier.substring(7, 15);
 
-        return userService.authenticateWithApple(customSocialId, email, defaultNickname,
-                appleTokenResponse.getRefreshToken());
+        return authenticate(customSocialId, email, defaultNickname, appleTokenResponse.getRefreshToken());
     }
 
-    public void unlinkFromApple(String refreshToken, String appleRefreshToken) {
+    public void unlinkFromApple(User user, String refreshToken) {
         String clientSecret = createClientSecret();
-        AppleTokenResponse appleTokenResponse = requestAppleTokenByRefreshToken(appleRefreshToken, clientSecret);
+        UserAppleToken userAppleToken = userAppleTokenRepository.findByUser(user).orElseThrow(
+                () -> new CustomAppleLoginException(USER_APPLE_REFRESH_TOKEN_NOT_FOUND,
+                        "cannot find the user Apple refresh token"));
+
+        AppleTokenResponse appleTokenResponse = requestAppleTokenByRefreshToken(userAppleToken.getAppleRefreshToken(),
+                clientSecret);
 
         if (appleTokenResponse.getAccessToken() != null) {
             RestClient restClient = RestClient.create();
@@ -271,6 +286,25 @@ public class AppleService {
         params.add("code", authorizationCode);
         params.add("redirect_uri", appleRedirectUrl);
         return params;
+    }
+
+    private AuthResponse authenticate(String socialId, String email, String nickname, String appleRefreshToken) {
+        User user = userRepository.findBySocialId(socialId);
+
+        if (user == null) {
+            user = userRepository.save(User.createBySocial(socialId, nickname, email));
+            userAppleTokenRepository.save(UserAppleToken.create(user, appleRefreshToken));
+        }
+
+        UserAuthentication userAuthentication = new UserAuthentication(user.getUserId(), null, null);
+        String accessToken = jwtProvider.generateAccessToken(userAuthentication);
+        String refreshToken = jwtProvider.generateRefreshToken(userAuthentication);
+
+        refreshTokenRepository.save(new RefreshToken(refreshToken, user.getUserId()));
+
+        boolean isRegister = !user.getNickname().contains("*");
+
+        return AuthResponse.of(accessToken, refreshToken, isRegister);
     }
 
     private AppleTokenResponse requestAppleTokenByRefreshToken(String appleRefreshToken, String clientSecret) {

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
@@ -135,6 +135,8 @@ public class AppleService {
                 .body(createUserRevokeParams(createClientSecret(), userAppleToken.getAppleRefreshToken()))
                 .retrieve()
                 .body(String.class);
+
+        userAppleTokenRepository.delete(userAppleToken);
     }
 
     private Map<String, String> parseAppleTokenHeader(String appleToken) {

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
@@ -123,7 +123,7 @@ public class AppleService {
         return authenticate(customSocialId, email, defaultNickname, appleTokenResponse.getRefreshToken());
     }
 
-    public void unlinkFromApple(User user, String refreshToken) {
+    public void unlinkFromApple(User user) {
         String clientSecret = createClientSecret();
         UserAppleToken userAppleToken = userAppleTokenRepository.findByUser(user).orElseThrow(
                 () -> new CustomAppleLoginException(USER_APPLE_REFRESH_TOKEN_NOT_FOUND,
@@ -141,8 +141,6 @@ public class AppleService {
                     .retrieve()
                     .body(String.class);
         }
-
-        refreshTokenRepository.findByRefreshToken(refreshToken).ifPresent(refreshTokenRepository::delete);
     }
 
     private Map<String, String> parseAppleTokenHeader(String appleToken) {

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
@@ -198,7 +198,6 @@ public class AppleService {
         } catch (IllegalArgumentException e) {
             throw new CustomAppleLoginException(EMPTY_JWT, "empty jwt");
         } catch (JwtException e) {
-            System.out.println(e.getMessage());
             throw new CustomAppleLoginException(JWT_VERIFICATION_FAILED, "jwt validation or analysis failed");
         }
     }
@@ -213,7 +212,6 @@ public class AppleService {
 
             return jwt.serialize();
         } catch (Exception e) {
-            System.out.println(e.getMessage());
             throw new CustomAppleLoginException(CLIENT_SECRET_CREATION_FAILED, "failed to generate client secret");
         }
     }
@@ -239,20 +237,16 @@ public class AppleService {
             JWSSigner signer = new ECDSASigner(ecPrivateKey.getS());
             jwt.sign(signer);
         } catch (Exception e) {
-            System.out.println(e.getMessage());
             throw new CustomAppleLoginException(CLIENT_SECRET_CREATION_FAILED, "failed to create client secret");
         }
     }
 
     private byte[] readPrivateKey(String keyPath) {
         Resource resource = new ClassPathResource(keyPath);
-        System.out.println("Resource exists: " + resource.exists());
-        System.out.println("Resource file path: " + resource.getFilename());
         try (PemReader pemReader = new PemReader(new InputStreamReader(resource.getInputStream()))) {
             PemObject pemObject = pemReader.readPemObject();
             return pemObject.getContent();
         } catch (IOException e) {
-            System.out.println(e.getMessage());
             throw new CustomAppleLoginException(PRIVATE_KEY_READ_FAILED, "failed to read private key");
         }
     }
@@ -267,7 +261,6 @@ public class AppleService {
                     .retrieve()
                     .body(AppleTokenResponse.class);
         } catch (Exception e) {
-            System.out.println(e.getMessage());
             throw new CustomAppleLoginException(TOKEN_REQUEST_FAILED, "failed to get token from Apple server");
         }
     }

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
@@ -124,10 +124,10 @@ public class AppleService {
     }
 
     public void unlinkFromApple(User user) {
-        String clientSecret = createClientSecret();
         UserAppleToken userAppleToken = userAppleTokenRepository.findByUser(user).orElseThrow(
                 () -> new CustomAppleLoginException(USER_APPLE_REFRESH_TOKEN_NOT_FOUND,
                         "cannot find the user Apple refresh token"));
+        String clientSecret = createClientSecret();
 
         AppleTokenResponse appleTokenResponse = requestAppleTokenByRefreshToken(userAppleToken.getAppleRefreshToken(),
                 clientSecret);

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -102,9 +102,7 @@ public class KakaoService {
                 .toBodilessEntity();
     }
 
-    public void unlinkFromKakao(User user, String refreshToken) {
-        refreshTokenRepository.findByRefreshToken(refreshToken).ifPresent(refreshTokenRepository::delete);
-
+    public void unlinkFromKakao(User user) {
         String socialId = user.getSocialId();
         String kakaoUserInfoId = socialId.replaceFirst("kakao_", "");
 

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -19,8 +19,6 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.auth.AuthResponse;
 import org.websoso.WSSServer.exception.exception.CustomKakaoException;
 import org.websoso.WSSServer.oauth2.dto.KakaoUserInfo;
-import org.websoso.WSSServer.repository.CommentRepository;
-import org.websoso.WSSServer.repository.FeedRepository;
 import org.websoso.WSSServer.repository.RefreshTokenRepository;
 import org.websoso.WSSServer.repository.UserRepository;
 
@@ -30,8 +28,6 @@ import org.websoso.WSSServer.repository.UserRepository;
 public class KakaoService {
 
     private final UserRepository userRepository;
-    private final FeedRepository feedRepository;
-    private final CommentRepository commentRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
 
@@ -111,10 +107,6 @@ public class KakaoService {
 
         String socialId = user.getSocialId();
         String kakaoUserInfoId = socialId.replaceFirst("kakao_", "");
-
-        feedRepository.updateUserToUnknown(user.getUserId());
-        commentRepository.updateUserToUnknown(user.getUserId());
-        userRepository.delete(user);
 
         MultiValueMap<String, String> withdrawInfoBodies = new LinkedMultiValueMap<>();
         withdrawInfoBodies.add("target_id_type", "user_id");

--- a/src/main/java/org/websoso/WSSServer/repository/UserAppleTokenRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserAppleTokenRepository.java
@@ -1,9 +1,13 @@
 package org.websoso.WSSServer.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserAppleToken;
 
 @Repository
 public interface UserAppleTokenRepository extends JpaRepository<UserAppleToken, Long> {
+
+    Optional<UserAppleToken> findByUser(User user);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/WithdrawalReasonRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/WithdrawalReasonRepository.java
@@ -1,0 +1,9 @@
+package org.websoso.WSSServer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.WithdrawalReason;
+
+@Repository
+public interface WithdrawalReasonRepository extends JpaRepository<WithdrawalReason, Long> {
+}

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -98,7 +98,7 @@ public class CommentService {
         messageService.sendDiscordWebhookMessage(
                 DiscordWebhookMessage.of(
                         MessageFormatter.formatCommentReportMessage(comment, reportedType, commentCreatedUser,
-                                reportedCount, shouldHide)));
+                                reportedCount, shouldHide), "report"));
     }
 
     private Comment getCommentOrException(Long commentId) {

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -2,6 +2,7 @@ package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.domain.common.Action.DELETE;
 import static org.websoso.WSSServer.domain.common.Action.UPDATE;
+import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.REPORT;
 import static org.websoso.WSSServer.domain.common.ReportedType.IMPERTINENCE;
 import static org.websoso.WSSServer.domain.common.ReportedType.SPOILER;
 import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_NOT_FOUND;
@@ -98,7 +99,7 @@ public class CommentService {
         messageService.sendDiscordWebhookMessage(
                 DiscordWebhookMessage.of(
                         MessageFormatter.formatCommentReportMessage(comment, reportedType, commentCreatedUser,
-                                reportedCount, shouldHide), "report"));
+                                reportedCount, shouldHide), REPORT));
     }
 
     private Comment getCommentOrException(Long commentId) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -196,7 +196,8 @@ public class FeedService {
 
         messageService.sendDiscordWebhookMessage(
                 DiscordWebhookMessage.of(
-                        MessageFormatter.formatFeedReportMessage(feed, reportedType, reportedCount, shouldHide)));
+                        MessageFormatter.formatFeedReportMessage(feed, reportedType, reportedCount, shouldHide),
+                        "report"));
     }
 
     public void reportComment(User user, Long feedId, Long commentId, ReportedType reportedType) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -2,6 +2,7 @@ package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.domain.common.Action.DELETE;
 import static org.websoso.WSSServer.domain.common.Action.UPDATE;
+import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.REPORT;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.BLOCKED_USER_ACCESS;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.HIDDEN_FEED_ACCESS;
@@ -197,7 +198,7 @@ public class FeedService {
         messageService.sendDiscordWebhookMessage(
                 DiscordWebhookMessage.of(
                         MessageFormatter.formatFeedReportMessage(feed, reportedType, reportedCount, shouldHide),
-                        "report"));
+                        REPORT));
     }
 
     public void reportComment(User user, Long feedId, Long commentId, ReportedType reportedType) {

--- a/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
@@ -32,6 +32,13 @@ public class MessageFormatter {
                     "[신고 횟수]\n총 신고 횟수 %d회.\n" +
                     "%s\n```";
 
+    private static final String USER_WITHDRAW_MESSAGE =
+            "```[%s] 사용자가 탈퇴하였습니다.\n\n" +
+                    "[탈퇴한 사용자]\n" +
+                    "유저 아이디 : %d\n" +
+                    "유저 닉네임 : %s\n\n" +
+                    "[탈퇴 사유]\n%s\n\n```";
+
     public static String formatFeedReportMessage(Feed feed, ReportedType reportedType, int reportedCount,
                                                  boolean isHidden) {
         String hiddenMessage = isHidden ? "해당 피드는 숨김 처리되었습니다." : "해당 피드는 숨김 처리되지 않았습니다.";
@@ -71,4 +78,13 @@ public class MessageFormatter {
         );
     }
 
+    public static String formatUserWithdrawMessage(Long userId, String userNickname, String reason) {
+        return String.format(
+                USER_WITHDRAW_MESSAGE,
+                LocalDateTime.now().format(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT)),
+                userId,
+                userNickname,
+                reason
+        );
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/service/MessageService.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageService.java
@@ -16,8 +16,11 @@ import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 @Slf4j
 public class MessageService {
 
-    @Value("${logging.discord.webhook-url}")
-    String discordWebhookUrl;
+    @Value("${logging.discord.report-webhook-url}")
+    private String discordReportWebhookUrl;
+
+    @Value("${logging.discord.withdraw-webhook-url}")
+    private String discordWithdrawWebhookUrl;
 
     public void sendDiscordWebhookMessage(DiscordWebhookMessage message) {
         try {
@@ -27,7 +30,9 @@ public class MessageService {
 
             RestTemplate template = new RestTemplate();
             ResponseEntity<String> response = template.exchange(
-                    discordWebhookUrl,
+                    message.type().equals("report") ?
+                            discordReportWebhookUrl :
+                            discordWithdrawWebhookUrl,
                     POST,
                     messageEntity,
                     String.class
@@ -41,5 +46,4 @@ public class MessageService {
             log.error("에러 발생 :: " + e);
         }
     }
-
 }

--- a/src/main/java/org/websoso/WSSServer/service/MessageService.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageService.java
@@ -2,6 +2,7 @@ package org.websoso.WSSServer.service;
 
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.REPORT;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,7 +31,7 @@ public class MessageService {
 
             RestTemplate template = new RestTemplate();
             ResponseEntity<String> response = template.exchange(
-                    message.type().equals("report") ?
+                    message.type() == REPORT ?
                             discordReportWebhookUrl :
                             discordWithdrawWebhookUrl,
                     POST,

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -171,14 +171,17 @@ public class UserService {
 
     public void withdrawUser(User user, String refreshToken) {
         if (user.getSocialId().startsWith(KAKAO_PREFIX)) {
-            kakaoService.unlinkFromKakao(user, refreshToken);
+            kakaoService.unlinkFromKakao(user);
         } else if (user.getSocialId().startsWith(APPLE_PREFIX)) {
-            appleService.unlinkFromApple(user, refreshToken);
+            appleService.unlinkFromApple(user);
         }
 
+        refreshTokenRepository.findByRefreshToken(refreshToken).ifPresent(refreshTokenRepository::delete);
         feedRepository.updateUserToUnknown(user.getUserId());
         commentRepository.updateUserToUnknown(user.getUserId());
         userRepository.delete(user);
+
+        // TODO : 디스코드 웹훅 알림 발송 로직 추가
     }
 
     private void checkNicknameIfAlreadyExist(String nickname) {

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -21,6 +21,7 @@ import org.websoso.WSSServer.domain.Avatar;
 import org.websoso.WSSServer.domain.Genre;
 import org.websoso.WSSServer.domain.GenrePreference;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.WithdrawalReason;
 import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
@@ -47,6 +48,7 @@ import org.websoso.WSSServer.repository.GenrePreferenceRepository;
 import org.websoso.WSSServer.repository.GenreRepository;
 import org.websoso.WSSServer.repository.RefreshTokenRepository;
 import org.websoso.WSSServer.repository.UserRepository;
+import org.websoso.WSSServer.repository.WithdrawalReasonRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -64,6 +66,7 @@ public class UserService {
     private final FeedRepository feedRepository;
     private final CommentRepository commentRepository;
     private final MessageService messageService;
+    private final WithdrawalReasonRepository withdrawalReasonRepository;
     private static final String KAKAO_PREFIX = "kakao";
     private static final String APPLE_PREFIX = "apple";
 
@@ -183,6 +186,8 @@ public class UserService {
 
         messageService.sendDiscordWebhookMessage(
                 DiscordWebhookMessage.of(messageContent, WITHDRAW));
+
+        withdrawalReasonRepository.save(WithdrawalReason.create(withdrawalRequest.reason()));
     }
 
     private void checkNicknameIfAlreadyExist(String nickname) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#218 -> dev
- close #218

## Key Changes
<!-- 최대한 자세히 -->
애플 소셜 유저 탈퇴 기능을 구현하면서, 기존 개발되어 있던 카카오 소셜 유저 탈퇴 기능과 로직을 통합시켰습니다.
탈퇴를 진행 후 팀 디스코드 서버의 웹 훅으로 탈퇴 알림(탈퇴 유저 id, 닉네임, 탈퇴 사유)를 발송하여 기록합니다.
또한, 탈퇴 사유는 데이터베이스 내 withdrawal_reason 테이블에 저장됩니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
