### PR TITLE
[FIX] 공지 반환 순서 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/repository/NoticeRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NoticeRepository.java
@@ -9,6 +9,6 @@ import org.websoso.WSSServer.domain.Notice;
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
-    @Query(value = "SELECT n FROM Notice n WHERE n.userId = ?1 OR n.userId = 0")
+    @Query(value = "SELECT n FROM Notice n WHERE n.userId = ?1 OR n.userId = 0 ORDER BY n.createdDate DESC")
     List<Notice> findByUserId(Long userId);
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#241 -> dev
- close #241

## Key Changes
<!-- 최대한 자세히 -->
- 공지가 오래된 순으로 반환되어 최신순으로 정렬되도록 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
