### PR TITLE
[FIX] SP2 QA 관련 오류 해결 - 본인 글에 댓글 작성 시 중복 알림 발생 버그 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -108,10 +108,13 @@ public class CommentService {
     }
 
     private void sendCommentPushMessageToCommenters(User user, Feed feed) {
+        User feedOwner = feed.getUser();
+
         List<User> commenters = feed.getComments()
                 .stream()
                 .map(Comment::getUserId)
                 .filter(userId -> !userId.equals(user.getUserId()))
+                .filter(userId -> !userId.equals(feedOwner.getUserId()))
                 .distinct()
                 .map(userService::getUserOrException)
                 .toList();


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#291 -> dev
- close #291

## Key Changes
<!-- 최대한 자세히 -->
- 피드 작성자가 본인 피드에 댓글을 작성한 경우 중복 발생하는 알림 제거
  - '내가 댓글 단 수다에 또 다른 댓글이 달렸어요' 알림은 송신하지 않도록 댓글 작성자 list에서 filter

