### PR TITLE
[FIX] 인기 수다글 선정 좋아요 기준 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -56,6 +56,7 @@ public class FeedService {
 
     private static final String DEFAULT_CATEGORY = "all";
     private static final int DEFAULT_PAGE_NUMBER = 0;
+    private static final int POPULAR_FEED_LIKE_THRESHOLD = 5;
     private final FeedRepository feedRepository;
     private final FeedCategoryService feedCategoryService;
     private final NovelService novelService;
@@ -107,12 +108,9 @@ public class FeedService {
         checkHiddenFeed(feed);
         checkBlocked(feed.getUser(), user);
 
-        boolean isPopularFeed = false;
-        if (feed.getLikes().size() == 9) {
-            isPopularFeed = true;
-        }
         likeService.createLike(user, feed);
-        if (isPopularFeed) {
+
+        if (feed.getLikes().size() == POPULAR_FEED_LIKE_THRESHOLD) {
             popularFeedService.createPopularFeed(feed);
         }
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#261 -> dev
- close #261

## Key Changes
<!-- 최대한 자세히 -->
- 인기 수다글 선정하는 기준 정책이 아래와 같이 변경되어 수다글 좋아요 생성 로직의 인기수다글 판별 코드를 수정했습니다.
  - `좋아요 10개`  ▶︎  `좋아요 5개`
- 기존에 하드코딩되어 있던 좋아요 기준 개수를 유지보수에 용이하도록 상수화했습니다.
- 인기수다글 판별 로직을 리팩토링 했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
