### PR TITLE
[FIX] 유저 가입 일시 저장 및 가입 시 디스코드 알람 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -14,7 +14,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.time.LocalDateTime;
 import java.time.Year;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.websoso.WSSServer.domain.common.BaseEntity;
 import org.websoso.WSSServer.domain.common.Gender;
 import org.websoso.WSSServer.domain.common.Role;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
@@ -40,7 +40,7 @@ import org.websoso.WSSServer.dto.user.UserBasicInfo;
                 name = "UNIQUE_SOCIAL_ID_CONSTRAINT",
                 columnNames = "social_id")
 })
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -78,9 +78,6 @@ public class User {
     @Column(nullable = false)
     @ColumnDefault("'USER'")
     private Role role;
-
-    @Column(nullable = false)
-    private LocalDateTime created_date;
 
     @OneToMany(mappedBy = "user", cascade = ALL, orphanRemoval = true)
     private List<GenrePreference> genrePreferences = new ArrayList<>();
@@ -130,7 +127,6 @@ public class User {
         this.socialId = socialId;
         this.nickname = nickname;
         this.email = email;
-        this.created_date = LocalDateTime.now();
     }
 
     public static User createBySocial(String socialId, String nickname, String email) {

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
 import java.time.Year;
 import java.util.ArrayList;
 import java.util.List;
@@ -78,6 +79,9 @@ public class User {
     @ColumnDefault("'USER'")
     private Role role;
 
+    @Column(nullable = false)
+    private LocalDateTime created_date;
+
     @OneToMany(mappedBy = "user", cascade = ALL, orphanRemoval = true)
     private List<GenrePreference> genrePreferences = new ArrayList<>();
 
@@ -126,6 +130,7 @@ public class User {
         this.socialId = socialId;
         this.nickname = nickname;
         this.email = email;
+        this.created_date = LocalDateTime.now();
     }
 
     public static User createBySocial(String socialId, String nickname, String email) {

--- a/src/main/java/org/websoso/WSSServer/domain/common/DiscordWebhookMessageType.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/DiscordWebhookMessageType.java
@@ -1,5 +1,5 @@
 package org.websoso.WSSServer.domain.common;
 
 public enum DiscordWebhookMessageType {
-    WITHDRAW, REPORT
+    WITHDRAW, REPORT, JOIN
 }

--- a/src/main/java/org/websoso/WSSServer/domain/common/SocialLoginType.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/SocialLoginType.java
@@ -1,0 +1,13 @@
+package org.websoso.WSSServer.domain.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SocialLoginType {
+    KAKAO("카카오"), APPLE("애플");
+
+    private final String label;
+    
+}

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
@@ -1,5 +1,7 @@
 package org.websoso.WSSServer.oauth2.service;
 
+import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.JOIN;
+import static org.websoso.WSSServer.domain.common.SocialLoginType.APPLE;
 import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.CLIENT_SECRET_CREATION_FAILED;
 import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.EMPTY_JWT;
 import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.HEADER_PARSING_FAILED;
@@ -53,6 +55,7 @@ import org.websoso.WSSServer.config.jwt.UserAuthentication;
 import org.websoso.WSSServer.domain.RefreshToken;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserAppleToken;
+import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.dto.auth.AppleLoginRequest;
 import org.websoso.WSSServer.dto.auth.ApplePublicKey;
 import org.websoso.WSSServer.dto.auth.ApplePublicKeys;
@@ -62,6 +65,8 @@ import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
 import org.websoso.WSSServer.repository.RefreshTokenRepository;
 import org.websoso.WSSServer.repository.UserAppleTokenRepository;
 import org.websoso.WSSServer.repository.UserRepository;
+import org.websoso.WSSServer.service.MessageFormatter;
+import org.websoso.WSSServer.service.MessageService;
 
 @Transactional
 @Service
@@ -81,6 +86,7 @@ public class AppleService {
     private final UserRepository userRepository;
     private final UserAppleTokenRepository userAppleTokenRepository;
     private final JwtProvider jwtProvider;
+    private final MessageService messageService;
 
     @Value("${apple.public-keys-url}")
     private String applePublicKeysUrl;
@@ -278,9 +284,12 @@ public class AppleService {
     private AuthResponse authenticate(String socialId, String email, String nickname, String appleRefreshToken) {
         User user = userRepository.findBySocialId(socialId);
 
+        boolean isNewUser = false;
+
         if (user == null) {
             user = userRepository.save(User.createBySocial(socialId, nickname, email));
             userAppleTokenRepository.save(UserAppleToken.create(user, appleRefreshToken));
+            isNewUser = true;
         }
 
         UserAuthentication userAuthentication = new UserAuthentication(user.getUserId(), null, null);
@@ -290,6 +299,11 @@ public class AppleService {
         refreshTokenRepository.save(new RefreshToken(refreshToken, user.getUserId()));
 
         boolean isRegister = !user.getNickname().contains("*");
+
+        if (isNewUser) {
+            messageService.sendDiscordWebhookMessage(
+                    DiscordWebhookMessage.of(MessageFormatter.formatUserJoinMessage(user, APPLE), JOIN));
+        }
 
         return AuthResponse.of(accessToken, refreshToken, isRegister);
     }

--- a/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
@@ -99,7 +99,7 @@ public class MessageFormatter {
     public static String formatUserJoinMessage(User user, SocialLoginType socialLoginType) {
         return String.format(
                 USER_JOIN_MESSAGE,
-                user.getCreated_date(),
+                user.getCreatedDate(),
                 socialLoginType.getLabel(),
                 user.getUserId()
         );

--- a/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
@@ -9,6 +9,7 @@ import org.websoso.WSSServer.domain.Comment;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.common.ReportedType;
+import org.websoso.WSSServer.domain.common.SocialLoginType;
 
 public class MessageFormatter {
 
@@ -38,6 +39,13 @@ public class MessageFormatter {
                     "유저 아이디 : %d\n" +
                     "유저 닉네임 : %s\n\n" +
                     "[탈퇴 사유]\n%s\n\n```";
+
+    private static final String USER_JOIN_MESSAGE =
+            "```[%s] 새로운 사용자가 가입하였습니다.\n\n" +
+                    "[가입한 사용자]\n" +
+                    "로그인 방식 : %s\n" +
+                    "유저 아이디 : %d\n" +
+                    "가입을 환영합니다!\n\n```";
 
     public static String formatFeedReportMessage(Feed feed, ReportedType reportedType, int reportedCount,
                                                  boolean isHidden) {
@@ -85,6 +93,15 @@ public class MessageFormatter {
                 userId,
                 userNickname,
                 reason
+        );
+    }
+
+    public static String formatUserJoinMessage(User user, SocialLoginType socialLoginType) {
+        return String.format(
+                USER_JOIN_MESSAGE,
+                user.getCreated_date(),
+                socialLoginType.getLabel(),
+                user.getUserId()
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/MessageService.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageService.java
@@ -2,7 +2,9 @@ package org.websoso.WSSServer.service;
 
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.JOIN;
 import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.REPORT;
+import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.WITHDRAW;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,21 +21,29 @@ public class MessageService {
 
     @Value("${logging.discord.report-webhook-url}")
     private String discordReportWebhookUrl;
-
     @Value("${logging.discord.withdraw-webhook-url}")
     private String discordWithdrawWebhookUrl;
+    @Value("${logging.discord.join-webhook-url}")
+    private String discordJoinWebhookUrl;
 
     public void sendDiscordWebhookMessage(DiscordWebhookMessage message) {
         try {
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.add("Content-Type", "application/json; utf-8");
             HttpEntity<DiscordWebhookMessage> messageEntity = new HttpEntity<>(message, httpHeaders);
+            String webhookUrl = "";
+
+            if (message.type() == REPORT) {
+                webhookUrl = discordReportWebhookUrl;
+            } else if (message.type() == WITHDRAW) {
+                webhookUrl = discordWithdrawWebhookUrl;
+            } else if (message.type() == JOIN) {
+                webhookUrl = discordJoinWebhookUrl;
+            }
 
             RestTemplate template = new RestTemplate();
             ResponseEntity<String> response = template.exchange(
-                    message.type() == REPORT ?
-                            discordReportWebhookUrl :
-                            discordWithdrawWebhookUrl,
+                    webhookUrl,
                     POST,
                     messageEntity,
                     String.class

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -1,8 +1,6 @@
 package org.websoso.WSSServer.service;
 
-import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.JOIN;
 import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.WITHDRAW;
-import static org.websoso.WSSServer.domain.common.SocialLoginType.KAKAO;
 import static org.websoso.WSSServer.exception.error.CustomAvatarError.AVATAR_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomGenreError.GENRE_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomUserError.ALREADY_SET_AVATAR;
@@ -89,9 +87,6 @@ public class UserService {
 
         UserAuthentication userAuthentication = new UserAuthentication(user.getUserId(), null, null);
         String token = jwtProvider.generateAccessToken(userAuthentication);
-
-        messageService.sendDiscordWebhookMessage(
-                DiscordWebhookMessage.of(MessageFormatter.formatUserJoinMessage(user, KAKAO), JOIN));
 
         return LoginResponse.of(token);
     }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -1,6 +1,8 @@
 package org.websoso.WSSServer.service;
 
+import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.JOIN;
 import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.WITHDRAW;
+import static org.websoso.WSSServer.domain.common.SocialLoginType.KAKAO;
 import static org.websoso.WSSServer.exception.error.CustomAvatarError.AVATAR_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomGenreError.GENRE_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomUserError.ALREADY_SET_AVATAR;
@@ -87,6 +89,9 @@ public class UserService {
 
         UserAuthentication userAuthentication = new UserAuthentication(user.getUserId(), null, null);
         String token = jwtProvider.generateAccessToken(userAuthentication);
+
+        messageService.sendDiscordWebhookMessage(
+                DiscordWebhookMessage.of(MessageFormatter.formatUserJoinMessage(user, KAKAO), JOIN));
 
         return LoginResponse.of(token);
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#249 -> dev
- close #249

## Key Changes
<!-- 최대한 자세히 -->
1. 유저 가입 일시 저장 기능 구현
   - user 테이블에 BaseEntity를 사용하여 생성시간과 수정시간 컬럼 추가 및 자동 저장 되도록 처리
   - 해당 PR 병합 전, 이미 존재하던 기존 유저 데이터는 생성시간, 수정시간 기본값을 2024-12-17 00:00:00으로 일괄 설정할 계획

2. 신규 유저 가입 시 디스코드 알람 전송 기능 추가
   - 새로운 유저 가입 시 디스코드 웹훅 메시지를 전송하도록 구현

3. 운영 서버와 개발 서버의 디스코드 웹훅 분리
   - 기존에는 운영 서버와 개발 서버가 동일한 디스코드 웹훅을 사용하여 알람이 혼재되었음
   - 운영 서버와 개발 서버 각각 고유의 웹훅 URL을 사용하여 알람 분리
   - `.yml`을 통해 배포 시 각 서버에 맞는 웹훅 URL이 매칭되도록 설정함 

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
12/29 ~ 1/1일 기간에 개발 서버에 유저가 가입하는 이슈가 있었습니다! 
추후 비슷한 이슈가 발생한다면 빠른 대처를 위해 기능을 보수하게 되었습니다.
이슈 한 번씩 보면 이해가 잘 되실겁니당!
혹시 누락된 점이나 로직 상 오류가 있다면 꼭 말씀해주세요! 🙌

## References
<!-- 참고한 자료-->
