### PR TITLE
[FEAT] 앱 내 푸시알림 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ src/main/generated/
 
 ## Apple Login Key File ##
 *.p8
+
+/src/main/resources/websoso-fcm.json

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ dependencies {
 
     //Apple Login
     implementation 'com.nimbusds:nimbus-jose-jwt:3.10'
+
+    // FCM
+    implementation 'com.google.firebase:firebase-admin:8.1.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -213,7 +213,7 @@ public class UserController {
 
     @PostMapping("/fcm-token")
     public ResponseEntity<Void> registerFCMToken(Principal principal,
-                                                 @RequestBody FCMTokenRequest fcmTokenRequest) {
+                                                 @Valid @RequestBody FCMTokenRequest fcmTokenRequest) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         userService.registerFCMToken(user, fcmTokenRequest.fcmToken());
         return ResponseEntity

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -22,6 +22,7 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.feed.UserFeedsGetResponse;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
+import org.websoso.WSSServer.dto.user.FCMTokenRequest;
 import org.websoso.WSSServer.dto.user.LoginResponse;
 import org.websoso.WSSServer.dto.user.MyProfileResponse;
 import org.websoso.WSSServer.dto.user.NicknameValidation;
@@ -208,5 +209,15 @@ public class UserController {
         return ResponseEntity
                 .status(OK)
                 .body(userService.getUserIdAndNicknameAndGender(user));
+    }
+
+    @PostMapping("/fcm-token")
+    public ResponseEntity<Void> registerFCMToken(Principal principal,
+                                                 @RequestBody FCMTokenRequest fcmTokenRequest) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        userService.registerFCMToken(user, fcmTokenRequest.fcmToken());
+        return ResponseEntity
+                .status(OK)
+                .build();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -139,4 +139,8 @@ public class User {
         this.gender = Gender.valueOf(editMyInfoRequest.gender());
         this.birth = Year.of(editMyInfoRequest.birth());
     }
+
+    public void updateFCMToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -49,6 +49,9 @@ public class User {
     @Column(nullable = false)
     private String socialId;
 
+    @Column
+    private String fcmToken;
+
     @Column(columnDefinition = "varchar(10)", nullable = false)
     private String nickname;
     //TODO 일부 특수문자 제외, 앞뒤 공백 불가능

--- a/src/main/java/org/websoso/WSSServer/dto/user/FCMTokenRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/FCMTokenRequest.java
@@ -1,6 +1,9 @@
 package org.websoso.WSSServer.dto.user;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record FCMTokenRequest(
+        @NotBlank(message = "FCM Token 값은 null 이거나, 공백일 수 없습니다.")
         String fcmToken
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/user/FCMTokenRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/FCMTokenRequest.java
@@ -1,0 +1,6 @@
+package org.websoso.WSSServer.dto.user;
+
+public record FCMTokenRequest(
+        String fcmToken
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
@@ -1,0 +1,14 @@
+package org.websoso.WSSServer.notification;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FCMConfig {
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.notification;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
 import org.springframework.context.annotation.Bean;
@@ -18,5 +19,9 @@ public class FCMConfig {
         FirebaseOptions firebaseOptions = FirebaseOptions.builder()
                 .setCredentials(googleCredentials)
                 .build();
+
+        if (FirebaseApp.getApps().isEmpty()) {
+            FirebaseApp.initializeApp(firebaseOptions);
+        }
     }
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
@@ -4,6 +4,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
@@ -11,10 +12,13 @@ import org.springframework.core.io.ClassPathResource;
 @Configuration
 public class FCMConfig {
 
+    @Value("${fcm.key-path}")
+    private String firebaseConfigPath;
+
     @Bean
     public FirebaseMessaging firebaseMessaging() {
         GoogleCredentials googleCredentials = GoogleCredentials
-                .fromStream(new ClassPathResource("websoso-fcm.json").getInputStream());
+                .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream());
 
         FirebaseOptions firebaseOptions = FirebaseOptions.builder()
                 .setCredentials(googleCredentials)

--- a/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
@@ -4,6 +4,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
+import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -19,17 +20,22 @@ public class FCMConfig {
 
     @Bean
     public FirebaseMessaging firebaseMessaging() {
-        GoogleCredentials googleCredentials = GoogleCredentials
-                .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream());
+        try {
+            GoogleCredentials googleCredentials = GoogleCredentials
+                    .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream());
 
-        FirebaseOptions firebaseOptions = FirebaseOptions.builder()
-                .setCredentials(googleCredentials)
-                .build();
+            FirebaseOptions firebaseOptions = FirebaseOptions.builder()
+                    .setCredentials(googleCredentials)
+                    .build();
 
-        if (FirebaseApp.getApps().isEmpty()) {
-            FirebaseApp.initializeApp(firebaseOptions);
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(firebaseOptions);
+            }
+
+            return FirebaseMessaging.getInstance();
+        } catch (IOException e) {
+            log.error("[FirebaseMessaging] Failed to initialize FirebaseMessaging", e);
+            throw new IllegalStateException("Failed to initialize FirebaseMessaging due to firebase key file", e);
         }
-
-        return FirebaseMessaging.getInstance();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.notification;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,5 +14,9 @@ public class FCMConfig {
     public FirebaseMessaging firebaseMessaging() {
         GoogleCredentials googleCredentials = GoogleCredentials
                 .fromStream(new ClassPathResource("websoso-fcm.json").getInputStream());
+
+        FirebaseOptions firebaseOptions = FirebaseOptions.builder()
+                .setCredentials(googleCredentials)
+                .build();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
@@ -4,11 +4,13 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 
+@Slf4j
 @Configuration
 public class FCMConfig {
 

--- a/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
@@ -23,5 +23,7 @@ public class FCMConfig {
         if (FirebaseApp.getApps().isEmpty()) {
             FirebaseApp.initializeApp(firebaseOptions);
         }
+
+        return FirebaseMessaging.getInstance();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMConfig.java
@@ -1,14 +1,17 @@
 package org.websoso.WSSServer.notification;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.messaging.FirebaseMessaging;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 
 @Configuration
 public class FCMConfig {
 
     @Bean
     public FirebaseMessaging firebaseMessaging() {
-
+        GoogleCredentials googleCredentials = GoogleCredentials
+                .fromStream(new ClassPathResource("websoso-fcm.json").getInputStream());
     }
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -2,6 +2,8 @@ package org.websoso.WSSServer.notification;
 
 import com.google.firebase.messaging.AndroidConfig;
 import com.google.firebase.messaging.AndroidNotification;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.FirebaseMessaging;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,6 +22,12 @@ public class FCMService {
                         .setClickAction(clickAction)
                         .build()
                 )
+                .build();
+
+        ApnsConfig apnsConfig = ApnsConfig.builder()
+                .setAps(Aps.builder()
+                        .setCategory(clickAction)
+                        .build())
                 .build();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -1,5 +1,7 @@
 package org.websoso.WSSServer.notification;
 
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.AndroidNotification;
 import com.google.firebase.messaging.FirebaseMessaging;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,4 +12,14 @@ public class FCMService {
 
     private final FirebaseMessaging firebaseMessaging;
 
+    public void sendPushMessage(String targetFCMToken, String title, String body, String clickAction) {
+        AndroidConfig androidConfig = AndroidConfig.builder()
+                .setNotification(AndroidNotification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .setClickAction(clickAction)
+                        .build()
+                )
+                .build();
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -5,6 +5,8 @@ import com.google.firebase.messaging.AndroidNotification;
 import com.google.firebase.messaging.ApnsConfig;
 import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +30,16 @@ public class FCMService {
                 .setAps(Aps.builder()
                         .setCategory(clickAction)
                         .build())
+                .build();
+
+        Message message = Message.builder()
+                .setToken(targetFCMToken)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .setAndroidConfig(androidConfig)
+                .setApnsConfig(apnsConfig)
                 .build();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -5,6 +5,7 @@ import com.google.firebase.messaging.AndroidNotification;
 import com.google.firebase.messaging.ApnsConfig;
 import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
@@ -19,31 +20,35 @@ public class FCMService {
     private final FirebaseMessaging firebaseMessaging;
 
     public void sendPushMessage(String targetFCMToken, String title, String body, String clickAction) {
-        AndroidConfig androidConfig = AndroidConfig.builder()
-                .setNotification(AndroidNotification.builder()
-                        .setTitle(title)
-                        .setBody(body)
-                        .setClickAction(clickAction)
-                        .build()
-                )
-                .build();
+        try {
+            AndroidConfig androidConfig = AndroidConfig.builder()
+                    .setNotification(AndroidNotification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .setClickAction(clickAction)
+                            .build()
+                    )
+                    .build();
 
-        ApnsConfig apnsConfig = ApnsConfig.builder()
-                .setAps(Aps.builder()
-                        .setCategory(clickAction)
-                        .build())
-                .build();
+            ApnsConfig apnsConfig = ApnsConfig.builder()
+                    .setAps(Aps.builder()
+                            .setCategory(clickAction)
+                            .build())
+                    .build();
 
-        Message message = Message.builder()
-                .setToken(targetFCMToken)
-                .setNotification(Notification.builder()
-                        .setTitle(title)
-                        .setBody(body)
-                        .build())
-                .setAndroidConfig(androidConfig)
-                .setApnsConfig(apnsConfig)
-                .build();
+            Message message = Message.builder()
+                    .setToken(targetFCMToken)
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build())
+                    .setAndroidConfig(androidConfig)
+                    .setApnsConfig(apnsConfig)
+                    .build();
 
-        firebaseMessaging.send(message);
+            firebaseMessaging.send(message);
+        } catch (FirebaseMessagingException e) {
+            log.error("[FirebaseMessagingException] exception ", e);
+        }
     }
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -49,6 +49,7 @@ public class FCMService {
             firebaseMessaging.send(message);
         } catch (FirebaseMessagingException e) {
             log.error("[FirebaseMessagingException] exception ", e);
+            // TODO: discord로 알림 추가 혹은 후속 작업 논의 후 추가
         }
     }
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -41,5 +41,7 @@ public class FCMService {
                 .setAndroidConfig(androidConfig)
                 .setApnsConfig(apnsConfig)
                 .build();
+
+        firebaseMessaging.send(message);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -8,8 +8,10 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FCMService {

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -11,6 +11,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 
 @Slf4j
 @Service
@@ -19,10 +20,8 @@ public class FCMService {
 
     private final FirebaseMessaging firebaseMessaging;
 
-    public void sendPushMessage(String targetFCMToken, String title, String body, String clickAction) {
-        Message message = createMessage(targetFCMToken, title, body, clickAction);
-    public void sendPushMessage(String targetFCMToken, String title, String body, String feedId, String view) {
-        Message message = createMessage(targetFCMToken, title, body, feedId, view);
+    public void sendPushMessage(String targetFCMToken, FCMMessageRequest fcmMessageRequest) {
+        Message message = createMessage(targetFCMToken, fcmMessageRequest);
 
         try {
             firebaseMessaging.send(message);
@@ -32,29 +31,28 @@ public class FCMService {
         }
     }
 
-    private Message createMessage(String targetFCMToken, String title, String body, String feedId, String view) {
+    private Message createMessage(String targetFCMToken, FCMMessageRequest fcmMessageRequest) {
         ApnsConfig apnsConfig = ApnsConfig.builder()
                 .setAps(Aps.builder()
                         .setAlert(ApsAlert.builder()
-                                .setTitle(title)
-                                .setBody(body)
+                                .setTitle(fcmMessageRequest.title())
+                                .setBody(fcmMessageRequest.body())
                                 .build())
                         .build())
                 .build();
 
         return Message.builder()
                 .setToken(targetFCMToken)
-                .putData("title", title)
-                .putData("body", body)
-                .putData("feedId", feedId)
-                .putData("view", view)
+                .putData("title", fcmMessageRequest.title())
+                .putData("body", fcmMessageRequest.body())
+                .putData("feedId", fcmMessageRequest.feedId())
+                .putData("view", fcmMessageRequest.view())
                 .setApnsConfig(apnsConfig)
                 .build();
     }
 
-    public void sendMulticastPushMessage(List<String> targetFCMTokens, String title,
-                                     String body, String feedId, String view) {
-        MulticastMessage multicastMessage = createMulticastMessage(targetFCMTokens, title, body, feedId, view);
+    public void sendMulticastPushMessage(List<String> targetFCMTokens, FCMMessageRequest fcmMessageRequest) {
+        MulticastMessage multicastMessage = createMulticastMessage(targetFCMTokens, fcmMessageRequest);
         try {
             firebaseMessaging.sendMulticast(multicastMessage);
         } catch (Exception e) {
@@ -63,23 +61,22 @@ public class FCMService {
         }
     }
 
-    private MulticastMessage createMulticastMessage(List<String> targetFCMTokens, String title,
-                                                    String body, String feedId, String view) {
+    private MulticastMessage createMulticastMessage(List<String> targetFCMTokens, FCMMessageRequest fcmMessageRequest) {
         ApnsConfig apnsConfig = ApnsConfig.builder()
                 .setAps(Aps.builder()
                         .setAlert(ApsAlert.builder()
-                                .setTitle(title)
-                                .setBody(body)
+                                .setTitle(fcmMessageRequest.title())
+                                .setBody(fcmMessageRequest.body())
                                 .build())
                         .build())
                 .build();
 
         return MulticastMessage.builder()
                 .addAllTokens(targetFCMTokens)
-                .putData("title", title)
-                .putData("body", body)
-                .putData("feedId", feedId)
-                .putData("view", view)
+                .putData("title", fcmMessageRequest.title())
+                .putData("body", fcmMessageRequest.body())
+                .putData("feedId", fcmMessageRequest.feedId())
+                .putData("view", fcmMessageRequest.view())
                 .setApnsConfig(apnsConfig)
                 .build();
     }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -55,7 +55,12 @@ public class FCMService {
     public void sendMulticastMessage(List<String> targetFCMTokens, String title,
                                      String body, String feedId, String view) {
         MulticastMessage multicastMessage = createMulticastMessage(targetFCMTokens, title, body, feedId, view);
-        firebaseMessaging.sendMulticast(multicastMessage);
+        try {
+            firebaseMessaging.sendMulticast(multicastMessage);
+        } catch (Exception e) {
+            log.error("[FirebaseMessagingException] exception ", e);
+            // TODO: discord로 알림 추가 혹은 후속 작업 논의 후 추가
+        }
     }
 
     private MulticastMessage createMulticastMessage(List<String> targetFCMTokens, String title,

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -20,9 +20,9 @@ public class FCMService {
     private final FirebaseMessaging firebaseMessaging;
 
     public void sendPushMessage(String targetFCMToken, String title, String body, String clickAction) {
-        try {
-            Message message = createMessage(targetFCMToken, title, body, clickAction);
+        Message message = createMessage(targetFCMToken, title, body, clickAction);
 
+        try {
             firebaseMessaging.send(message);
         } catch (FirebaseMessagingException e) {
             log.error("[FirebaseMessagingException] exception ", e);

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -21,35 +21,39 @@ public class FCMService {
 
     public void sendPushMessage(String targetFCMToken, String title, String body, String clickAction) {
         try {
-            AndroidConfig androidConfig = AndroidConfig.builder()
-                    .setNotification(AndroidNotification.builder()
-                            .setTitle(title)
-                            .setBody(body)
-                            .setClickAction(clickAction)
-                            .build()
-                    )
-                    .build();
-
-            ApnsConfig apnsConfig = ApnsConfig.builder()
-                    .setAps(Aps.builder()
-                            .setCategory(clickAction)
-                            .build())
-                    .build();
-
-            Message message = Message.builder()
-                    .setToken(targetFCMToken)
-                    .setNotification(Notification.builder()
-                            .setTitle(title)
-                            .setBody(body)
-                            .build())
-                    .setAndroidConfig(androidConfig)
-                    .setApnsConfig(apnsConfig)
-                    .build();
+            Message message = createMessage(targetFCMToken, title, body, clickAction);
 
             firebaseMessaging.send(message);
         } catch (FirebaseMessagingException e) {
             log.error("[FirebaseMessagingException] exception ", e);
             // TODO: discord로 알림 추가 혹은 후속 작업 논의 후 추가
         }
+    }
+
+    private Message createMessage(String targetFCMToken, String title, String body, String clickAction) {
+        AndroidConfig androidConfig = AndroidConfig.builder()
+                .setNotification(AndroidNotification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .setClickAction(clickAction)
+                        .build()
+                )
+                .build();
+
+        ApnsConfig apnsConfig = ApnsConfig.builder()
+                .setAps(Aps.builder()
+                        .setCategory(clickAction)
+                        .build())
+                .build();
+
+        return Message.builder()
+                .setToken(targetFCMToken)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .setAndroidConfig(androidConfig)
+                .setApnsConfig(apnsConfig)
+                .build();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -52,7 +52,7 @@ public class FCMService {
                 .build();
     }
 
-    public void sendMulticastMessage(List<String> targetFCMTokens, String title,
+    public void sendMulticastPushMessage(List<String> targetFCMTokens, String title,
                                      String body, String feedId, String view) {
         MulticastMessage multicastMessage = createMulticastMessage(targetFCMTokens, title, body, feedId, view);
         try {

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -1,8 +1,13 @@
 package org.websoso.WSSServer.notification;
 
+import com.google.firebase.messaging.FirebaseMessaging;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class FCMService {
+
+    private final FirebaseMessaging firebaseMessaging;
 
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -1,13 +1,11 @@
 package org.websoso.WSSServer.notification;
 
-import com.google.firebase.messaging.AndroidConfig;
-import com.google.firebase.messaging.AndroidNotification;
 import com.google.firebase.messaging.ApnsConfig;
 import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.ApsAlert;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,6 +19,8 @@ public class FCMService {
 
     public void sendPushMessage(String targetFCMToken, String title, String body, String clickAction) {
         Message message = createMessage(targetFCMToken, title, body, clickAction);
+    public void sendPushMessage(String targetFCMToken, String title, String body, String feedId, String view) {
+        Message message = createMessage(targetFCMToken, title, body, feedId, view);
 
         try {
             firebaseMessaging.send(message);
@@ -30,29 +30,22 @@ public class FCMService {
         }
     }
 
-    private Message createMessage(String targetFCMToken, String title, String body, String clickAction) {
-        AndroidConfig androidConfig = AndroidConfig.builder()
-                .setNotification(AndroidNotification.builder()
-                        .setTitle(title)
-                        .setBody(body)
-                        .setClickAction(clickAction)
-                        .build()
-                )
-                .build();
-
+    private Message createMessage(String targetFCMToken, String title, String body, String feedId, String view) {
         ApnsConfig apnsConfig = ApnsConfig.builder()
                 .setAps(Aps.builder()
-                        .setCategory(clickAction)
+                        .setAlert(ApsAlert.builder()
+                                .setTitle(title)
+                                .setBody(body)
+                                .build())
                         .build())
                 .build();
 
         return Message.builder()
                 .setToken(targetFCMToken)
-                .setNotification(Notification.builder()
-                        .setTitle(title)
-                        .setBody(body)
-                        .build())
-                .setAndroidConfig(androidConfig)
+                .putData("title", title)
+                .putData("body", body)
+                .putData("feedId", feedId)
+                .putData("view", view)
                 .setApnsConfig(apnsConfig)
                 .build();
     }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -6,6 +6,8 @@ import com.google.firebase.messaging.ApsAlert;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MulticastMessage;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -42,6 +44,33 @@ public class FCMService {
 
         return Message.builder()
                 .setToken(targetFCMToken)
+                .putData("title", title)
+                .putData("body", body)
+                .putData("feedId", feedId)
+                .putData("view", view)
+                .setApnsConfig(apnsConfig)
+                .build();
+    }
+
+    public void sendMulticastMessage(List<String> targetFCMTokens, String title,
+                                     String body, String feedId, String view) {
+        MulticastMessage multicastMessage = createMulticastMessage(targetFCMTokens, title, body, feedId, view);
+        firebaseMessaging.sendMulticast(multicastMessage);
+    }
+
+    private MulticastMessage createMulticastMessage(List<String> targetFCMTokens, String title,
+                                                    String body, String feedId, String view) {
+        ApnsConfig apnsConfig = ApnsConfig.builder()
+                .setAps(Aps.builder()
+                        .setAlert(ApsAlert.builder()
+                                .setTitle(title)
+                                .setBody(body)
+                                .build())
+                        .build())
+                .build();
+
+        return MulticastMessage.builder()
+                .addAllTokens(targetFCMTokens)
                 .putData("title", title)
                 .putData("body", body)
                 .putData("feedId", feedId)

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -1,0 +1,8 @@
+package org.websoso.WSSServer.notification;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class FCMService {
+
+}

--- a/src/main/java/org/websoso/WSSServer/notification/dto/FCMMessageRequest.java
+++ b/src/main/java/org/websoso/WSSServer/notification/dto/FCMMessageRequest.java
@@ -1,0 +1,13 @@
+package org.websoso.WSSServer.notification.dto;
+
+public record FCMMessageRequest(
+        String title,
+        String body,
+        String feedId,
+        String view
+) {
+
+    public static FCMMessageRequest of(String title, String body, String feedId, String view) {
+        return new FCMMessageRequest(title, body, feedId, view);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -42,10 +42,10 @@ public class CommentService {
 
     public void createComment(User user, Feed feed, String commentContent) {
         commentRepository.save(Comment.create(user.getUserId(), feed, commentContent));
-        sendCommentPushMessage(user, feed);
+        sendCommentPushMessageToFeedOwner(user, feed);
     }
 
-    private void sendCommentPushMessage(User user, Feed feed) {
+    private void sendCommentPushMessageToFeedOwner(User user, Feed feed) {
         fcmService.sendPushMessage(
                 feed.getUser().getFcmToken(),
                 createNotificationTitle(feed),

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -38,8 +38,8 @@ public class CommentService {
     private final MessageService messageService;
     private final FCMService fcmService;
 
-    public void createComment(Long userId, Feed feed, String commentContent) {
-        commentRepository.save(Comment.create(userId, feed, commentContent));
+    public void createComment(User user, Feed feed, String commentContent) {
+        commentRepository.save(Comment.create(user.getUserId(), feed, commentContent));
     }
 
     public void updateComment(Long userId, Feed feed, Long commentId, String commentContent) {

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -80,6 +80,7 @@ public class CommentService {
                 .stream()
                 .map(Comment::getUserId)
                 .filter(userId -> !userId.equals(user.getUserId()))
+                .distinct()
                 .map(userService::getUserOrException)
                 .map(User::getFcmToken)
                 .toList();

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -22,6 +22,7 @@ import org.websoso.WSSServer.dto.comment.CommentGetResponse;
 import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomCommentException;
+import org.websoso.WSSServer.notification.FCMService;
 import org.websoso.WSSServer.repository.CommentRepository;
 
 @Service
@@ -35,6 +36,7 @@ public class CommentService {
     private final BlockService blockService;
     private final ReportedCommentService reportedCommentService;
     private final MessageService messageService;
+    private final FCMService fcmService;
 
     public void createComment(Long userId, Feed feed, String commentContent) {
         commentRepository.save(Comment.create(userId, feed, commentContent));

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -74,7 +74,7 @@ public class CommentService {
                 .map(userService::getUserOrException)
                 .map(User::getFcmToken)
                 .toList();
-        fcmService.sendMulticastMessage(
+        fcmService.sendMulticastPushMessage(
                 commentersUserId,
                 createNotificationTitle(feed),
                 "내가 댓글 단 수다글에 또 다른 댓글이 달렸어요.",

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -37,6 +37,7 @@ public class CommentService {
     private final ReportedCommentService reportedCommentService;
     private final MessageService messageService;
     private final FCMService fcmService;
+    private final NovelService novelService;
 
     public void createComment(User user, Feed feed, String commentContent) {
         commentRepository.save(Comment.create(user.getUserId(), feed, commentContent));

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -56,7 +56,7 @@ public class CommentService {
     }
 
     private String createNotificationTitle(Feed feed) {
-        if (feed.getNovelId() == null) { //연결X
+        if (feed.getNovelId() == null) {
             String feedContent = feed.getFeedContent();
             return feedContent.length() <= 12
                     ? feedContent

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -24,6 +24,7 @@ import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomCommentException;
 import org.websoso.WSSServer.notification.FCMService;
+import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 import org.websoso.WSSServer.repository.CommentRepository;
 
 @Service
@@ -50,12 +51,16 @@ public class CommentService {
         if (isUserCommentOwner(user, feed.getUser())) {
             return;
         }
-        fcmService.sendPushMessage(
-                feed.getUser().getFcmToken(),
+
+        FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 createNotificationTitle(feed),
                 String.format("%s님이 내 수다글에 댓글을 남겼어요", user.getNickname()),
                 String.valueOf(feed.getFeedId()),
                 "feedDetail"
+        );
+        fcmService.sendPushMessage(
+                feed.getUser().getFcmToken(),
+                fcmMessageRequest
         );
     }
 
@@ -78,12 +83,16 @@ public class CommentService {
                 .map(userService::getUserOrException)
                 .map(User::getFcmToken)
                 .toList();
-        fcmService.sendMulticastPushMessage(
-                commentersUserId,
+
+        FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 createNotificationTitle(feed),
                 "내가 댓글 단 수다글에 또 다른 댓글이 달렸어요.",
                 String.valueOf(feed.getFeedId()),
                 "feedDetail"
+        );
+        fcmService.sendMulticastPushMessage(
+                commentersUserId,
+                fcmMessageRequest
         );
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -135,7 +135,7 @@ public class FeedService {
             String feedContent = feed.getFeedContent();
             return feedContent.length() <= 12
                     ? feedContent
-                    : feedContent.substring(0, 12) + "...";
+                    : "'" + feedContent.substring(0, 12) + "...'";
         }
         Novel novel = novelService.getNovelOrException(feed.getNovelId());
         return novel.getTitle();

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -134,7 +134,10 @@ public class FeedService {
 
     private String createNotificationTitle(Feed feed) {
         if (feed.getNovelId() == null) {
-            return String.format("%s...", feed.getFeedContent());
+            String feedContent = feed.getFeedContent();
+            return feedContent.length() <= 12
+                    ? feedContent
+                    : feedContent.substring(0, 12) + "...";
         }
         Novel novel = novelService.getNovelOrException(feed.getNovelId());
         return novel.getTitle();

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -119,6 +119,16 @@ public class FeedService {
         }
 
         String targetFCMToken = feed.getUser().getFcmToken();
+
+        if (feed.getNovelId() == null) { //연결 작품 X
+            fcmService.sendPushMessage(
+
+            );
+        } else { //연결 작품 O
+            fcmService.sendPushMessage(
+
+            );
+        }
     }
 
     public void unLikeFeed(User user, Long feedId) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -44,6 +44,7 @@ import org.websoso.WSSServer.dto.novel.NovelGetResponseFeedTab;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
+import org.websoso.WSSServer.notification.FCMService;
 import org.websoso.WSSServer.repository.AvatarRepository;
 import org.websoso.WSSServer.repository.FeedRepository;
 import org.websoso.WSSServer.repository.NovelRepository;
@@ -70,6 +71,7 @@ public class FeedService {
     private final MessageService messageService;
     private final UserService userService;
     private final NovelRepository novelRepository;
+    private final FCMService fcmService;
 
     public void createFeed(User user, FeedCreateRequest request) {
         if (request.novelId() != null) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -178,7 +178,7 @@ public class FeedService {
     public void createComment(User user, Long feedId, CommentCreateRequest request) {
         Feed feed = getFeedOrException(feedId);
         validateFeedAccess(feed, user);
-        commentService.createComment(user.getUserId(), feed, request.commentContent());
+        commentService.createComment(user, feed, request.commentContent());
     }
 
     public void updateComment(User user, Long feedId, Long commentId, CommentUpdateRequest request) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -129,8 +129,13 @@ public class FeedService {
                     "feedDetail"
             );
         } else { //연결 작품 O
+            Novel novel = novelService.getNovelOrException(feed.getNovelId());
             fcmService.sendPushMessage(
-
+                    targetFCMToken,
+                    novel.getTitle(),
+                    String.format("%s님이 내 수다글을 좋아해요.", user.getNickname()),
+                    String.valueOf(feedId),
+                    "feedDetail"
             );
         }
     }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -122,7 +122,11 @@ public class FeedService {
 
         if (feed.getNovelId() == null) { //연결 작품 X
             fcmService.sendPushMessage(
-
+                    targetFCMToken,
+                    String.format("%s...", feed.getFeedContent()),
+                    String.format("%s님이 내 수다글을 좋아해요.", user.getNickname()),
+                    String.valueOf(feedId),
+                    "feedDetail"
             );
         } else { //연결 작품 O
             fcmService.sendPushMessage(

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -122,6 +122,9 @@ public class FeedService {
     }
 
     private void sendLikePushMessage(User liker, Feed feed) {
+        if (liker.equals(feed.getUser())) {
+            return;
+        }
         fcmService.sendPushMessage(
                 feed.getUser().getFcmToken(),
                 createNotificationTitle(feed),

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -45,6 +45,7 @@ import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
 import org.websoso.WSSServer.notification.FCMService;
+import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 import org.websoso.WSSServer.repository.AvatarRepository;
 import org.websoso.WSSServer.repository.FeedRepository;
 import org.websoso.WSSServer.repository.NovelRepository;
@@ -125,12 +126,17 @@ public class FeedService {
         if (liker.equals(feed.getUser())) {
             return;
         }
-        fcmService.sendPushMessage(
-                feed.getUser().getFcmToken(),
+
+        FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 createNotificationTitle(feed),
                 String.format("%s님이 내 수다글을 좋아해요.", liker.getNickname()),
                 String.valueOf(feed.getFeedId()),
-                "feedDetail");
+                "feedDetail"
+        );
+        fcmService.sendPushMessage(
+                feed.getUser().getFcmToken(),
+                fcmMessageRequest
+        );
     }
 
     private String createNotificationTitle(Feed feed) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -122,14 +122,12 @@ public class FeedService {
     }
 
     private void sendLikePushMessage(User liker, Feed feed) {
-        String targetFCMToken = feed.getUser().getFcmToken();
-
-        String title = createNotificationTitle(feed);
-        String body = String.format("%s님이 내 수다글을 좋아해요.", liker.getNickname());
-        String feedId = String.valueOf(feed.getFeedId());
-        String view = "feedDetail";
-
-        fcmService.sendPushMessage(targetFCMToken, title, body, feedId, view);
+        fcmService.sendPushMessage(
+                feed.getUser().getFcmToken(),
+                createNotificationTitle(feed),
+                String.format("%s님이 내 수다글을 좋아해요.", liker.getNickname()),
+                String.valueOf(feed.getFeedId()),
+                "feedDetail");
     }
 
     private String createNotificationTitle(Feed feed) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -117,6 +117,8 @@ public class FeedService {
         if (isPopularFeed) {
             popularFeedService.createPopularFeed(feed);
         }
+
+        String targetFCMToken = feed.getUser().getFcmToken();
     }
 
     public void unLikeFeed(User user, Long feedId) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -124,18 +124,20 @@ public class FeedService {
     private void sendLikePushMessage(User liker, Feed feed) {
         String targetFCMToken = feed.getUser().getFcmToken();
 
-        String title;
-        Novel novel = novelService.getNovelOrException(feed.getNovelId());
-        if (feed.getNovelId() == null) {
-            title = String.format("%s...", feed.getFeedContent());
-        } else {
-            title = novel.getTitle();
-        }
+        String title = createNotificationTitle(feed);
         String body = String.format("%s님이 내 수다글을 좋아해요.", liker.getNickname());
         String feedId = String.valueOf(feed.getFeedId());
         String view = "feedDetail";
 
         fcmService.sendPushMessage(targetFCMToken, title, body, feedId, view);
+    }
+
+    private String createNotificationTitle(Feed feed) {
+        if (feed.getNovelId() == null) {
+            return String.format("%s...", feed.getFeedContent());
+        }
+        Novel novel = novelService.getNovelOrException(feed.getNovelId());
+        return novel.getTitle();
     }
 
     public void unLikeFeed(User user, Long feedId) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -118,26 +118,24 @@ public class FeedService {
             popularFeedService.createPopularFeed(feed);
         }
 
+        sendLikePushMessage(user, feed);
+    }
+
+    private void sendLikePushMessage(User liker, Feed feed) {
         String targetFCMToken = feed.getUser().getFcmToken();
 
-        if (feed.getNovelId() == null) { //연결 작품 X
-            fcmService.sendPushMessage(
-                    targetFCMToken,
-                    String.format("%s...", feed.getFeedContent()),
-                    String.format("%s님이 내 수다글을 좋아해요.", user.getNickname()),
-                    String.valueOf(feedId),
-                    "feedDetail"
-            );
-        } else { //연결 작품 O
-            Novel novel = novelService.getNovelOrException(feed.getNovelId());
-            fcmService.sendPushMessage(
-                    targetFCMToken,
-                    novel.getTitle(),
-                    String.format("%s님이 내 수다글을 좋아해요.", user.getNickname()),
-                    String.valueOf(feedId),
-                    "feedDetail"
-            );
+        String title;
+        Novel novel = novelService.getNovelOrException(feed.getNovelId());
+        if (feed.getNovelId() == null) {
+            title = String.format("%s...", feed.getFeedContent());
+        } else {
+            title = novel.getTitle();
         }
+        String body = String.format("%s님이 내 수다글을 좋아해요.", liker.getNickname());
+        String feedId = String.valueOf(feed.getFeedId());
+        String view = "feedDetail";
+
+        fcmService.sendPushMessage(targetFCMToken, title, body, feedId, view);
     }
 
     public void unLikeFeed(User user, Long feedId) {

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -40,18 +40,18 @@ public class PopularFeedService {
     }
 
     private String createNotificationBody(Feed feed) {
-        String tmp;
+        return String.format("내가 남긴 %s 글이 관심 받고 있어요!", generateNotificationBodyFragment(feed));
+    }
+
+    private String generateNotificationBodyFragment(Feed feed) {
         if (feed.getNovelId() == null) {
             String feedContent = feed.getFeedContent();
-            tmp = feedContent.length() <= 12
+            return feedContent.length() <= 12
                     ? feedContent
                     : feedContent.substring(0, 12) + "...";
-        } else {
-            Novel novel = novelService.getNovelOrException(feed.getNovelId());
-            tmp = String.format("<%s>", novel.getTitle());
         }
-
-        return String.format("내가 남긴 %s 글이 관심 받고 있어요!", tmp);
+        Novel novel = novelService.getNovelOrException(feed.getNovelId());
+        return String.format("<%s>", novel.getTitle());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -48,7 +48,7 @@ public class PopularFeedService {
             String feedContent = feed.getFeedContent();
             return feedContent.length() <= 12
                     ? feedContent
-                    : feedContent.substring(0, 12) + "...";
+                    : "'" + feedContent.substring(0, 12) + "...'";
         }
         Novel novel = novelService.getNovelOrException(feed.getNovelId());
         return String.format("<%s>", novel.getTitle());

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -18,6 +18,7 @@ import org.websoso.WSSServer.repository.PopularFeedRepository;
 public class PopularFeedService {
 
     private final PopularFeedRepository popularFeedRepository;
+    private final NovelService novelService;
     private final FCMService fcmService;
 
     public void createPopularFeed(Feed feed) {

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -33,7 +33,7 @@ public class PopularFeedService {
 
     private void sendPopularFeedPushMessage(Feed feed) {
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
-                "지금 뜨는 수다글 등극",
+                "지금 뜨는 수다글 등극\uD83D\uDE4C",
                 createNotificationBody(feed),
                 String.valueOf(feed.getFeedId()),
                 "feedDetail"

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -11,6 +11,7 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedGetResponse;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
 import org.websoso.WSSServer.notification.FCMService;
+import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 import org.websoso.WSSServer.repository.PopularFeedRepository;
 
 @Service
@@ -31,12 +32,16 @@ public class PopularFeedService {
     }
 
     private void sendPopularFeedPushMessage(Feed feed) {
-        fcmService.sendPushMessage(
-                feed.getUser().getFcmToken(),
+        FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 "지금 뜨는 수다글 등극",
                 createNotificationBody(feed),
                 String.valueOf(feed.getFeedId()),
-                "feedDetail");
+                "feedDetail"
+        );
+        fcmService.sendPushMessage(
+                feed.getUser().getFcmToken(),
+                fcmMessageRequest
+        );
     }
 
     private String createNotificationBody(Feed feed) {

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -9,6 +9,7 @@ import org.websoso.WSSServer.domain.PopularFeed;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedGetResponse;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
+import org.websoso.WSSServer.notification.FCMService;
 import org.websoso.WSSServer.repository.PopularFeedRepository;
 
 @Service
@@ -17,6 +18,7 @@ import org.websoso.WSSServer.repository.PopularFeedRepository;
 public class PopularFeedService {
 
     private final PopularFeedRepository popularFeedRepository;
+    private final FCMService fcmService;
 
     public void createPopularFeed(Feed feed) {
         if (!popularFeedRepository.existsByFeed(feed)) {

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -241,4 +241,9 @@ public class UserService {
     public UserIdAndNicknameResponse getUserIdAndNicknameAndGender(User user) {
         return UserIdAndNicknameResponse.of(user);
     }
+
+    @Transactional
+    public void registerFCMToken(User user, String fcmToken) {
+        user.updateFCMToken(fcmToken);
+    }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#251 -> dev
- close #251

## Key Changes
<!-- 최대한 자세히 -->
- 유저 활동 관련 푸시 알림 구현입니다. 아래 4가지 상황입니다. 공지에 대한 알림은 이번 스프린트에 포함되지 않더라구요..!
  - 좋아요 알림
  - 댓글 알림(내가 쓴 글/내가 댓글 단 글)
  - 지금 뜨는 수다글
- 클라이언트에서 발급한 FCM token 서버 사이드에서 저장하는 API
  - `/users/fcm-token`에서 저장합니다
  - `ref2`를 확인해보면 redis를 통해 TTL을 적용하는게 좋아 보입니다! 일단은 RDB에 저장하도록 했습니다. (null check도 추가해야 할 듯 합니다..ㅜ)
  - TTL 이외에도 권장 관리 사항 만족하도록 하는 로직들 추가해서 추가 PR 올리겠습니다.
- `FirebaseMessaging`을 bean으로 주입시켜서 `서버 <-> FCM` 간에 통신합니다.
  - specific device에 대한 push는 `sendPushMessage`로, multiple device에 대한 push는 `sendMulticastMessage`로 처리합니다.(specific과 multiple에 device에 대한 설명은 공식문서인 `ref1`에서 확인할 수 있습니다.)
    - 추후 공지의 경우 topic을 통해 처리하려고 합니다.(topic에 대한 설명도 공식 문서인 `ref1`에서 확인할 수 있습니다.)
- FCMService에서 push 관련 로직을 처리합니다. 이후 push가 발생하는 service layer에서 bean으로 주입받아 사용합니다. (CommentService, FeedService, PopularFeedService에서 주입받아 사용합니다.)
- 기획에서 정해진 UX 라이팅이 있는데, 이를 따로 enum에서 관리하면 좋을 것 같아서 추후 리팩터링 사항으로 남겨두겠습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 덩어리가 꽤나 크네요.. 리뷰 감사합니다.
- `ref1`랑 `ref2`는 지금이 아니더라고 꼭 읽어보시길 추천하며, 플로우와 정해져있는 포맷을 이해하신다면 PR도 무리없이 파악될 것이라 생각합니다!

## References
<!-- 참고한 자료-->
- `ref1`: https://firebase.google.com/docs/cloud-messaging/send-message
- `ref2`: https://firebase.google.com/docs/cloud-messaging/manage-tokens
- `ref3`: https://swatiomar09.medium.com/behind-the-scenes-how-fcm-push-notifications-working-internally-56820cc70652
- `ref4`: https://firebase.google.com/docs/cloud-messaging/android/receive
- `ref5`: https://firebase.google.com/docs/cloud-messaging/ios/receive