### PR TITLE
[FIX] 유저 가입 디스코드 알림 발송 시점(기준) 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/common/DiscordMessageTemplate.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/DiscordMessageTemplate.java
@@ -44,7 +44,7 @@ public enum DiscordMessageTemplate {
             "```[%s] 🎉 새로운 사용자가 가입하였습니다 🎉\n\n"
                     + "[가입한 사용자]\n"
                     + "- 로그인 방식: %s\n"
-                    + "- ID: %d\n"
+                    + "- 닉네임: %s (ID: %d)\n"
                     + "환영합니다!\n\n```");
 
     private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm";

--- a/src/main/java/org/websoso/WSSServer/domain/common/SocialLoginType.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/SocialLoginType.java
@@ -1,13 +1,26 @@
 package org.websoso.WSSServer.domain.common;
 
+import static org.websoso.WSSServer.exception.error.CustomAuthError.UNSUPPORTED_SOCIAL_LOGIN_TYPE;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.websoso.WSSServer.exception.exception.CustomAuthException;
 
 @Getter
 @AllArgsConstructor
 public enum SocialLoginType {
-    KAKAO("카카오"), APPLE("애플");
+    KAKAO("카카오", "kakao"),
+    APPLE("애플", "apple");
 
     private final String label;
-    
+    private final String prefix;
+
+    public static SocialLoginType fromSocialId(String socialId) {
+        for (SocialLoginType type : values()) {
+            if (socialId.startsWith(type.getPrefix())) {
+                return type;
+            }
+        }
+        throw new CustomAuthException(UNSUPPORTED_SOCIAL_LOGIN_TYPE, "unsupported social login type");
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomAuthError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomAuthError.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.exception.error;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import lombok.AllArgsConstructor;
@@ -11,7 +12,8 @@ import org.websoso.WSSServer.exception.common.ICustomError;
 @AllArgsConstructor
 public enum CustomAuthError implements ICustomError {
 
-    INVALID_TOKEN("AUTH-001", "유효하지 않은 토큰입니다.", UNAUTHORIZED);
+    INVALID_TOKEN("AUTH-001", "유효하지 않은 토큰입니다.", UNAUTHORIZED),
+    UNSUPPORTED_SOCIAL_LOGIN_TYPE("AUTH-002", "지원되지 않는 소셜 로그인 유형입니다.", BAD_REQUEST);
 
     private final String code;
     private final String description;

--- a/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/KakaoService.java
@@ -1,7 +1,5 @@
 package org.websoso.WSSServer.oauth2.service;
 
-import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.JOIN;
-import static org.websoso.WSSServer.domain.common.SocialLoginType.KAKAO;
 import static org.websoso.WSSServer.exception.error.CustomKakaoError.INVALID_KAKAO_ACCESS_TOKEN;
 import static org.websoso.WSSServer.exception.error.CustomKakaoError.KAKAO_SERVER_ERROR;
 
@@ -18,13 +16,11 @@ import org.websoso.WSSServer.config.jwt.JwtProvider;
 import org.websoso.WSSServer.config.jwt.UserAuthentication;
 import org.websoso.WSSServer.domain.RefreshToken;
 import org.websoso.WSSServer.domain.User;
-import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.dto.auth.AuthResponse;
 import org.websoso.WSSServer.exception.exception.CustomKakaoException;
 import org.websoso.WSSServer.oauth2.dto.KakaoUserInfo;
 import org.websoso.WSSServer.repository.RefreshTokenRepository;
 import org.websoso.WSSServer.repository.UserRepository;
-import org.websoso.WSSServer.service.MessageFormatter;
 import org.websoso.WSSServer.service.MessageService;
 
 @Service
@@ -69,11 +65,9 @@ public class KakaoService {
         String socialId = "kakao_" + kakaoUserInfo.id();
         String defaultNickname = "k*" + kakaoUserInfo.id().toString().substring(2, 10);
 
-        boolean isNewUser = false;
         User user = userRepository.findBySocialId(socialId);
         if (user == null) {
             user = userRepository.save(User.createBySocial(socialId, defaultNickname, kakaoUserInfo.email()));
-            isNewUser = true;
         }
 
         UserAuthentication userAuthentication = new UserAuthentication(user.getUserId(), null, null);
@@ -84,11 +78,6 @@ public class KakaoService {
         refreshTokenRepository.save(redisRefreshToken);
 
         boolean isRegister = !user.getNickname().contains("*");
-
-        if (isNewUser) {
-            messageService.sendDiscordWebhookMessage(
-                    DiscordWebhookMessage.of(MessageFormatter.formatUserJoinMessage(user, KAKAO), JOIN));
-        }
         return AuthResponse.of(accessToken, refreshToken, isRegister);
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
@@ -78,6 +78,7 @@ public class MessageFormatter {
                 USER_JOIN.getTemplate(),
                 DiscordMessageTemplate.getCurrentDateTime(),
                 socialLoginType.getLabel(),
+                user.getNickname(),
                 user.getUserId()
         );
     }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.service;
 
+import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.JOIN;
 import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.WITHDRAW;
 import static org.websoso.WSSServer.exception.error.CustomAvatarError.AVATAR_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomGenreError.GENRE_NOT_FOUND;
@@ -23,6 +24,7 @@ import org.websoso.WSSServer.domain.GenrePreference;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.WithdrawalReason;
 import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
+import org.websoso.WSSServer.domain.common.SocialLoginType;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
 import org.websoso.WSSServer.dto.user.LoginResponse;
@@ -167,6 +169,9 @@ public class UserService {
         user.updateUserInfo(registerUserInfoRequest);
         List<GenrePreference> preferGenres = createGenrePreferences(user, registerUserInfoRequest.genrePreferences());
         genrePreferenceRepository.saveAll(preferGenres);
+
+        messageService.sendDiscordWebhookMessage(DiscordWebhookMessage.of(
+                MessageFormatter.formatUserJoinMessage(user, SocialLoginType.fromSocialId(user.getSocialId())), JOIN));
     }
 
     public void logout(User user, String refreshToken) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#262 -> dev
- close #262 

## Key Changes
<!-- 최대한 자세히 -->
유저 가입 디스코드 알림 발송 시점(기준)을 변경했습니다. 변경 사유는 관련 이슈에 명시되어 있습니다.
- 기존: 유저가 소셜 로그인으로 가입하여 데이터베이스에 저장되면 디스코드 알림 발송
- 변경: 유저가 소셜 로그인으로 가입 후, 온보딩 과정을 완료(닉네임, 선호 장르 등 프로필 설정 완료)한 이후에만 디스코드 알림을 발송하도록 로직 수정

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- #256

  - 디스코드 알림 발송 로직 전체를 리팩토링한 PR입니다.
  - 해당 PR 브랜치에서 rebase 후 개발을 진행해서 코드리뷰 주실 때 제일 최근 커밋만 확인해주시면 됩니다!
