### PR TITLE
[FIX] 알림 수신 동의하지 않았을 경우 푸시알림 받지 않도록 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -1,9 +1,26 @@
 package org.websoso.WSSServer.service;
 
+import static java.lang.Boolean.TRUE;
+import static org.websoso.WSSServer.domain.common.Action.DELETE;
+import static org.websoso.WSSServer.domain.common.Action.UPDATE;
+import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.REPORT;
+import static org.websoso.WSSServer.domain.common.ReportedType.IMPERTINENCE;
+import static org.websoso.WSSServer.domain.common.ReportedType.SPOILER;
+import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_NOT_FOUND;
+import static org.websoso.WSSServer.exception.error.CustomCommentError.SELF_REPORT_NOT_ALLOWED;
+
+import java.util.AbstractMap;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.websoso.WSSServer.domain.*;
+import org.websoso.WSSServer.domain.Comment;
+import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.Notification;
+import org.websoso.WSSServer.domain.NotificationType;
+import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserDevice;
 import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.domain.common.ReportedType;
 import org.websoso.WSSServer.dto.comment.CommentGetResponse;
@@ -15,18 +32,6 @@ import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 import org.websoso.WSSServer.repository.CommentRepository;
 import org.websoso.WSSServer.repository.NotificationRepository;
 import org.websoso.WSSServer.repository.NotificationTypeRepository;
-
-import java.util.AbstractMap;
-import java.util.List;
-
-import static java.lang.Boolean.TRUE;
-import static org.websoso.WSSServer.domain.common.Action.DELETE;
-import static org.websoso.WSSServer.domain.common.Action.UPDATE;
-import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.REPORT;
-import static org.websoso.WSSServer.domain.common.ReportedType.IMPERTINENCE;
-import static org.websoso.WSSServer.domain.common.ReportedType.SPOILER;
-import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_NOT_FOUND;
-import static org.websoso.WSSServer.exception.error.CustomCommentError.SELF_REPORT_NOT_ALLOWED;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -1,25 +1,9 @@
 package org.websoso.WSSServer.service;
 
-import static org.websoso.WSSServer.domain.common.Action.DELETE;
-import static org.websoso.WSSServer.domain.common.Action.UPDATE;
-import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.REPORT;
-import static org.websoso.WSSServer.domain.common.ReportedType.IMPERTINENCE;
-import static org.websoso.WSSServer.domain.common.ReportedType.SPOILER;
-import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_NOT_FOUND;
-import static org.websoso.WSSServer.exception.error.CustomCommentError.SELF_REPORT_NOT_ALLOWED;
-
-import java.util.AbstractMap;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.websoso.WSSServer.domain.Comment;
-import org.websoso.WSSServer.domain.Feed;
-import org.websoso.WSSServer.domain.Notification;
-import org.websoso.WSSServer.domain.NotificationType;
-import org.websoso.WSSServer.domain.Novel;
-import org.websoso.WSSServer.domain.User;
-import org.websoso.WSSServer.domain.UserDevice;
+import org.websoso.WSSServer.domain.*;
 import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.domain.common.ReportedType;
 import org.websoso.WSSServer.dto.comment.CommentGetResponse;
@@ -31,6 +15,18 @@ import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 import org.websoso.WSSServer.repository.CommentRepository;
 import org.websoso.WSSServer.repository.NotificationRepository;
 import org.websoso.WSSServer.repository.NotificationTypeRepository;
+
+import java.util.AbstractMap;
+import java.util.List;
+
+import static java.lang.Boolean.TRUE;
+import static org.websoso.WSSServer.domain.common.Action.DELETE;
+import static org.websoso.WSSServer.domain.common.Action.UPDATE;
+import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.REPORT;
+import static org.websoso.WSSServer.domain.common.ReportedType.IMPERTINENCE;
+import static org.websoso.WSSServer.domain.common.ReportedType.SPOILER;
+import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_NOT_FOUND;
+import static org.websoso.WSSServer.exception.error.CustomCommentError.SELF_REPORT_NOT_ALLOWED;
 
 @Service
 @RequiredArgsConstructor
@@ -75,6 +71,10 @@ public class CommentService {
                 notificationTypeComment
         );
         notificationRepository.save(notification);
