### PR TITLE
[FIX] 피드 수정 API 요청값 novelId null 체크 로직 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -89,7 +89,7 @@ public class FeedService {
         Feed feed = getFeedOrException(feedId);
         feed.validateUserAuthorization(user, UPDATE);
 
-        if (feed.isNovelChanged(request.novelId())) {
+        if (request.novelId() != null && feed.isNovelChanged(request.novelId())) {
             novelService.getNovelOrException(feed.getNovelId());
         }
         feed.updateFeed(request.feedContent(), request.isSpoiler(), request.novelId());


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#243 -> dev
- close #243

## Key Changes
<!-- 최대한 자세히 -->
소소피드 수정 API의 `FeedService.updateFeed` 메서드에서 요청값으로 들어온 `novelId`가 null일 경우를 고려하여 로직을 수정하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
