### PR TITLE
[FIX] 차단된 유저에 대한 알림 받지 않도록 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -56,7 +56,7 @@ public class CommentService {
 
     private void sendCommentPushMessageToFeedOwner(User user, Feed feed) {
         User feedOwner = feed.getUser();
-        if (isUserCommentOwner(user, feedOwner)) {
+        if (isUserCommentOwner(user, feedOwner) || blockService.isBlocked(feedOwner.getUserId(), user.getUserId())) {
             return;
         }
 

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -114,7 +114,8 @@ public class CommentService {
                 .filter(userId -> !userId.equals(user.getUserId()))
                 .distinct()
                 .map(userService::getUserOrException)
-                .filter(commenter -> !blockService.isBlocked(commenter.getUserId(), user.getUserId()))
+                .filter(commenter -> !blockService.isBlocked(commenter.getUserId(), user.getUserId())
+                        && !blockService.isBlocked(commenter.getUserId(), feed.getUser().getUserId()))
                 .toList();
 
         if (commenters.isEmpty()) {

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -112,10 +112,10 @@ public class CommentService {
                 .stream()
                 .map(Comment::getUserId)
                 .filter(userId -> !userId.equals(user.getUserId()))
+                .filter(userId -> !blockService.isBlocked(userId, user.getUserId())
+                        && !blockService.isBlocked(userId, feed.getUser().getUserId()))
                 .distinct()
                 .map(userService::getUserOrException)
-                .filter(commenter -> !blockService.isBlocked(commenter.getUserId(), user.getUserId())
-                        && !blockService.isBlocked(commenter.getUserId(), feed.getUser().getUserId()))
                 .toList();
 
         if (commenters.isEmpty()) {

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -114,6 +114,7 @@ public class CommentService {
                 .filter(userId -> !userId.equals(user.getUserId()))
                 .distinct()
                 .map(userService::getUserOrException)
+                .filter(commenter -> !blockService.isBlocked(commenter.getUserId(), user.getUserId()))
                 .toList();
 
         if (commenters.isEmpty()) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -115,8 +115,9 @@ public class FeedService {
 
     public void likeFeed(User user, Long feedId) {
         Feed feed = getFeedOrException(feedId);
+        User feedOwner = feed.getUser();
         checkHiddenFeed(feed);
-        checkBlocked(feed.getUser(), user);
+        checkBlocked(feedOwner, user);
 
         likeService.createLike(user, feed);
 
@@ -124,7 +125,9 @@ public class FeedService {
             popularFeedService.createPopularFeed(feed);
         }
 
-        sendLikePushMessage(user, feed);
+        if (!blockService.isBlocked(feedOwner.getUserId(), user.getUserId())) {
+            sendLikePushMessage(user, feed);
+        }
     }
 
     private void sendLikePushMessage(User liker, Feed feed) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -115,9 +115,8 @@ public class FeedService {
 
     public void likeFeed(User user, Long feedId) {
         Feed feed = getFeedOrException(feedId);
-        User feedOwner = feed.getUser();
         checkHiddenFeed(feed);
-        checkBlocked(feedOwner, user);
+        checkBlocked(feed.getUser(), user);
 
         likeService.createLike(user, feed);
 
@@ -125,14 +124,12 @@ public class FeedService {
             popularFeedService.createPopularFeed(feed);
         }
 
-        if (!blockService.isBlocked(feedOwner.getUserId(), user.getUserId())) {
-            sendLikePushMessage(user, feed);
-        }
+        sendLikePushMessage(user, feed);
     }
 
     private void sendLikePushMessage(User liker, Feed feed) {
         User feedOwner = feed.getUser();
-        if (liker.equals(feedOwner)) {
+        if (liker.equals(feedOwner) || blockService.isBlocked(feedOwner.getUserId(), liker.getUserId())) {
             return;
         }
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#299 -> dev
- close #299

## Key Changes
<!-- 최대한 자세히 -->
차단한 유저에 대한 알림을 받지 않도록 수정하였습니다.
- 차단한 유저가 좋아요를 누른 경우
- 차단한 유저가 댓글을 쓴 경우 (내가 쓴 피드인 경우)
- 차단한 유저가 댓글을 쓴 경우 (내가 댓글을 쓴 피드인 경우)
- 수다글에 댓글을 남긴 이후 수다 작성자를 차단한 경우
위 4가지 경우에 대한 알림이 생성되지 않도록 하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
