### PR TITLE
[FIX] 알림 목록 조회 정렬 기준 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/repository/NotificationRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NotificationRepository.java
@@ -15,7 +15,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query(value = "SELECT n FROM Notification n WHERE "
             + "(:lastNotificationId = 0 OR n.notificationId < :lastNotificationId) "
             + "AND (n.userId = 0 OR n.userId = :userId) "
-            + "ORDER BY n.createdDate DESC")
+            + "ORDER BY n.notificationId DESC")
     Slice<Notification> findNotifications(Long lastNotificationId, Long userId, PageRequest pageRequest);
 
     @Query("SELECT CASE WHEN COUNT(n) > 0 THEN TRUE ELSE FALSE END " +


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#309 -> dev
- close #309 

## Key Changes
<!-- 최대한 자세히 -->
알림 목록 조회 시 정렬 기준을 `알림 id` 기준으로 변경하였습니다.
  - 기존: 알림 생성 시간(`createdDate`) 기준 정렬  
  - 변경: `알림 id` 기준 정렬 (id가 시간순으로 증가)  

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
