### PR TITLE
[FEAT] 약관 동의 조회 API 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -22,6 +22,7 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.feed.UserFeedsGetResponse;
 import org.websoso.WSSServer.dto.notification.PushSettingGetResponse;
 import org.websoso.WSSServer.dto.notification.PushSettingRequest;
+import org.websoso.WSSServer.dto.user.ConsentSettingGetResponse;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
 import org.websoso.WSSServer.dto.user.FCMTokenRequest;
@@ -238,5 +239,13 @@ public class UserController {
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();
+    }
+
+    @GetMapping("/consent-settings")
+    public ResponseEntity<ConsentSettingGetResponse> getConsentSettingValue(Principal principal) {
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        return ResponseEntity
+                .status(OK)
+                .body(userService.getConsentSettingValue(user));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -241,7 +241,7 @@ public class UserController {
                 .build();
     }
 
-    @GetMapping("/consent-settings")
+    @GetMapping("/terms-settings")
     public ResponseEntity<ConsentSettingGetResponse> getConsentSettingValue(Principal principal) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -22,7 +22,6 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.feed.UserFeedsGetResponse;
 import org.websoso.WSSServer.dto.notification.PushSettingGetResponse;
 import org.websoso.WSSServer.dto.notification.PushSettingRequest;
-import org.websoso.WSSServer.dto.user.ConsentSettingGetResponse;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
 import org.websoso.WSSServer.dto.user.FCMTokenRequest;
@@ -32,6 +31,7 @@ import org.websoso.WSSServer.dto.user.NicknameValidation;
 import org.websoso.WSSServer.dto.user.ProfileGetResponse;
 import org.websoso.WSSServer.dto.user.ProfileStatusResponse;
 import org.websoso.WSSServer.dto.user.RegisterUserInfoRequest;
+import org.websoso.WSSServer.dto.user.TermsSettingGetResponse;
 import org.websoso.WSSServer.dto.user.UpdateMyProfileRequest;
 import org.websoso.WSSServer.dto.user.UserIdAndNicknameResponse;
 import org.websoso.WSSServer.dto.user.UserInfoGetResponse;
@@ -242,7 +242,7 @@ public class UserController {
     }
 
     @GetMapping("/terms-settings")
-    public ResponseEntity<ConsentSettingGetResponse> getConsentSettingValue(Principal principal) {
+    public ResponseEntity<TermsSettingGetResponse> getConsentSettingValue(Principal principal) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
                 .status(OK)

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -242,10 +242,10 @@ public class UserController {
     }
 
     @GetMapping("/terms-settings")
-    public ResponseEntity<TermsSettingGetResponse> getConsentSettingValue(Principal principal) {
+    public ResponseEntity<TermsSettingGetResponse> getTermsSettingValue(Principal principal) {
         User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
                 .status(OK)
-                .body(userService.getConsentSettingValue(user));
+                .body(userService.getTermsSettingValue(user));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -139,6 +139,9 @@ public class User extends BaseEntity {
         this.avatarId = 1;
         this.isProfilePublic = true;
         this.isPushEnabled = true;
+        this.isTermsAgreed = false;
+        this.isPrivacyConsented = false;
+        this.isMarketingConsented = false;
         this.role = USER;
         this.socialId = socialId;
         this.nickname = nickname;

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -77,6 +77,15 @@ public class User extends BaseEntity {
     @Column(columnDefinition = "Boolean default true", nullable = false)
     private Boolean isPushEnabled;
 
+    @Column(columnDefinition = "Boolean default false", nullable = false)
+    private Boolean isTermsAgreed;
+
+    @Column(columnDefinition = "Boolean default false", nullable = false)
+    private Boolean isPrivacyConsented;
+
+    @Column(columnDefinition = "Boolean default false", nullable = false)
+    private Boolean isMarketingConsented;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @ColumnDefault("'USER'")

--- a/src/main/java/org/websoso/WSSServer/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/domain/User.java
@@ -78,13 +78,13 @@ public class User extends BaseEntity {
     private Boolean isPushEnabled;
 
     @Column(columnDefinition = "Boolean default false", nullable = false)
-    private Boolean isTermsAgreed;
+    private Boolean serviceAgreed;
 
     @Column(columnDefinition = "Boolean default false", nullable = false)
-    private Boolean isPrivacyConsented;
+    private Boolean privacyAgreed;
 
     @Column(columnDefinition = "Boolean default false", nullable = false)
-    private Boolean isMarketingConsented;
+    private Boolean marketingAgreed;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -139,9 +139,9 @@ public class User extends BaseEntity {
         this.avatarId = 1;
         this.isProfilePublic = true;
         this.isPushEnabled = true;
-        this.isTermsAgreed = false;
-        this.isPrivacyConsented = false;
-        this.isMarketingConsented = false;
+        this.serviceAgreed = false;
+        this.privacyAgreed = false;
+        this.marketingAgreed = false;
         this.role = USER;
         this.socialId = socialId;
         this.nickname = nickname;

--- a/src/main/java/org/websoso/WSSServer/dto/user/ConsentSettingGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/ConsentSettingGetResponse.java
@@ -1,0 +1,16 @@
+package org.websoso.WSSServer.dto.user;
+
+public record ConsentSettingGetResponse(
+        Boolean isTermsAgreed,
+        Boolean isPrivacyConsented,
+        Boolean isMarketingConsented
+) {
+    public static ConsentSettingGetResponse of(Boolean isTermsAgreed, Boolean isPrivacyConsented,
+                                               Boolean isMarketingConsented) {
+        return new ConsentSettingGetResponse(
+                isTermsAgreed,
+                isPrivacyConsented,
+                isMarketingConsented
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/user/ConsentSettingGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/ConsentSettingGetResponse.java
@@ -1,16 +1,15 @@
 package org.websoso.WSSServer.dto.user;
 
 public record ConsentSettingGetResponse(
-        Boolean isTermsAgreed,
-        Boolean isPrivacyConsented,
-        Boolean isMarketingConsented
+        Boolean serviceAgreed,
+        Boolean privacyAgreed,
+        Boolean marketingAgreed
 ) {
-    public static ConsentSettingGetResponse of(Boolean isTermsAgreed, Boolean isPrivacyConsented,
-                                               Boolean isMarketingConsented) {
+    public static ConsentSettingGetResponse of(Boolean serviceAgreed, Boolean privacyAgreed, Boolean marketingAgreed) {
         return new ConsentSettingGetResponse(
-                isTermsAgreed,
-                isPrivacyConsented,
-                isMarketingConsented
+                serviceAgreed,
+                privacyAgreed,
+                marketingAgreed
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/user/TermsSettingGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/TermsSettingGetResponse.java
@@ -1,12 +1,12 @@
 package org.websoso.WSSServer.dto.user;
 
-public record ConsentSettingGetResponse(
+public record TermsSettingGetResponse(
         Boolean serviceAgreed,
         Boolean privacyAgreed,
         Boolean marketingAgreed
 ) {
-    public static ConsentSettingGetResponse of(Boolean serviceAgreed, Boolean privacyAgreed, Boolean marketingAgreed) {
-        return new ConsentSettingGetResponse(
+    public static TermsSettingGetResponse of(Boolean serviceAgreed, Boolean privacyAgreed, Boolean marketingAgreed) {
+        return new TermsSettingGetResponse(
                 serviceAgreed,
                 privacyAgreed,
                 marketingAgreed

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -281,7 +281,7 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public ConsentSettingGetResponse getConsentSettingValue(User user) {
-        return ConsentSettingGetResponse.of(user.getIsTermsAgreed(), user.getIsPrivacyConsented(),
-                user.getIsMarketingConsented());
+        return ConsentSettingGetResponse.of(user.getServiceAgreed(), user.getPrivacyAgreed(),
+                user.getMarketingAgreed());
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -280,7 +280,7 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public TermsSettingGetResponse getConsentSettingValue(User user) {
+    public TermsSettingGetResponse getTermsSettingValue(User user) {
         return TermsSettingGetResponse.of(user.getServiceAgreed(), user.getPrivacyAgreed(),
                 user.getMarketingAgreed());
     }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -27,7 +27,6 @@ import org.websoso.WSSServer.domain.WithdrawalReason;
 import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.domain.common.SocialLoginType;
 import org.websoso.WSSServer.dto.notification.PushSettingGetResponse;
-import org.websoso.WSSServer.dto.user.ConsentSettingGetResponse;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
 import org.websoso.WSSServer.dto.user.FCMTokenRequest;
@@ -37,6 +36,7 @@ import org.websoso.WSSServer.dto.user.NicknameValidation;
 import org.websoso.WSSServer.dto.user.ProfileGetResponse;
 import org.websoso.WSSServer.dto.user.ProfileStatusResponse;
 import org.websoso.WSSServer.dto.user.RegisterUserInfoRequest;
+import org.websoso.WSSServer.dto.user.TermsSettingGetResponse;
 import org.websoso.WSSServer.dto.user.UpdateMyProfileRequest;
 import org.websoso.WSSServer.dto.user.UserIdAndNicknameResponse;
 import org.websoso.WSSServer.dto.user.UserInfoGetResponse;
@@ -280,8 +280,8 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public ConsentSettingGetResponse getConsentSettingValue(User user) {
-        return ConsentSettingGetResponse.of(user.getServiceAgreed(), user.getPrivacyAgreed(),
+    public TermsSettingGetResponse getConsentSettingValue(User user) {
+        return TermsSettingGetResponse.of(user.getServiceAgreed(), user.getPrivacyAgreed(),
                 user.getMarketingAgreed());
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -27,6 +27,7 @@ import org.websoso.WSSServer.domain.WithdrawalReason;
 import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.domain.common.SocialLoginType;
 import org.websoso.WSSServer.dto.notification.PushSettingGetResponse;
+import org.websoso.WSSServer.dto.user.ConsentSettingGetResponse;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
 import org.websoso.WSSServer.dto.user.FCMTokenRequest;
@@ -276,5 +277,11 @@ public class UserService {
     @Transactional(readOnly = true)
     public PushSettingGetResponse getPushSettingValue(User user) {
         return PushSettingGetResponse.of(user.getIsPushEnabled());
+    }
+
+    @Transactional(readOnly = true)
+    public ConsentSettingGetResponse getConsentSettingValue(User user) {
+        return ConsentSettingGetResponse.of(user.getIsTermsAgreed(), user.getIsPrivacyConsented(),
+                user.getIsMarketingConsented());
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#295 -> dev
- close #295 

## Key Changes
<!-- 최대한 자세히 -->
약관 동의를 조회하는 API를 구현했습니다.
사용자가 조회하기 위함이 아닌 클라이언트 측에서 기존 유저가 새롭게 동의를 받아야하는지 확인하기 위한 api 입니다.
- 약관 동의 여부를 저장하기 위해 `User` 안에 `isTermsAgreed`, `isPrivacyConsented`, `isMarketingConsented`를 추가했습니다.
- 필드 추가에 따라 생성자를 수정하였습니다.
- **GET**  `/users/consent-settings` 로 조회할 수 있습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 생성자만 수정해주면 되는 것으로 확인했는데 혹시 회원가입 시 필드 추가로 인한 오류가 일어날만한 예외사항이 있을지 한번 더 체크 부탁드립니다아
- 아직 DB에는 필드 추가를 적용하지 않았습니다!

## References
<!-- 참고한 자료-->
- [API 명세서(Notion)](https://www.notion.so/kimmjabc/API-1959e64a45328006afc0d50e04d9ec72?pvs=4)