### PR TITLE
[FIX] 알림 목록 조회 API 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/notification/NotificationInfo.java
+++ b/src/main/java/org/websoso/WSSServer/dto/notification/NotificationInfo.java
@@ -1,10 +1,12 @@
 package org.websoso.WSSServer.dto.notification;
 
+import static org.websoso.WSSServer.domain.common.NotificationTypeGroup.NOTICE;
+
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Set;
 import org.websoso.WSSServer.domain.Notification;
+import org.websoso.WSSServer.domain.common.NotificationTypeGroup;
 
 public record NotificationInfo(
         Long notificationId,
@@ -23,7 +25,6 @@ public record NotificationInfo(
     private static final String DATE_PATTERN = "yyyy.MM.dd";
 
     static public NotificationInfo of(Notification notification, Boolean isRead) {
-        Set<String> validNoticeTypes = Set.of("공지", "이벤트");
         return new NotificationInfo(
                 notification.getNotificationId(),
                 notification.getNotificationType().getNotificationTypeImage(),
@@ -31,7 +32,8 @@ public record NotificationInfo(
                 notification.getNotificationBody(),
                 formatCreatedDate(notification.getCreatedDate()),
                 isRead,
-                validNoticeTypes.contains(notification.getNotificationType().getNotificationTypeName()),
+                NotificationTypeGroup.isTypeInGroup(notification.getNotificationType().getNotificationTypeName(),
+                        NOTICE),
                 notification.getFeedId()
         );
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#301 -> dev
- close #301

## Key Changes
<!-- 최대한 자세히 -->
기존 알림 목록 조회 API의 공지 알림 유형을 확인하는 로직에서 `Set.of("공지", "이벤트")`와 같이 하드코딩된 방식을 사용하고 있었는데, 서버 내 공지의 명칭이 "공지" → "공지사항"으로 변경되면서 예외가 발생하는 문제가 있었습니다.
이를 해결하기 위해 공지 알림 유형을 확인하는 로직을 메서드를 활용하는 방식으로 변경하였습니다.

**추가 변경 사항**  
- 현재 푸시 알림이 불안정한 상황이어서 푸시 알림 전송 과정의 로깅을 추가하였습니다.  
  (이 부분은 해당 PR의 주요 기능과는 별개지만, 디버깅을 위한 개선 사항입니다.)

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 본 PR에서 수정된 클래스는 직전 PR(dev 병합 전)에 새롭게 생성된 클래스를 포함하고 있습니다.
- 따라서 직전 PR의 코드와 본 PR의 코드가 함께 포함되어 있을 수 있으며, 변경된 부분에 대해서는 따로 코멘트를 남겨두겠습니다. 🙏

## References
<!-- 참고한 자료-->
