### PR TITLE
[FEAT] NoticeCategory 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/Notice.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Notice.java
@@ -28,6 +28,9 @@ public class Notice extends BaseEntity {
     @Column(columnDefinition = "varchar(2000)", nullable = false)
     private String noticeContent;
 
+    @Column(columnDefinition = "text", nullable = false)
+    private String noticeIcon;
+
     @Column
     private Long userId;
 

--- a/src/main/java/org/websoso/WSSServer/domain/Notice.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Notice.java
@@ -4,8 +4,11 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,17 +37,23 @@ public class Notice extends BaseEntity {
     @Column
     private Long userId;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_category_id", nullable = false)
+    private NoticeCategory noticeCategory;
+
     @Builder
-    private Notice(String noticeTitle, String noticeContent, Long userId) {
+    private Notice(String noticeTitle, String noticeContent, Long userId, NoticeCategory noticeCategory) {
         this.noticeTitle = noticeTitle;
         this.noticeContent = noticeContent;
         this.userId = userId;
+        this.noticeCategory = noticeCategory;
     }
 
-    public void updateNotice(String noticeTitle, String noticeContent, Long userId) {
+    public void updateNotice(String noticeTitle, String noticeContent, Long userId, NoticeCategory noticeCategory) {
         this.noticeTitle = noticeTitle;
         this.noticeContent = noticeContent;
         this.userId = userId;
+        this.noticeCategory = noticeCategory;
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/domain/NoticeCategory.java
+++ b/src/main/java/org/websoso/WSSServer/domain/NoticeCategory.java
@@ -1,0 +1,28 @@
+package org.websoso.WSSServer.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeCategory {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false)
+    private Byte noticeCategoryId;
+
+    @Column(columnDefinition = "varchar(10)", nullable = false)
+    private String noticeCategoryName;
+
+    @Column(columnDefinition = "text", nullable = false)
+    private String noticeCategoryImage;
+}

--- a/src/main/java/org/websoso/WSSServer/dto/notice/NoticeEditRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notice/NoticeEditRequest.java
@@ -15,6 +15,8 @@ public record NoticeEditRequest(
         String noticeContent,
 
         @ZeroAllowedUserIdConstraint
-        Long userId
+        Long userId,
+
+        Byte noticeCategoryId
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/notice/NoticeGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notice/NoticeGetResponse.java
@@ -7,6 +7,7 @@ import org.websoso.WSSServer.domain.Notice;
 public record NoticeGetResponse(
         String noticeTitle,
         String noticeContent,
+        String noticeCategoryImage,
         String createdDate
 ) {
 
@@ -14,6 +15,7 @@ public record NoticeGetResponse(
         return new NoticeGetResponse(
                 notice.getNoticeTitle(),
                 notice.getNoticeContent(),
+                notice.getNoticeCategory().getNoticeCategoryImage(),
                 formatDateString(notice.getCreatedDate())
         );
     }

--- a/src/main/java/org/websoso/WSSServer/dto/notice/NoticePostRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notice/NoticePostRequest.java
@@ -15,6 +15,8 @@ public record NoticePostRequest(
         String noticeContent,
 
         @ZeroAllowedUserIdConstraint
-        Long userId
+        Long userId,
+
+        Byte noticeCategoryId
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomNoticeCategoryError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomNoticeCategoryError.java
@@ -1,0 +1,19 @@
+package org.websoso.WSSServer.exception.error;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.websoso.WSSServer.exception.common.ICustomError;
+
+@AllArgsConstructor
+@Getter
+public enum CustomNoticeCategoryError implements ICustomError {
+
+    NOTICE_CATEGORY_NOT_FOUND("NOTICE_CATEGORY-001", "해당 아이디를 가진 공지 카테고리를 찾을 수 없습니다.", NOT_FOUND);
+
+    private final String code;
+    private final String description;
+    private final HttpStatus statusCode;
+}

--- a/src/main/java/org/websoso/WSSServer/exception/exception/CustomNoticeCategoryException.java
+++ b/src/main/java/org/websoso/WSSServer/exception/exception/CustomNoticeCategoryException.java
@@ -1,0 +1,13 @@
+package org.websoso.WSSServer.exception.exception;
+
+import lombok.Getter;
+import org.websoso.WSSServer.exception.common.AbstractCustomException;
+import org.websoso.WSSServer.exception.error.CustomNoticeCategoryError;
+
+@Getter
+public class CustomNoticeCategoryException extends AbstractCustomException {
+
+    public CustomNoticeCategoryException(CustomNoticeCategoryError customNoticeCategoryError, String message) {
+        super(customNoticeCategoryError, message);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/repository/NoticeCategoryRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NoticeCategoryRepository.java
@@ -1,0 +1,9 @@
+package org.websoso.WSSServer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.NoticeCategory;
+
+@Repository
+public interface NoticeCategoryRepository extends JpaRepository<NoticeCategory, Byte> {
+}

--- a/src/main/java/org/websoso/WSSServer/service/NoticeService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NoticeService.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.domain.common.Role.ADMIN;
+import static org.websoso.WSSServer.exception.error.CustomNoticeCategoryError.NOTICE_CATEGORY_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomNoticeError.NOTICE_FORBIDDEN;
 import static org.websoso.WSSServer.exception.error.CustomNoticeError.NOTICE_NOT_FOUND;
 
@@ -9,12 +10,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Notice;
+import org.websoso.WSSServer.domain.NoticeCategory;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.common.Role;
 import org.websoso.WSSServer.dto.notice.NoticeEditRequest;
 import org.websoso.WSSServer.dto.notice.NoticePostRequest;
 import org.websoso.WSSServer.dto.notice.NoticesGetResponse;
+import org.websoso.WSSServer.exception.exception.CustomNoticeCategoryException;
 import org.websoso.WSSServer.exception.exception.CustomNoticeException;
+import org.websoso.WSSServer.repository.NoticeCategoryRepository;
 import org.websoso.WSSServer.repository.NoticeRepository;
 
 @Service
@@ -23,6 +27,8 @@ import org.websoso.WSSServer.repository.NoticeRepository;
 public class NoticeService {
 
     private final NoticeRepository noticeRepository;
+    private final NoticeCategoryRepository noticeCategoryRepository;
+
     private static final Role ADMIN_ROLE = ADMIN;
 
     public void createNotice(User user, NoticePostRequest noticePostRequest) {
@@ -31,6 +37,7 @@ public class NoticeService {
                 .noticeTitle(noticePostRequest.noticeTitle())
                 .noticeContent(noticePostRequest.noticeContent())
                 .userId(noticePostRequest.userId())
+                .noticeCategory(getNoticeCategoryOrException(noticePostRequest.noticeCategoryId()))
                 .build());
     }
 
@@ -38,7 +45,7 @@ public class NoticeService {
         validateAuthorization(user);
         Notice notice = getNoticeOrException(noticeId);
         notice.updateNotice(noticeEditRequest.noticeTitle(), noticeEditRequest.noticeContent(),
-                noticeEditRequest.userId());
+                noticeEditRequest.userId(), getNoticeCategoryOrException(noticeEditRequest.noticeCategoryId()));
     }
 
     private static void validateAuthorization(User user) {
@@ -63,5 +70,11 @@ public class NoticeService {
     private Notice getNoticeOrException(Long noticeId) {
         return noticeRepository.findById(noticeId).orElseThrow(() ->
                 new CustomNoticeException(NOTICE_NOT_FOUND, "notice with given noticeId was not found"));
+    }
+
+    private NoticeCategory getNoticeCategoryOrException(Byte noticeCategoryId) {
+        return noticeCategoryRepository.findById(noticeCategoryId).orElseThrow(
+                () -> new CustomNoticeCategoryException(NOTICE_CATEGORY_NOT_FOUND,
+                        "notice category with given noticeCategoryId was not found"));
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#253 -> dev
- close #253 

## Key Changes
<!-- 최대한 자세히 -->
공지를 내려주는 방식에 변경사항이 있었습니다.

- 기존방식: 공지에서 모두 같은 아이콘을 사용해 클라에서 처리
- 변경된방식: 공지마다 다른 아이콘을 사용해 서버에서 이미지값 함께 반환

이에 NoticeCategory를 추가하고 이를 기존 코드에 반영했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
테이블 변경사항은 DEV DB에만 반영해뒀습니다! 추후 머지되면 PROD DB에도 반영하겠습니다~

## References
<!-- 참고한 자료-->
- [공지를 내려주는 방식에 변경사항](https://www.notion.so/kimmjabc/1729e64a453280139ee5ffa58ef6a6d5)