### PR TITLE
[FIX] 유저 수다글 조회 API에서 별점 값을 반올림된 값으로 응답하도록 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -97,7 +97,7 @@ public record UserFeedGetResponse(
             return null;
         }
         return novelRatingCount > 0
-                ? getNovelRatingSum(novel) / novelRatingCount
+                ? Math.round(getNovelRatingSum(novel) / novelRatingCount * 10) / 10.0f
                 : 0.0f;
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#272 -> dev
- close #272

## Key Changes
<!-- 최대한 자세히 -->
기존 유저 수다글 조회 API 응답값에서 작품 평균 별점이 반올림되지 않은 값으로 반환되던 문제를 수정하였습니다.
- 작품 평균 별점을 계산하는 함수에서 소수점 첫째 자리까지 반올림 처리하여 반환하도록 반올림 로직 추가하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->