### PR TITLE
[HOTFIX] 수다 카테고리 수정 시 특정 피드와 연관된 카테고리만 삭제되도록 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCategoryRepository.java
@@ -15,7 +15,7 @@ public interface FeedCategoryRepository extends JpaRepository<FeedCategory, Long
 
     List<FeedCategory> findByFeed(Feed feed);
 
-    void deleteByCategory(Category category);
+    void deleteByCategoryAndFeed(Category category, Feed feed);
 
     @Query(value = "SELECT fc.feed FROM FeedCategory fc "
             + "WHERE fc.category = :category "

--- a/src/main/java/org/websoso/WSSServer/service/FeedCategoryService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedCategoryService.java
@@ -53,7 +53,7 @@ public class FeedCategoryService {
         }
 
         for (Category category : categories) {
-            feedcategoryRepository.deleteByCategory(category);
+            feedcategoryRepository.deleteByCategoryAndFeed(category, feed);
         }
     }
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- bugfix/#257 -> dev
- close #257

## Key Changes
<!-- 최대한 자세히 -->
- 기존 로직에서 `deleteByCategory`를 사용하여 동일 카테고리를 가진 모든 엔티티가 삭제되는 문제
   ➡️  새로운 메서드 `deleteByCategoryAndFeed`를 사용하여 특정 피드와 연결된 카테고리만 삭제하도록 변경

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 해당 수다 수정 API 초기 설계 시부터 잘못 구현된 부분을 이제서야 발견했습니다 ㅠㅠ
- 늦게 발견된 점 죄송하며, 문제가 긴급하다고 판단되어 hotfix로 분류했습니다.
- 로컬 환경에서 잘 작동되는 것을 확인했고, 빠른 시일 내에 반영될 수 있도록 리뷰 부탁드립니다 🙏