### PR TITLE
[FIX] '이벤트' 타입의 알림도 isNotice = True로 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/notification/NotificationInfo.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notification/NotificationInfo.java
@@ -3,6 +3,7 @@ package org.websoso.WSSServer.dto.notification;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Set;
 import org.websoso.WSSServer.domain.Notification;
 
 public record NotificationInfo(
@@ -22,6 +23,7 @@ public record NotificationInfo(
     private static final String DATE_PATTERN = "yyyy.MM.dd";
 
     static public NotificationInfo of(Notification notification, Boolean isRead) {
+        Set<String> validNoticeTypes = Set.of("공지", "이벤트");
         return new NotificationInfo(
                 notification.getNotificationId(),
                 notification.getNotificationType().getNotificationTypeImage(),
@@ -29,7 +31,7 @@ public record NotificationInfo(
                 notification.getNotificationDescription(),
                 formatCreatedDate(notification.getCreatedDate()),
                 isRead,
-                notification.getNotificationType().getNotificationTypeName().equals("공지"),
+                validNoticeTypes.contains(notification.getNotificationType().getNotificationTypeName()),
                 notification.getFeedId()
         );
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#264 -> dev
- close #264

## Key Changes
<!-- 최대한 자세히 -->
기존 코드에서 공지 타입만 isNotice을 True로 반환하여, 이벤트 타입도 True를 반환하도록 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->