### PR TITLE
[FIX] 수다글 삭제 시 지금 뜨는 수다글도 함께 삭제되도록 연관관계 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -68,6 +69,9 @@ public class Feed {
 
     @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<ReportedFeed> reportedFeeds = new ArrayList<>();
+
+    @OneToOne(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private PopularFeed popularFeed;
 
     @Builder
     public Feed(String feedContent, Boolean isSpoiler, Long novelId, User user) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#307 -> dev
- close #307

## Key Changes
<!-- 최대한 자세히 -->
Feed와 PopularFeed 간 양방향 매핑을 적용하고 `@OneToOne(mappedBy = "feed", cascade = CascadeType.ALL, orphanRemoval = true)` 적용하여 수다글 삭제 시 연관된 지금 뜨는 수다글도 자동 삭제되도록 변경하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
