### PR TITLE
[FEAT] 알림 읽음 처리 API 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/NotificationController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.controller;
 
+import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.security.Principal;
@@ -7,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -51,5 +53,15 @@ public class NotificationController {
         return ResponseEntity
                 .status(OK)
                 .body(notificationService.getNotification(user, notificationId));
+    }
+
+    @PostMapping("/{notificationId}/read")
+    public ResponseEntity<Void> createNotificationAsRead(Principal principal,
+                                                         @PathVariable("notificationId") Long notificationId) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        notificationService.createNotificationAsRead(user, notificationId);
+        return ResponseEntity
+                .status(CREATED)
+                .build();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/common/NotificationTypeGroup.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/NotificationTypeGroup.java
@@ -1,0 +1,21 @@
+package org.websoso.WSSServer.domain.common;
+
+import java.util.Set;
+import lombok.Getter;
+
+@Getter
+public enum NotificationTypeGroup {
+
+    NOTICE("공지사항", "이벤트"),
+    FEED("지금뜨는수다글", "댓글", "좋아요");
+
+    private final Set<String> types;
+
+    NotificationTypeGroup(String... types) {
+        this.types = Set.copyOf(Set.of(types));
+    }
+
+    public static boolean isTypeInGroup(String typeName, NotificationTypeGroup group) {
+        return group.types.contains(typeName);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomNotificationError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomNotificationError.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.exception.error;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
@@ -15,7 +16,8 @@ public enum CustomNotificationError implements ICustomError {
 
     NOTIFICATION_NOT_FOUND("NOTIFICATION-001", "해당 ID를 가진 공지사항을 찾을 수 없습니다.", NOT_FOUND),
     NOTIFICATION_READ_FORBIDDEN("NOTIFICATION-002", "해당 알림의 대상 유저가 아닙니다.", FORBIDDEN),
-    NOTIFICATION_TYPE_INVALID("NOTIFICATION-003", "해당 알림은 공지사항에 적합한 타입이 아닙니다.", BAD_REQUEST);
+    NOTIFICATION_TYPE_INVALID("NOTIFICATION-003", "해당 알림은 요구된 알림 타입에 적합하지 않습니다.", BAD_REQUEST),
+    NOTIFICATION_ALREADY_READ("NOTIFICATION-004", "해당 알림은 유저가 이미 읽은 알림입니다.", CONFLICT);
 
     private final String code;
     private final String description;


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#282 -> dev
- close #282

## Key Changes
<!-- 최대한 자세히 -->
1. 수다글 관련 알림을 유저가 눌렀을 경우 읽음 처리를 하기 위한 알림 읽음 처리 API를 구현했습니다.
   - 수다글 관련 알림이 아닐 경우 예외를 발생시킵니다.

2. 기존 알림 단건 조회(공지) API와 중복 코드가 많아, 공통 로직을 별도의 메서드로 분리했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
리팩터링 과정에서 기존 알림 단건 조회 관련 코드가 변경되었습니다. 이 부분이 적절하지 않거나, 추가적인 개선이 필요하다고 생각되시면 피드백 부탁드립니닷 🙂

## References
<!-- 참고한 자료-->
