### PR TITLE
[FIX] 누락된 푸시알림 구현 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -223,10 +223,10 @@ public class UserController {
     }
 
     @GetMapping("/push-settings")
-    public ResponseEntity<PushSettingGetResponse> getPushSettingValue() {
-
+    public ResponseEntity<PushSettingGetResponse> getPushSettingValue(Principal principal) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
                 .status(OK)
-                .body();
+                .body(userService.getPushSettingValue(user));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.feed.UserFeedsGetResponse;
+import org.websoso.WSSServer.dto.notification.PushSettingGetResponse;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
 import org.websoso.WSSServer.dto.user.FCMTokenRequest;
@@ -219,5 +220,13 @@ public class UserController {
         return ResponseEntity
                 .status(OK)
                 .build();
+    }
+
+    @GetMapping("/push-settings")
+    public ResponseEntity<PushSettingGetResponse> getPushSettingValue() {
+
+        return ResponseEntity
+                .status(OK)
+                .body();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -216,10 +216,9 @@ public class UserController {
     public ResponseEntity<Void> registerFCMToken(Principal principal,
                                                  @Valid @RequestBody FCMTokenRequest fcmTokenRequest) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
-        userService.registerFCMToken(user, fcmTokenRequest);
-        return ResponseEntity
-                .status(OK)
-                .build();
+        return userService.registerFCMToken(user, fcmTokenRequest)
+                ? ResponseEntity.status(OK).build()
+                : ResponseEntity.status(NO_CONTENT).build();
     }
 
     @GetMapping("/push-settings")

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -217,7 +217,7 @@ public class UserController {
                                                  @Valid @RequestBody FCMTokenRequest fcmTokenRequest) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         return userService.registerFCMToken(user, fcmTokenRequest)
-                ? ResponseEntity.status(OK).build()
+                ? ResponseEntity.status(CREATED).build()
                 : ResponseEntity.status(NO_CONTENT).build();
     }
 

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -216,7 +216,7 @@ public class UserController {
     public ResponseEntity<Void> registerFCMToken(Principal principal,
                                                  @Valid @RequestBody FCMTokenRequest fcmTokenRequest) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
-        userService.registerFCMToken(user, fcmTokenRequest.fcmToken());
+        userService.registerFCMToken(user, fcmTokenRequest);
         return ResponseEntity
                 .status(OK)
                 .build();

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.feed.UserFeedsGetResponse;
 import org.websoso.WSSServer.dto.notification.PushSettingGetResponse;
+import org.websoso.WSSServer.dto.notification.PushSettingRequest;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
 import org.websoso.WSSServer.dto.user.FCMTokenRequest;
@@ -227,5 +228,15 @@ public class UserController {
         return ResponseEntity
                 .status(OK)
                 .body(userService.getPushSettingValue(user));
+    }
+
+    @PostMapping("/push-settings")
+    public ResponseEntity<Void> registerPushSetting(Principal principal,
+                                                    @Valid @RequestBody PushSettingRequest pushSettingRequest) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        userService.registerPushSetting(user, pushSettingRequest.isPushEnabled());
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -141,4 +141,8 @@ public class User extends BaseEntity {
         this.gender = Gender.valueOf(editMyInfoRequest.gender());
         this.birth = Year.of(editMyInfoRequest.birth());
     }
+
+    public void updatePushSetting(boolean isPushEnabled) {
+        this.isPushEnabled = isPushEnabled;
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -50,9 +50,6 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String socialId;
 
-    @Column
-    private String fcmToken;
-
     @Column(columnDefinition = "varchar(10)", nullable = false)
     private String nickname;
     //TODO 일부 특수문자 제외, 앞뒤 공백 불가능
@@ -142,9 +139,5 @@ public class User extends BaseEntity {
     public void editMyInfo(EditMyInfoRequest editMyInfoRequest) {
         this.gender = Gender.valueOf(editMyInfoRequest.gender());
         this.birth = Year.of(editMyInfoRequest.birth());
-    }
-
-    public void updateFCMToken(String fcmToken) {
-        this.fcmToken = fcmToken;
     }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -126,6 +126,7 @@ public class User extends BaseEntity {
         this.birth = Year.now();
         this.avatarId = 1;
         this.isProfilePublic = true;
+        this.isPushEnabled = true;
         this.role = USER;
         this.socialId = socialId;
         this.nickname = nickname;

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -77,6 +77,9 @@ public class User extends BaseEntity {
     @Column(columnDefinition = "Boolean default true", nullable = false)
     private Boolean isProfilePublic;
 
+    @Column(columnDefinition = "Boolean default true", nullable = false)
+    private Boolean isPushEnabled;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @ColumnDefault("'USER'")

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -94,6 +94,9 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = ALL, orphanRemoval = true)
     private List<ReportedComment> reportedComments = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = ALL, orphanRemoval = true)
+    private List<UserDevice> userDevices = new ArrayList<>();
+
     public void updateProfileStatus(Boolean profileStatus) {
         this.isProfilePublic = profileStatus;
     }

--- a/src/main/java/org/websoso/WSSServer/domain/UserDevice.java
+++ b/src/main/java/org/websoso/WSSServer/domain/UserDevice.java
@@ -31,4 +31,14 @@ public class UserDevice {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    private UserDevice(String fcmToken, String deviceIdentifier, User user) {
+        this.fcmToken = fcmToken;
+        this.deviceIdentifier = deviceIdentifier;
+        this.user = user;
+    }
+
+    public static UserDevice create(String fcmToken, String deviceIdentifier, User user) {
+        return new UserDevice(fcmToken, deviceIdentifier, user);
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/UserDevice.java
+++ b/src/main/java/org/websoso/WSSServer/domain/UserDevice.java
@@ -1,0 +1,34 @@
+package org.websoso.WSSServer.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserDevice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long userDeviceId;
+
+    @Column
+    private String fcmToken;
+
+    @Column(nullable = false)
+    private String deviceIdentifier;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/org/websoso/WSSServer/domain/UserDevice.java
+++ b/src/main/java/org/websoso/WSSServer/domain/UserDevice.java
@@ -41,4 +41,8 @@ public class UserDevice {
     public static UserDevice create(String fcmToken, String deviceIdentifier, User user) {
         return new UserDevice(fcmToken, deviceIdentifier, user);
     }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/notification/PushSettingGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notification/PushSettingGetResponse.java
@@ -1,0 +1,10 @@
+package org.websoso.WSSServer.dto.notification;
+
+public record PushSettingGetResponse(
+        Boolean isPushEnabled
+) {
+
+    public static PushSettingGetResponse of(Boolean isPushEnabled) {
+        return new PushSettingGetResponse(isPushEnabled);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/notification/PushSettingRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notification/PushSettingRequest.java
@@ -1,0 +1,9 @@
+package org.websoso.WSSServer.dto.notification;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PushSettingRequest(
+        @NotNull(message = "푸시 알림 설정 값은 null일 수 없습니다.")
+        Boolean isPushEnabled
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/dto/user/FCMTokenRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/FCMTokenRequest.java
@@ -4,6 +4,9 @@ import jakarta.validation.constraints.NotBlank;
 
 public record FCMTokenRequest(
         @NotBlank(message = "FCM Token 값은 null 이거나, 공백일 수 없습니다.")
-        String fcmToken
+        String fcmToken,
+
+        @NotBlank(message = "디바이스 식별자 값 null 이거나, 공백일 수 없습니다.")
+        String deviceIdentifier
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -47,6 +47,7 @@ public class FCMService {
                 .putData("body", fcmMessageRequest.body())
                 .putData("feedId", fcmMessageRequest.feedId())
                 .putData("view", fcmMessageRequest.view())
+                .putData("notificationId", fcmMessageRequest.notificationId())
                 .setApnsConfig(apnsConfig)
                 .build();
     }
@@ -77,6 +78,7 @@ public class FCMService {
                 .putData("body", fcmMessageRequest.body())
                 .putData("feedId", fcmMessageRequest.feedId())
                 .putData("view", fcmMessageRequest.view())
+                .putData("notificationId", fcmMessageRequest.notificationId())
                 .setApnsConfig(apnsConfig)
                 .build();
     }

--- a/src/main/java/org/websoso/WSSServer/notification/dto/FCMMessageRequest.java
+++ b/src/main/java/org/websoso/WSSServer/notification/dto/FCMMessageRequest.java
@@ -4,10 +4,11 @@ public record FCMMessageRequest(
         String title,
         String body,
         String feedId,
-        String view
+        String view,
+        String notificationId
 ) {
 
-    public static FCMMessageRequest of(String title, String body, String feedId, String view) {
-        return new FCMMessageRequest(title, body, feedId, view);
+    public static FCMMessageRequest of(String title, String body, String feedId, String view, String notificationId) {
+        return new FCMMessageRequest(title, body, feedId, view, notificationId);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/repository/NotificationTypeRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NotificationTypeRepository.java
@@ -1,0 +1,11 @@
+package org.websoso.WSSServer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.NotificationType;
+
+@Repository
+public interface NotificationTypeRepository extends JpaRepository<NotificationType, Long> {
+
+    NotificationType findByNotificationTypeName(String notificationTypeName);
+}

--- a/src/main/java/org/websoso/WSSServer/repository/UserDeviceRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserDeviceRepository.java
@@ -1,0 +1,10 @@
+package org.websoso.WSSServer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.UserDevice;
+
+@Repository
+public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
+
+}

--- a/src/main/java/org/websoso/WSSServer/repository/UserDeviceRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserDeviceRepository.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.UserDevice;
@@ -7,4 +8,5 @@ import org.websoso.WSSServer.domain.UserDevice;
 @Repository
 public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
 
+    Optional<UserDevice> findByDeviceIdentifier(String deviceIdentifier);
 }

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -136,6 +136,7 @@ public class CommentService {
                         notificationTypeComment
                 ))
                 .toList();
+        notificationRepository.saveAll(notifications);
 
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 notificationTitle,

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -120,9 +120,22 @@ public class CommentService {
             return;
         }
 
+        NotificationType notificationTypeComment = notificationTypeRepository.findByNotificationTypeName("댓글");
+
         String notificationTitle = createNotificationTitle(feed);
         String notificationBody = "내가 댓글 단 수다글에 또 다른 댓글이 달렸어요.";
         Long feedId = feed.getFeedId();
+
+        List<Notification> notifications = commenters.stream()
+                .map(commenter -> Notification.create(
+                        notificationTitle,
+                        notificationBody,
+                        null,
+                        commenter.getUserId(),
+                        feedId,
+                        notificationTypeComment
+                ))
+                .toList();
 
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 notificationTitle,

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Comment;
 import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.Notification;
+import org.websoso.WSSServer.domain.NotificationType;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserDevice;
@@ -54,6 +56,17 @@ public class CommentService {
         if (isUserCommentOwner(user, feed.getUser())) {
             return;
         }
+
+        NotificationType notificationTypeComment = notificationTypeRepository.findByNotificationTypeName("댓글");
+
+        Notification notification = Notification.create(
+                createNotificationTitle(feed),
+                String.format("%s님이 내 수다글에 댓글을 남겼어요", user.getNickname()),
+                null,
+                feed.getUser().getUserId(),
+                feed.getFeedId(),
+                notificationTypeComment
+        );
 
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 createNotificationTitle(feed),

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -123,10 +123,14 @@ public class CommentService {
             return;
         }
 
+        String notificationTitle = createNotificationTitle(feed);
+        String notificationBody = "내가 댓글 단 수다글에 또 다른 댓글이 달렸어요.";
+        Long feedId = feed.getFeedId();
+
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
-                createNotificationTitle(feed),
-                "내가 댓글 단 수다글에 또 다른 댓글이 달렸어요.",
-                String.valueOf(feed.getFeedId()),
+                notificationTitle,
+                notificationBody,
+                String.valueOf(feedId),
                 "feedDetail"
         );
         fcmService.sendMulticastPushMessage(

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -29,6 +29,7 @@ import org.websoso.WSSServer.exception.exception.CustomCommentException;
 import org.websoso.WSSServer.notification.FCMService;
 import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 import org.websoso.WSSServer.repository.CommentRepository;
+import org.websoso.WSSServer.repository.NotificationRepository;
 import org.websoso.WSSServer.repository.NotificationTypeRepository;
 
 @Service
@@ -45,6 +46,7 @@ public class CommentService {
     private final FCMService fcmService;
     private final NovelService novelService;
     private final NotificationTypeRepository notificationTypeRepository;
+    private final NotificationRepository notificationRepository;
 
     public void createComment(User user, Feed feed, String commentContent) {
         commentRepository.save(Comment.create(user.getUserId(), feed, commentContent));

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -72,7 +72,8 @@ public class CommentService {
                 createNotificationTitle(feed),
                 String.format("%s님이 내 수다글에 댓글을 남겼어요", user.getNickname()),
                 String.valueOf(feed.getFeedId()),
-                "feedDetail"
+                "feedDetail",
+                String.valueOf(notification.getNotificationId())
         );
 
         List<String> targetFCMTokens = feed.getUser()

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -154,9 +154,8 @@ public class CommentService {
                 ))
                 .toList();
 
-        fcmService.sendMulticastPushMessage(
-                targetFCMTokens,
-                fcmMessageRequest
+        fcmMessageRequests.forEach(fcmMessageRequest
+                -> fcmService.sendMulticastPushMessage(targetFCMTokens, fcmMessageRequest)
         );
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -74,6 +74,7 @@ public class CommentService {
                 feedId,
                 notificationTypeComment
         );
+        notificationRepository.save(notification);
 
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 notificationTitle,

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -108,18 +108,15 @@ public class CommentService {
     }
 
     private void sendCommentPushMessageToCommenters(User user, Feed feed) {
-        List<String> commentersUserId = feed.getComments()
+        List<User> commenters = feed.getComments()
                 .stream()
                 .map(Comment::getUserId)
                 .filter(userId -> !userId.equals(user.getUserId()))
                 .distinct()
                 .map(userService::getUserOrException)
-                .map(User::getUserDevices)
-                .flatMap(List::stream)
-                .map(UserDevice::getFcmToken)
                 .toList();
 
-        if (commentersUserId.isEmpty()) {
+        if (commenters.isEmpty()) {
             return;
         }
 

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -138,6 +138,12 @@ public class CommentService {
                 .toList();
         notificationRepository.saveAll(notifications);
 
+        List<String> targetFCMTokens = commenters.stream()
+                .flatMap(commenter -> commenter.getUserDevices().stream())
+                .map(UserDevice::getFcmToken)
+                .distinct()
+                .toList();
+
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 notificationTitle,
                 notificationBody,
@@ -145,7 +151,7 @@ public class CommentService {
                 "feedDetail"
         );
         fcmService.sendMulticastPushMessage(
-                commentersUserId,
+                targetFCMTokens,
                 fcmMessageRequest
         );
     }

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -27,6 +27,7 @@ import org.websoso.WSSServer.exception.exception.CustomCommentException;
 import org.websoso.WSSServer.notification.FCMService;
 import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 import org.websoso.WSSServer.repository.CommentRepository;
+import org.websoso.WSSServer.repository.NotificationTypeRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +42,7 @@ public class CommentService {
     private final MessageService messageService;
     private final FCMService fcmService;
     private final NovelService novelService;
+    private final NotificationTypeRepository notificationTypeRepository;
 
     public void createComment(User user, Feed feed, String commentContent) {
         commentRepository.save(Comment.create(user.getUserId(), feed, commentContent));

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -60,19 +60,23 @@ public class CommentService {
 
         NotificationType notificationTypeComment = notificationTypeRepository.findByNotificationTypeName("댓글");
 
+        String notificationTitle = createNotificationTitle(feed);
+        String notificationBody = String.format("%s님이 내 수다글에 댓글을 남겼어요", user.getNickname());
+        Long feedId = feed.getFeedId();
+
         Notification notification = Notification.create(
-                createNotificationTitle(feed),
-                String.format("%s님이 내 수다글에 댓글을 남겼어요", user.getNickname()),
+                notificationTitle,
+                notificationBody,
                 null,
                 feedOwner.getUserId(),
-                feed.getFeedId(),
+                feedId,
                 notificationTypeComment
         );
 
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
-                createNotificationTitle(feed),
-                String.format("%s님이 내 수다글에 댓글을 남겼어요", user.getNickname()),
-                String.valueOf(feed.getFeedId()),
+                notificationTitle,
+                notificationBody,
+                String.valueOf(feedId),
                 "feedDetail",
                 String.valueOf(notification.getNotificationId())
         );

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -53,7 +53,8 @@ public class CommentService {
     }
 
     private void sendCommentPushMessageToFeedOwner(User user, Feed feed) {
-        if (isUserCommentOwner(user, feed.getUser())) {
+        User feedOwner = feed.getUser();
+        if (isUserCommentOwner(user, feedOwner)) {
             return;
         }
 
@@ -63,7 +64,7 @@ public class CommentService {
                 createNotificationTitle(feed),
                 String.format("%s님이 내 수다글에 댓글을 남겼어요", user.getNickname()),
                 null,
-                feed.getUser().getUserId(),
+                feedOwner.getUserId(),
                 feed.getFeedId(),
                 notificationTypeComment
         );
@@ -76,7 +77,7 @@ public class CommentService {
                 String.valueOf(notification.getNotificationId())
         );
 
-        List<String> targetFCMTokens = feed.getUser()
+        List<String> targetFCMTokens = feedOwner
                 .getUserDevices()
                 .stream()
                 .map(UserDevice::getFcmToken)

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -144,12 +144,16 @@ public class CommentService {
                 .distinct()
                 .toList();
 
-        FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
-                notificationTitle,
-                notificationBody,
-                String.valueOf(feedId),
-                "feedDetail"
-        );
+        List<FCMMessageRequest> fcmMessageRequests = notifications.stream()
+                .map(notification -> FCMMessageRequest.of(
+                        notificationTitle,
+                        notificationBody,
+                        String.valueOf(feedId),
+                        "feedDetail",
+                        String.valueOf(notification.getNotificationId())
+                ))
+                .toList();
+
         fcmService.sendMulticastPushMessage(
                 targetFCMTokens,
                 fcmMessageRequest

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -49,6 +49,7 @@ import org.websoso.WSSServer.notification.FCMService;
 import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 import org.websoso.WSSServer.repository.AvatarRepository;
 import org.websoso.WSSServer.repository.FeedRepository;
+import org.websoso.WSSServer.repository.NotificationTypeRepository;
 import org.websoso.WSSServer.repository.NovelRepository;
 import org.websoso.WSSServer.repository.UserNovelRepository;
 
@@ -75,6 +76,7 @@ public class FeedService {
     private final UserService userService;
     private final NovelRepository novelRepository;
     private final FCMService fcmService;
+    private final NotificationTypeRepository notificationTypeRepository;
 
     public void createFeed(User user, FeedCreateRequest request) {
         if (request.novelId() != null) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -133,7 +133,7 @@ public class FeedService {
             return;
         }
 
-        NotificationType notificationTypeComment = notificationTypeRepository.findByNotificationTypeName("댓글");
+        NotificationType notificationTypeComment = notificationTypeRepository.findByNotificationTypeName("좋아요");
 
         String notificationTitle = createNotificationTitle(feed);
         String notificationBody = String.format("%s님이 내 수다글을 좋아해요.", liker.getNickname());

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -25,6 +25,7 @@ import org.websoso.WSSServer.domain.Avatar;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserDevice;
 import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.domain.common.ReportedType;
@@ -131,8 +132,14 @@ public class FeedService {
                 String.valueOf(feed.getFeedId()),
                 "feedDetail"
         );
-        fcmService.sendPushMessage(
-                feed.getUser().getFcmToken(),
+
+        List<String> targetFCMTokens = feed.getUser()
+                .getUserDevices()
+                .stream()
+                .map(UserDevice::getFcmToken)
+                .toList();
+        fcmService.sendMulticastPushMessage(
+                targetFCMTokens,
                 fcmMessageRequest
         );
     }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -51,6 +51,7 @@ import org.websoso.WSSServer.notification.FCMService;
 import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 import org.websoso.WSSServer.repository.AvatarRepository;
 import org.websoso.WSSServer.repository.FeedRepository;
+import org.websoso.WSSServer.repository.NotificationRepository;
 import org.websoso.WSSServer.repository.NotificationTypeRepository;
 import org.websoso.WSSServer.repository.NovelRepository;
 import org.websoso.WSSServer.repository.UserNovelRepository;
@@ -79,6 +80,7 @@ public class FeedService {
     private final NovelRepository novelRepository;
     private final FCMService fcmService;
     private final NotificationTypeRepository notificationTypeRepository;
+    private final NotificationRepository notificationRepository;
 
     public void createFeed(User user, FeedCreateRequest request) {
         if (request.novelId() != null) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -153,7 +153,8 @@ public class FeedService {
                 notificationTitle,
                 notificationBody,
                 String.valueOf(feedId),
-                "feedDetail"
+                "feedDetail",
+                String.valueOf(notification.getNotificationId())
         );
 
         List<String> targetFCMTokens = feedOwner

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -122,18 +122,23 @@ public class FeedService {
     }
 
     private void sendLikePushMessage(User liker, Feed feed) {
-        if (liker.equals(feed.getUser())) {
+        User feedOwner = feed.getUser();
+        if (liker.equals(feedOwner)) {
             return;
         }
 
+        String notificationTitle = createNotificationTitle(feed);
+        String notificationBody = String.format("%s님이 내 수다글을 좋아해요.", liker.getNickname());
+        Long feedId = feed.getFeedId();
+
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
-                createNotificationTitle(feed),
-                String.format("%s님이 내 수다글을 좋아해요.", liker.getNickname()),
-                String.valueOf(feed.getFeedId()),
+                notificationTitle,
+                notificationBody,
+                String.valueOf(feedId),
                 "feedDetail"
         );
 
-        List<String> targetFCMTokens = feed.getUser()
+        List<String> targetFCMTokens = feedOwner
                 .getUserDevices()
                 .stream()
                 .map(UserDevice::getFcmToken)

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -23,6 +23,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Avatar;
 import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.Notification;
+import org.websoso.WSSServer.domain.NotificationType;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserDevice;
@@ -129,9 +131,21 @@ public class FeedService {
             return;
         }
 
+        NotificationType notificationTypeComment = notificationTypeRepository.findByNotificationTypeName("댓글");
+
         String notificationTitle = createNotificationTitle(feed);
         String notificationBody = String.format("%s님이 내 수다글을 좋아해요.", liker.getNickname());
         Long feedId = feed.getFeedId();
+
+        Notification notification = Notification.create(
+                notificationTitle,
+                notificationBody,
+                null,
+                feedOwner.getUserId(),
+                feedId,
+                notificationTypeComment
+        );
+        notificationRepository.save(notification);
 
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 notificationTitle,

--- a/src/main/java/org/websoso/WSSServer/service/NotificationService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NotificationService.java
@@ -7,7 +7,7 @@ import static org.websoso.WSSServer.exception.error.CustomNotificationError.NOTI
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -24,7 +24,7 @@ import org.websoso.WSSServer.repository.NotificationRepository;
 import org.websoso.WSSServer.repository.ReadNotificationRepository;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Transactional
 public class NotificationService {
 

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -13,6 +13,7 @@ import org.websoso.WSSServer.dto.popularFeed.PopularFeedGetResponse;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
 import org.websoso.WSSServer.notification.FCMService;
 import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
+import org.websoso.WSSServer.repository.NotificationTypeRepository;
 import org.websoso.WSSServer.repository.PopularFeedRepository;
 
 @Service
@@ -23,6 +24,7 @@ public class PopularFeedService {
     private final PopularFeedRepository popularFeedRepository;
     private final NovelService novelService;
     private final FCMService fcmService;
+    private final NotificationTypeRepository notificationTypeRepository;
 
     public void createPopularFeed(Feed feed) {
         if (!popularFeedRepository.existsByFeed(feed)) {

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.Notification;
+import org.websoso.WSSServer.domain.NotificationType;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.PopularFeed;
 import org.websoso.WSSServer.domain.User;
@@ -37,9 +39,22 @@ public class PopularFeedService {
     }
 
     private void sendPopularFeedPushMessage(Feed feed) {
+        NotificationType notificationTypeComment = notificationTypeRepository.findByNotificationTypeName("지금뜨는수다글");
+
         Long feedId = feed.getFeedId();
         String notificationTitle = "지금 뜨는 수다글 등극\uD83D\uDE4C";
         String notificationBody = createNotificationBody(feed);
+
+        Notification notification = Notification.create(
+                notificationTitle,
+                notificationBody,
+                null,
+                feed.getUser().getUserId(),
+                feedId,
+                notificationTypeComment
+        );
+        notificationRepository.save(notification);
+
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 notificationTitle,
                 notificationBody,

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -8,6 +8,7 @@ import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.PopularFeed;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserDevice;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedGetResponse;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
 import org.websoso.WSSServer.notification.FCMService;
@@ -38,8 +39,14 @@ public class PopularFeedService {
                 String.valueOf(feed.getFeedId()),
                 "feedDetail"
         );
-        fcmService.sendPushMessage(
-                feed.getUser().getFcmToken(),
+
+        List<String> targetFCMTokens = feed.getUser()
+                .getUserDevices()
+                .stream()
+                .map(UserDevice::getFcmToken)
+                .toList();
+        fcmService.sendMulticastPushMessage(
+                targetFCMTokens,
                 fcmMessageRequest
         );
     }

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -59,6 +59,8 @@ public class PopularFeedService {
                 notificationTitle,
                 notificationBody,
                 String.valueOf(feedId),
+                "feedDetail",
+                String.valueOf(notification.getNotificationId())
         );
 
         List<String> targetFCMTokens = feed.getUser()

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -41,6 +41,7 @@ public class PopularFeedService {
     private void sendPopularFeedPushMessage(Feed feed) {
         NotificationType notificationTypeComment = notificationTypeRepository.findByNotificationTypeName("지금뜨는수다글");
 
+        User feedOwner = feed.getUser();
         Long feedId = feed.getFeedId();
         String notificationTitle = "지금 뜨는 수다글 등극\uD83D\uDE4C";
         String notificationBody = createNotificationBody(feed);
@@ -49,7 +50,7 @@ public class PopularFeedService {
                 notificationTitle,
                 notificationBody,
                 null,
-                feed.getUser().getUserId(),
+                feedOwner.getUserId(),
                 feedId,
                 notificationTypeComment
         );

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -13,6 +13,7 @@ import org.websoso.WSSServer.dto.popularFeed.PopularFeedGetResponse;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
 import org.websoso.WSSServer.notification.FCMService;
 import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
+import org.websoso.WSSServer.repository.NotificationRepository;
 import org.websoso.WSSServer.repository.NotificationTypeRepository;
 import org.websoso.WSSServer.repository.PopularFeedRepository;
 
@@ -25,6 +26,7 @@ public class PopularFeedService {
     private final NovelService novelService;
     private final FCMService fcmService;
     private final NotificationTypeRepository notificationTypeRepository;
+    private final NotificationRepository notificationRepository;
 
     public void createPopularFeed(Feed feed) {
         if (!popularFeedRepository.existsByFeed(feed)) {

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -33,11 +33,13 @@ public class PopularFeedService {
     }
 
     private void sendPopularFeedPushMessage(Feed feed) {
+        Long feedId = feed.getFeedId();
+        String notificationTitle = "지금 뜨는 수다글 등극\uD83D\uDE4C";
+        String notificationBody = createNotificationBody(feed);
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
-                "지금 뜨는 수다글 등극\uD83D\uDE4C",
-                createNotificationBody(feed),
-                String.valueOf(feed.getFeedId()),
-                "feedDetail"
+                notificationTitle,
+                notificationBody,
+                String.valueOf(feedId),
         );
 
         List<String> targetFCMTokens = feed.getUser()

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -269,6 +269,10 @@ public class UserService {
                 });
     }
 
+    public void registerPushSetting(User user, Boolean isPushEnabled) {
+        user.updatePushSetting(isPushEnabled);
+    }
+
     @Transactional(readOnly = true)
     public PushSettingGetResponse getPushSettingValue(User user) {
         return PushSettingGetResponse.of(user.getIsPushEnabled());

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -252,19 +252,21 @@ public class UserService {
         return UserIdAndNicknameResponse.of(user);
     }
 
-    public void registerFCMToken(User user, FCMTokenRequest fcmTokenRequest) {
-        userDeviceRepository.findByDeviceIdentifier(fcmTokenRequest.deviceIdentifier())
-                .ifPresentOrElse(
-                        userDevice -> userDevice.updateFcmToken(fcmTokenRequest.fcmToken()),
-                        () -> {
-                            UserDevice userDevice = UserDevice.create(
-                                    fcmTokenRequest.fcmToken(),
-                                    fcmTokenRequest.deviceIdentifier(),
-                                    user
-                            );
-                            userDeviceRepository.save(userDevice);
-                        }
-                );
+    public boolean registerFCMToken(User user, FCMTokenRequest fcmTokenRequest) {
+        return userDeviceRepository.findByDeviceIdentifier(fcmTokenRequest.deviceIdentifier())
+                .map(userDevice -> {
+                    userDevice.updateFcmToken(fcmTokenRequest.fcmToken());
+                    return false;
+                })
+                .orElseGet(() -> {
+                    UserDevice userDevice = UserDevice.create(
+                            fcmTokenRequest.fcmToken(),
+                            fcmTokenRequest.deviceIdentifier(),
+                            user
+                    );
+                    userDeviceRepository.save(userDevice);
+                    return true;
+                });
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -247,7 +247,6 @@ public class UserService {
         return UserIdAndNicknameResponse.of(user);
     }
 
-    @Transactional
     public void registerFCMToken(User user, String fcmToken) {
         user.updateFCMToken(fcmToken);
     }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -25,6 +25,7 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.WithdrawalReason;
 import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.domain.common.SocialLoginType;
+import org.websoso.WSSServer.dto.notification.PushSettingGetResponse;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
 import org.websoso.WSSServer.dto.user.LoginResponse;
@@ -249,5 +250,10 @@ public class UserService {
 
     public void registerFCMToken(User user, String fcmToken) {
         user.updateFCMToken(fcmToken);
+    }
+
+    @Transactional(readOnly = true)
+    public PushSettingGetResponse getPushSettingValue(User user) {
+        return PushSettingGetResponse.of(user.getIsPushEnabled());
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -22,12 +22,14 @@ import org.websoso.WSSServer.domain.Avatar;
 import org.websoso.WSSServer.domain.Genre;
 import org.websoso.WSSServer.domain.GenrePreference;
 import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserDevice;
 import org.websoso.WSSServer.domain.WithdrawalReason;
 import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.domain.common.SocialLoginType;
 import org.websoso.WSSServer.dto.notification.PushSettingGetResponse;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
+import org.websoso.WSSServer.dto.user.FCMTokenRequest;
 import org.websoso.WSSServer.dto.user.LoginResponse;
 import org.websoso.WSSServer.dto.user.MyProfileResponse;
 import org.websoso.WSSServer.dto.user.NicknameValidation;
@@ -50,6 +52,7 @@ import org.websoso.WSSServer.repository.FeedRepository;
 import org.websoso.WSSServer.repository.GenrePreferenceRepository;
 import org.websoso.WSSServer.repository.GenreRepository;
 import org.websoso.WSSServer.repository.RefreshTokenRepository;
+import org.websoso.WSSServer.repository.UserDeviceRepository;
 import org.websoso.WSSServer.repository.UserRepository;
 import org.websoso.WSSServer.repository.WithdrawalReasonRepository;
 
@@ -249,8 +252,19 @@ public class UserService {
         return UserIdAndNicknameResponse.of(user);
     }
 
-    public void registerFCMToken(User user, String fcmToken) {
-        user.updateFCMToken(fcmToken);
+    public void registerFCMToken(User user, FCMTokenRequest fcmTokenRequest) {
+        userDeviceRepository.findByDeviceIdentifier(fcmTokenRequest.deviceIdentifier())
+                .ifPresentOrElse(
+                        userDevice -> userDevice.updateFcmToken(fcmTokenRequest.fcmToken()),
+                        () -> {
+                            UserDevice userDevice = UserDevice.create(
+                                    fcmTokenRequest.fcmToken(),
+                                    fcmTokenRequest.deviceIdentifier(),
+                                    user
+                            );
+                            userDeviceRepository.save(userDevice);
+                        }
+                );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -70,6 +70,7 @@ public class UserService {
     private final CommentRepository commentRepository;
     private final MessageService messageService;
     private final WithdrawalReasonRepository withdrawalReasonRepository;
+    private final UserDeviceRepository userDeviceRepository;
     private static final String KAKAO_PREFIX = "kakao";
     private static final String APPLE_PREFIX = "apple";
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#281 -> dev
- close #281

## Key Changes
<!-- 최대한 자세히 -->
- 멀티 디바이스를 고려
  - `UserDevice`로 엔티티 분리
  - 기존 `sendPushMessage`를 `sendMulticastPushMessage`로 변경: 유저 한 명에게 발송하더라도 기기가 여러 대면 fcmToken이 여러 개가 되기 때문
- `푸시 알림 수신 여부 설정 및 수정을 위한 api` 추가
- fcm token 등록 api -> `등록 및 수정 api`로 변경

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 운영 서버에서 isPushEnabled 컬럼 추가할 때 문제 발생 가능성