+
+        if (!TRUE.equals(feedOwner.getIsPushEnabled())) {
+            return;
+        }
 
         List<UserDevice> feedOwnerDevices = feedOwner.getUserDevices();
         if (feedOwnerDevices.isEmpty()) {

--- a/src/main/java/org/websoso/WSSServer/service/CommentService.java
+++ b/src/main/java/org/websoso/WSSServer/service/CommentService.java
@@ -147,6 +147,10 @@ public class CommentService {
             );
             notificationRepository.save(notification);
 
+            if (!TRUE.equals(commenter.getIsPushEnabled())) {
+                return;
+            }
+
             List<UserDevice> commenterDevices = commenter.getUserDevices();
             if (commenterDevices.isEmpty()) {
                 return;

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -1,34 +1,61 @@
 package org.websoso.WSSServer.service;
 
+import static java.lang.Boolean.TRUE;
+import static org.websoso.WSSServer.domain.common.Action.DELETE;
+import static org.websoso.WSSServer.domain.common.Action.UPDATE;
+import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.REPORT;
+import static org.websoso.WSSServer.exception.error.CustomFeedError.BLOCKED_USER_ACCESS;
+import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOUND;
+import static org.websoso.WSSServer.exception.error.CustomFeedError.HIDDEN_FEED_ACCESS;
+import static org.websoso.WSSServer.exception.error.CustomFeedError.SELF_REPORT_NOT_ALLOWED;
+import static org.websoso.WSSServer.exception.error.CustomUserError.PRIVATE_PROFILE_STATUS;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.websoso.WSSServer.domain.*;
+import org.websoso.WSSServer.domain.Avatar;
+import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.Notification;
+import org.websoso.WSSServer.domain.NotificationType;
+import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserDevice;
+import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.domain.common.ReportedType;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
 import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
-import org.websoso.WSSServer.dto.feed.*;
+import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
+import org.websoso.WSSServer.dto.feed.FeedGetResponse;
+import org.websoso.WSSServer.dto.feed.FeedInfo;
+import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
+import org.websoso.WSSServer.dto.feed.FeedsGetResponse;
+import org.websoso.WSSServer.dto.feed.InterestFeedGetResponse;
+import org.websoso.WSSServer.dto.feed.InterestFeedsGetResponse;
+import org.websoso.WSSServer.dto.feed.UserFeedGetResponse;
+import org.websoso.WSSServer.dto.feed.UserFeedsGetResponse;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseFeedTab;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
 import org.websoso.WSSServer.notification.FCMService;
 import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
-import org.websoso.WSSServer.repository.*;
-
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static java.lang.Boolean.TRUE;
-import static org.websoso.WSSServer.domain.common.Action.DELETE;
-import static org.websoso.WSSServer.domain.common.Action.UPDATE;
-import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.REPORT;
-import static org.websoso.WSSServer.exception.error.CustomFeedError.*;
-import static org.websoso.WSSServer.exception.error.CustomUserError.PRIVATE_PROFILE_STATUS;
+import org.websoso.WSSServer.repository.AvatarRepository;
+import org.websoso.WSSServer.repository.FeedRepository;
+import org.websoso.WSSServer.repository.NotificationRepository;
+import org.websoso.WSSServer.repository.NotificationTypeRepository;
+import org.websoso.WSSServer.repository.NovelRepository;
+import org.websoso.WSSServer.repository.UserNovelRepository;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -1,60 +1,34 @@
 package org.websoso.WSSServer.service;
 
-import static org.websoso.WSSServer.domain.common.Action.DELETE;
-import static org.websoso.WSSServer.domain.common.Action.UPDATE;
-import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.REPORT;
-import static org.websoso.WSSServer.exception.error.CustomFeedError.BLOCKED_USER_ACCESS;
-import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOUND;
-import static org.websoso.WSSServer.exception.error.CustomFeedError.HIDDEN_FEED_ACCESS;
-import static org.websoso.WSSServer.exception.error.CustomFeedError.SELF_REPORT_NOT_ALLOWED;
-import static org.websoso.WSSServer.exception.error.CustomUserError.PRIVATE_PROFILE_STATUS;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.websoso.WSSServer.domain.Avatar;
-import org.websoso.WSSServer.domain.Feed;
-import org.websoso.WSSServer.domain.Notification;
-import org.websoso.WSSServer.domain.NotificationType;
-import org.websoso.WSSServer.domain.Novel;
-import org.websoso.WSSServer.domain.User;
-import org.websoso.WSSServer.domain.UserDevice;
-import org.websoso.WSSServer.domain.UserNovel;
+import org.websoso.WSSServer.domain.*;
 import org.websoso.WSSServer.domain.common.DiscordWebhookMessage;
 import org.websoso.WSSServer.domain.common.ReportedType;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
 import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
-import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
-import org.websoso.WSSServer.dto.feed.FeedGetResponse;
-import org.websoso.WSSServer.dto.feed.FeedInfo;
-import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
-import org.websoso.WSSServer.dto.feed.FeedsGetResponse;
-import org.websoso.WSSServer.dto.feed.InterestFeedGetResponse;
-import org.websoso.WSSServer.dto.feed.InterestFeedsGetResponse;
-import org.websoso.WSSServer.dto.feed.UserFeedGetResponse;
-import org.websoso.WSSServer.dto.feed.UserFeedsGetResponse;
+import org.websoso.WSSServer.dto.feed.*;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseFeedTab;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
 import org.websoso.WSSServer.notification.FCMService;
 import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
-import org.websoso.WSSServer.repository.AvatarRepository;
-import org.websoso.WSSServer.repository.FeedRepository;
-import org.websoso.WSSServer.repository.NotificationRepository;
-import org.websoso.WSSServer.repository.NotificationTypeRepository;
-import org.websoso.WSSServer.repository.NovelRepository;
-import org.websoso.WSSServer.repository.UserNovelRepository;
+import org.websoso.WSSServer.repository.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.lang.Boolean.TRUE;
+import static org.websoso.WSSServer.domain.common.Action.DELETE;
+import static org.websoso.WSSServer.domain.common.Action.UPDATE;
+import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.REPORT;
+import static org.websoso.WSSServer.exception.error.CustomFeedError.*;
+import static org.websoso.WSSServer.exception.error.CustomUserError.PRIVATE_PROFILE_STATUS;
 
 @Service
 @RequiredArgsConstructor
@@ -148,6 +122,10 @@ public class FeedService {
                 notificationTypeComment
         );
         notificationRepository.save(notification);
+
+        if (!TRUE.equals(feedOwner.getIsPushEnabled())) {
+            return;
+        }
 
         List<UserDevice> feedOwnerDevices = feedOwner.getUserDevices();
         if (feedOwnerDevices.isEmpty()) {

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -1,9 +1,18 @@
 package org.websoso.WSSServer.service;
 
+import static java.lang.Boolean.TRUE;
+
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.websoso.WSSServer.domain.*;
+import org.websoso.WSSServer.domain.Feed;
+import org.websoso.WSSServer.domain.Notification;
+import org.websoso.WSSServer.domain.NotificationType;
+import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.PopularFeed;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserDevice;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedGetResponse;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
 import org.websoso.WSSServer.notification.FCMService;
@@ -11,10 +20,6 @@ import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 import org.websoso.WSSServer.repository.NotificationRepository;
 import org.websoso.WSSServer.repository.NotificationTypeRepository;
 import org.websoso.WSSServer.repository.PopularFeedRepository;
-
-import java.util.List;
-
-import static java.lang.Boolean.TRUE;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -1,16 +1,9 @@
 package org.websoso.WSSServer.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.websoso.WSSServer.domain.Feed;
-import org.websoso.WSSServer.domain.Notification;
-import org.websoso.WSSServer.domain.NotificationType;
-import org.websoso.WSSServer.domain.Novel;
-import org.websoso.WSSServer.domain.PopularFeed;
-import org.websoso.WSSServer.domain.User;
-import org.websoso.WSSServer.domain.UserDevice;
+import org.websoso.WSSServer.domain.*;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedGetResponse;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
 import org.websoso.WSSServer.notification.FCMService;
@@ -18,6 +11,10 @@ import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 import org.websoso.WSSServer.repository.NotificationRepository;
 import org.websoso.WSSServer.repository.NotificationTypeRepository;
 import org.websoso.WSSServer.repository.PopularFeedRepository;
+
+import java.util.List;
+
+import static java.lang.Boolean.TRUE;
 
 @Service
 @RequiredArgsConstructor
@@ -55,6 +52,10 @@ public class PopularFeedService {
                 notificationTypeComment
         );
         notificationRepository.save(notification);
+
+        if (!TRUE.equals(feedOwner.getIsPushEnabled())) {
+            return;
+        }
 
         List<UserDevice> feedOwnerDevices = feedOwner.getUserDevices();
         if (feedOwnerDevices.isEmpty()) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#305 -> dev
- close #305

## Key Changes
<!-- 최대한 자세히 -->
현재 푸시 알림에 미동의한 유저들에게도 푸시알림이 가고 있어, 해당 유저들에 대해 앱 내 알림은 생성되지만, 푸시알림은 생성되지 않도록 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 공지/이벤트 타입의 알림들은 현재 열려있는 pr#304 확인해주시면 됩니다

## References
<!-- 참고한 자료-->
