### PR TITLE
[FIX] deprecated된 FirebaseMessaging 내부 메서드 사용으로 인한 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation 'com.nimbusds:nimbus-jose-jwt:3.10'
 
     // FCM
-    implementation 'com.google.firebase:firebase-admin:8.1.0'
+    implementation 'com.google.firebase:firebase-admin:9.4.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/websoso/WSSServer/notification/FCMService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/FCMService.java
@@ -55,7 +55,7 @@ public class FCMService {
     public void sendMulticastPushMessage(List<String> targetFCMTokens, FCMMessageRequest fcmMessageRequest) {
         MulticastMessage multicastMessage = createMulticastMessage(targetFCMTokens, fcmMessageRequest);
         try {
-            firebaseMessaging.sendMulticast(multicastMessage);
+            firebaseMessaging.sendEachForMulticast(multicastMessage);
         } catch (Exception e) {
             log.error("[FirebaseMessagingException] exception ", e);
             // TODO: discord로 알림 추가 혹은 후속 작업 논의 후 추가


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#285 -> dev
- close #285

## Key Changes
<!-- 최대한 자세히 -->
- deprecated된 `sendMulticast` 메서드 사용으로 인한 문제 발생
- firebase-admin 버전 변경, `sendEachForMulticast` 메서드로 수정하여 문제 해결 

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 버전은 중요하다.