### PR TITLE
[FIX] 일반 검색 시 특수문자 무시하도록 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
@@ -35,10 +35,10 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 
     @Override
     public Page<Novel> findSearchedNovels(Pageable pageable, String query) {
-        String searchQuery = query.replaceAll("\\s+", "");
+        String searchQuery = query.replaceAll("\\s+", "").replaceAll("[^a-zA-Z0-9가-힣]", "");
 
-        BooleanExpression titleContainsQuery = getSpaceRemovedString(novel.title).containsIgnoreCase(searchQuery);
-        BooleanExpression authorContainsQuery = getSpaceRemovedString(novel.author).containsIgnoreCase(searchQuery);
+        BooleanExpression titleContainsQuery = getCleanedString(novel.title).containsIgnoreCase(searchQuery);
+        BooleanExpression authorContainsQuery = getCleanedString(novel.author).containsIgnoreCase(searchQuery);
 
         List<Novel> novelsByTitle = jpaQueryFactory
                 .selectFrom(novel)
@@ -67,9 +67,9 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
         return new PageImpl<>(result.subList(start, end), pageable, total);
     }
 
-    private StringTemplate getSpaceRemovedString(StringPath stringPath) {
+    private StringTemplate getCleanedString(StringPath stringPath) {
         return Expressions.stringTemplate(
-                "REPLACE(REPLACE({0}, ' ', ''), CHAR(9), '')",
+                "CAST(REGEXP_REPLACE(REPLACE(REPLACE({0}, ' ', ''), CHAR(9), ''), '[^a-zA-Z0-9가-힣]', '') AS STRING)",
                 stringPath
         );
     }

--- a/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
@@ -34,8 +34,7 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Page<Novel> findSearchedNovels(Pageable pageable, String query) {
-        String searchQuery = query.replaceAll("\\s+", "").replaceAll("[^a-zA-Z0-9가-힣]", "");
+    public Page<Novel> findSearchedNovels(Pageable pageable, String searchQuery) {
 
         BooleanExpression titleContainsQuery = getCleanedString(novel.title).containsIgnoreCase(searchQuery);
         BooleanExpression authorContainsQuery = getCleanedString(novel.author).containsIgnoreCase(searchQuery);

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -280,12 +280,13 @@ public class NovelService {
     @Transactional(readOnly = true)
     public SearchedNovelsGetResponse searchNovels(String query, int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size);
+        String searchQuery = query.replaceAll("\\s+", "").replaceAll("[^a-zA-Z0-9가-힣]", "");
 
-        if (query.isBlank()) {
+        if (searchQuery.isBlank()) {
             return SearchedNovelsGetResponse.of(0L, false, Collections.emptyList());
         }
 
-        Page<Novel> novels = novelRepository.findSearchedNovels(pageRequest, query);
+        Page<Novel> novels = novelRepository.findSearchedNovels(pageRequest, searchQuery);
 
         List<NovelGetResponsePreview> novelGetResponsePreviews = novels.stream()
                 .map(this::convertToDTO)


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#247 -> dev
- close #247 

## Key Changes
<!-- 최대한 자세히 -->
- **Notion** [검색 시 특수문자 무시 설정](https://www.notion.so/kimmjabc/1669e64a4532805794b5efaf75def62a)
- **현재 검색 방식:**
  "울어 봐"라고 검색하면 "울어봐"로 띄어쓰기를 없앤 뒤, 모든 띄어쓰기를 없앤 작품 제목들 중 "울어봐"를 포함한 작품들을 반환합니다. 그렇기 때문에 "울어봐 빌어도"라고 검색하면 "울어봐빌어도"를 포함한 것들을 검색하기 때문에 "울어 봐, 빌어도 좋고"라는 작품은 검색 결과로 나타나지 않습니다.
- **변경된 검색 방식:**
  그렇기 때문에 검색 시 특수문자를 무시하도록 검색 방식이 수정됐습니다.
  또한 기획 측에서 결정한 내용에 따라 특수문자만을 가지고 검색 시 빈 리스트를 반환하도록 수정하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 다음 스프린트, 혹은 다다음... 스프린트 중에 검색 방식을 아예 개편할 것 같습니다. 일단 임시방편으로 특수문자를 무시하도록 바꿨다는 점...

## References
<!-- 참고한 자료-->
