### PR TITLE
[FIX] 카테고리 lightNovel의 한글명을 '라이트노벨'에서 '라노벨'로 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/common/CategoryName.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/CategoryName.java
@@ -12,7 +12,7 @@ public enum CategoryName {
     fantasy("판타지"),
     modernFantasy("현판"),
     drama("드라마"),
-    lightNovel("라이트노벨"),
+    lightNovel("라노벨"),
     wuxia("무협"),
     mystery("미스터리"),
     BL("BL"),


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#231 -> dev
- close #231

## Key Changes
<!-- 최대한 자세히 -->
기존 정책에 맞지 않게 잘못 설정되어 있던 카테고리 lightNovel의 한글명을 수정했습니다.
[라이트노벨] -> [라노벨]

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
