### PR TITLE
[FIX] 댓글 엔티티 생성 및 수정 시간 수동 기록 방식으로 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/Comment.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Comment.java
@@ -11,13 +11,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import org.websoso.WSSServer.domain.common.Action;
-import org.websoso.WSSServer.domain.common.BaseEntity;
 import org.websoso.WSSServer.exception.exception.CustomCommentException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
 
@@ -25,7 +25,7 @@ import org.websoso.WSSServer.exception.exception.CustomUserException;
 @Getter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment extends BaseEntity {
+public class Comment {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -44,6 +44,12 @@ public class Comment extends BaseEntity {
     @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isSpoiler;
 
+    @Column(nullable = false)
+    private LocalDateTime createdDate;
+
+    @Column(nullable = false)
+    private LocalDateTime modifiedDate;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_id", nullable = false)
     private Feed feed;
@@ -61,6 +67,7 @@ public class Comment extends BaseEntity {
 
     public void updateContent(String commentContent) {
         this.commentContent = commentContent;
+        this.modifiedDate = LocalDateTime.now();
     }
 
     public void validateFeedAssociation(Feed feed) {
@@ -74,6 +81,8 @@ public class Comment extends BaseEntity {
         this.commentContent = commentContent;
         this.userId = userId;
         this.feed = feed;
+        this.createdDate = LocalDateTime.now();
+        this.modifiedDate = this.createdDate;
     }
 
     public void hideComment() {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#229 -> dev
- close #229

## Key Changes
<!-- 최대한 자세히 -->
@ 11/17 클라이언트 QA 과정에서 발견된 이슈입니다
이전 피드 엔티티와 동일하게 BaseEntity 사용으로 인해, 댓글 엔티티가 신고 누적으로 숨김 처리될 때 comment 테이블의 수정 시간(modified_date) 컬럼이 갱신되는 문제가 발생했습니다. 이를 해결하기 위해 Comment 엔티티에서 BaseEntity 상속을 제거하고, 생성 시간과 수정 시간을 직접 관리하도록 로직을 수정하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
