### PR TITLE
[FIX] 유저 탈퇴 디스코드 알림 메시지 포맷팅 오류 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
+++ b/src/main/java/org/websoso/WSSServer/service/MessageFormatter.java
@@ -67,8 +67,8 @@ public class MessageFormatter {
         return String.format(
                 USER_WITHDRAW.getTemplate(),
                 DiscordMessageTemplate.getCurrentDateTime(),
-                userId,
                 userNickname,
+                userId,
                 reason
         );
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#279 -> dev
- close #279

## Key Changes
<!-- 최대한 자세히 -->
유저 탈퇴 디스코드 알림 메시지 템플릿의 `%d`와 `%s` 포맷팅 순서를 수정하였습니다.
- 템플릿 매개변수와 formatUserWithdrawMessage 메서드의 매개변수 순서가 올바르게 매핑되도록 변경

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
