### PR TITLE
[FIX] 동일 기기 여러 계정 푸시 알림 처리

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/AuthController.java
@@ -59,7 +59,8 @@ public class AuthController {
                                        @Valid @RequestBody LogoutRequest request) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         String refreshToken = request.refreshToken();
-        userService.logout(user, refreshToken);
+        String deviceIdentifier = request.deviceIdentifier();
+        userService.logout(user, refreshToken, deviceIdentifier);
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();

--- a/src/main/java/org/websoso/WSSServer/dto/auth/LogoutRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/auth/LogoutRequest.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.dto.auth;
 
 public record LogoutRequest(
-        String refreshToken
+        String refreshToken,
+        String deviceIdentifier
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserDeviceRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserDeviceRepository.java
@@ -11,5 +11,5 @@ public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
 
     Optional<UserDevice> findByDeviceIdentifierAndUser(String deviceIdentifier, User user);
 
-    void deleteByUser(User user);
+    void deleteByUserAndDeviceIdentifier(User user, String deviceIdentifier);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserDeviceRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserDeviceRepository.java
@@ -10,4 +10,6 @@ import org.websoso.WSSServer.domain.UserDevice;
 public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
 
     Optional<UserDevice> findByDeviceIdentifierAndUser(String deviceIdentifier, User user);
+
+    void deleteByUser(User user);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserDeviceRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserDeviceRepository.java
@@ -3,10 +3,11 @@ package org.websoso.WSSServer.repository;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserDevice;
 
 @Repository
 public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
 
-    Optional<UserDevice> findByDeviceIdentifier(String deviceIdentifier);
+    Optional<UserDevice> findByDeviceIdentifierAndUser(String deviceIdentifier, User user);
 }

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -141,7 +141,12 @@ public class CommentService {
             );
             notificationRepository.save(notification);
 
-            List<String> targetFCMTokens = commenter.getUserDevices()
+            List<UserDevice> commenterDevices = commenter.getUserDevices();
+            if (commenterDevices.isEmpty()) {
+                return;
+            }
+
+            List<String> targetFCMTokens = commenterDevices
                     .stream()
                     .map(UserDevice::getFcmToken)
                     .distinct()

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -159,7 +159,10 @@ public class CommentService {
                     "feedDetail",
                     String.valueOf(notification.getNotificationId())
             );
-            fcmService.sendMulticastPushMessage(targetFCMTokens, fcmMessageRequest);
+            fcmService.sendMulticastPushMessage(
+                    targetFCMTokens,
+                    fcmMessageRequest
+            );
         });
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -76,6 +76,11 @@ public class CommentService {
         );
         notificationRepository.save(notification);
 
+        List<UserDevice> feedOwnerDevices = feedOwner.getUserDevices();
+        if (feedOwnerDevices.isEmpty()) {
+            return;
+        }
+
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 notificationTitle,
                 notificationBody,
@@ -84,8 +89,7 @@ public class CommentService {
                 String.valueOf(notification.getNotificationId())
         );
 
-        List<String> targetFCMTokens = feedOwner
-                .getUserDevices()
+        List<String> targetFCMTokens = feedOwnerDevices
                 .stream()
                 .map(UserDevice::getFcmToken)
                 .toList();

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -149,6 +149,11 @@ public class FeedService {
         );
         notificationRepository.save(notification);
 
+        List<UserDevice> feedOwnerDevices = feedOwner.getUserDevices();
+        if (feedOwnerDevices.isEmpty()) {
+            return;
+        }
+
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 notificationTitle,
                 notificationBody,
@@ -157,8 +162,7 @@ public class FeedService {
                 String.valueOf(notification.getNotificationId())
         );
 
-        List<String> targetFCMTokens = feedOwner
-                .getUserDevices()
+        List<String> targetFCMTokens = feedOwnerDevices
                 .stream()
                 .map(UserDevice::getFcmToken)
                 .toList();

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -56,6 +56,11 @@ public class PopularFeedService {
         );
         notificationRepository.save(notification);
 
+        List<UserDevice> feedOwnerDevices = feedOwner.getUserDevices();
+        if (feedOwnerDevices.isEmpty()) {
+            return;
+        }
+
         FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(
                 notificationTitle,
                 notificationBody,
@@ -64,8 +69,7 @@ public class PopularFeedService {
                 String.valueOf(notification.getNotificationId())
         );
 
-        List<String> targetFCMTokens = feed.getUser()
-                .getUserDevices()
+        List<String> targetFCMTokens = feedOwnerDevices
                 .stream()
                 .map(UserDevice::getFcmToken)
                 .toList();

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -253,7 +253,7 @@ public class UserService {
     }
 
     public boolean registerFCMToken(User user, FCMTokenRequest fcmTokenRequest) {
-        return userDeviceRepository.findByDeviceIdentifier(fcmTokenRequest.deviceIdentifier())
+        return userDeviceRepository.findByDeviceIdentifierAndUser(fcmTokenRequest.deviceIdentifier(), user)
                 .map(userDevice -> {
                     userDevice.updateFcmToken(fcmTokenRequest.fcmToken());
                     return false;

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -181,6 +181,7 @@ public class UserService {
 
     public void logout(User user, String refreshToken) {
         refreshTokenRepository.findByRefreshToken(refreshToken).ifPresent(refreshTokenRepository::delete);
+        userDeviceRepository.deleteByUser(user);
         if (user.getSocialId().startsWith(KAKAO_PREFIX)) {
             kakaoService.kakaoLogout(user);
         }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -179,9 +179,9 @@ public class UserService {
                 MessageFormatter.formatUserJoinMessage(user, SocialLoginType.fromSocialId(user.getSocialId())), JOIN));
     }
 
-    public void logout(User user, String refreshToken) {
+    public void logout(User user, String refreshToken, String deviceIdentifier) {
         refreshTokenRepository.findByRefreshToken(refreshToken).ifPresent(refreshTokenRepository::delete);
-        userDeviceRepository.deleteByUser(user);
+        userDeviceRepository.deleteByUserAndDeviceIdentifier(user, deviceIdentifier);
         if (user.getSocialId().startsWith(KAKAO_PREFIX)) {
             kakaoService.kakaoLogout(user);
         }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#293 -> dev
- close #293 

## Key Changes
<!-- 최대한 자세히 -->
현재 로직에서는 유저가 로그아웃 해도 저장되어 있던 유저의 devices 정보를 삭제하지 않습니다.
그러다보니, 유저1이 로그아웃 후 유저2로 접속 시 유저1의 devices와 유저2의 devices가 같기 때문에 유저2는 자신의 알람과 유저1의 알림까지 함께 받게 됩니다.
하여, 유저가 로그아웃 할 때 해당 기기의 디바이스 값을 삭제하고 유저 로그인 시 매번 새로운 fcm token을 발급받는 방식으로 해당 상황을 해결했습니다.

### 주요 변경사항
1. 유저 로그아웃 API 변경
   - Request에 디바이스고유값(deviceIdentefier) 컬럼 추가
   - 로그아웃 시 유저의 디바이스 값 제거 로직 추가
2. FCM token 등록 API 변경
   - 유저를 기준으로 기존 저장된 FCM token이 존재하는지 조회하던 것을 유저와 디바이스값으로 기준 변경
3. 푸시 알림 발송 로직 수정
   - 알림 대상 유저로 저장된 디바이스 값이 없다면 푸시 알림 발송하지 않도록 수정

+ 클라에게 로그인 시마다 fcm toekn 저장 API 호출 요청해야 합니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
