### PR TITLE
[FIX] '알 수 없음' 프로필 조회 불가 처리

### DIFF
--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomUserError.java
@@ -30,7 +30,8 @@ public enum CustomUserError implements ICustomError {
     ALREADY_SET_NICKNAME("USER-014", "닉네임은 이미 설정된 닉네임과 동일합니다.", BAD_REQUEST),
     PRIVATE_PROFILE_STATUS("USER-015", "프로필 공개 설정이 비공개이므로 접근할 수 없습니다.", FORBIDDEN),
     ALREADY_SET_AVATAR("USER-016", "아바타는 이미 설정된 아바타와 동일합니다.", BAD_REQUEST),
-    ALREADY_SET_INTRO("USER-017", "소개글은 이미 설정된 소개글과 동일합니다.", BAD_REQUEST);
+    ALREADY_SET_INTRO("USER-017", "소개글은 이미 설정된 소개글과 동일합니다.", BAD_REQUEST),
+    INACCESSIBLE_USER_PROFILE("USER-018", "해당 사용자는 접근할 수 없는 상태입니다.", FORBIDDEN);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -7,6 +7,7 @@ import static org.websoso.WSSServer.exception.error.CustomUserError.ALREADY_SET_
 import static org.websoso.WSSServer.exception.error.CustomUserError.ALREADY_SET_NICKNAME;
 import static org.websoso.WSSServer.exception.error.CustomUserError.ALREADY_SET_PROFILE_STATUS;
 import static org.websoso.WSSServer.exception.error.CustomUserError.DUPLICATED_NICKNAME;
+import static org.websoso.WSSServer.exception.error.CustomUserError.INACCESSIBLE_USER_PROFILE;
 import static org.websoso.WSSServer.exception.error.CustomUserError.USER_NOT_FOUND;
 
 import java.util.List;
@@ -133,6 +134,10 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public ProfileGetResponse getProfileInfo(User visitor, Long ownerId) {
+        if (ownerId == -1L) {
+            throw new CustomUserException(INACCESSIBLE_USER_PROFILE,
+                    "The profile for this user is inaccessible: unknown");
+        }
         User owner = getUserOrException(ownerId);
         Byte avatarId = owner.getAvatarId();
         Avatar avatar = findAvatarByIdOrThrow(avatarId);


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#227 -> dev
- close #227

## Key Changes
<!-- 최대한 자세히 -->
- `알 수 없음`의 프로필을 조회하려 할 때 예외를 발생시킵니다.