### PR TITLE
[FIX] 유저 탈퇴 시 해당 유저의 모든 리프레시 토큰 제거 로직 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/RefreshToken.java
+++ b/src/main/java/org/websoso/WSSServer/domain/RefreshToken.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @AllArgsConstructor
@@ -13,5 +14,6 @@ public class RefreshToken {
     @Id
     private String refreshToken;
 
+    @Indexed
     private Long userId;
 }

--- a/src/main/java/org/websoso/WSSServer/dto/user/WithdrawalRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/WithdrawalRequest.java
@@ -1,12 +1,9 @@
 package org.websoso.WSSServer.dto.user;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record WithdrawalRequest(
         @Size(max = 80, message = "탈퇴 사유는 80자를 초과할 수 없습니다.")
-        String reason,
-        @NotBlank(message = "리프레시 토큰은 null 이거나, 공백일 수 없습니다.")
-        String refreshToken
+        String reason
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/RefreshTokenRepository.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import org.websoso.WSSServer.domain.RefreshToken;
@@ -7,4 +8,6 @@ import org.websoso.WSSServer.domain.RefreshToken;
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+    List<RefreshToken> findAllByUserId(Long userId);
 }

--- a/src/main/java/org/websoso/WSSServer/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserService.java
@@ -196,7 +196,7 @@ public class UserService {
         String messageContent = MessageFormatter.formatUserWithdrawMessage(user.getUserId(), user.getNickname(),
                 withdrawalRequest.reason());
 
-        cleanupUserData(user.getUserId(), withdrawalRequest.refreshToken());
+        cleanupUserData(user.getUserId());
 
         messageService.sendDiscordWebhookMessage(
                 DiscordWebhookMessage.of(messageContent, WITHDRAW));
@@ -239,9 +239,8 @@ public class UserService {
         }
     }
 
-    private void cleanupUserData(Long userId, String refreshToken) {
-        refreshTokenRepository.findByRefreshToken(refreshToken)
-                .ifPresent(refreshTokenRepository::delete);
+    private void cleanupUserData(Long userId) {
+        refreshTokenRepository.deleteAll(refreshTokenRepository.findAllByUserId(userId));
         feedRepository.updateUserToUnknown(userId);
         commentRepository.updateUserToUnknown(userId);
         userRepository.deleteById(userId);


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#311 -> dev
- close #311

## Key Changes
<!-- 최대한 자세히 -->
- RefreshToken 엔티티에 @Indexed 어노테이션 추가하여 userId로 RefreshToken을 조회할 수 있도록 함.
   - @indexed 사용 시 RefreshToken 생성/삭제 시 한 번의 추가 연산이 발생하나, 검토한 방법들 중 가장 성능 영향이 적음.
   - index로 생성된 값도 TTL이 적용되며, 본체 삭제 시 인덱스도 자동 삭제되어 관리가 용이할 것이라 판단함.
   - 인덱스 생성 예시
      ![image](https://github.com/user-attachments/assets/406953c4-8a0c-443b-acfa-4c53fd90b4e5)

- 유저 탈퇴 로직에 유저의 모든 RefreshToken 제거 로직 추가
    - Redis 특성상 deleteAllByUserId가 지원되지 않아 findAllByUserId로 조회 후 deleteAll로 일괄 삭제하는 방식 적용.
- 회원 탈퇴 API의 Request DTO 수정
   - 기존 사용하던 유저의 RefreshToken을 받아서 해당 토큰만 제거했지만 이제는 user의 모든 RefreshToken을 제거하기 때문에 받을 필요가 없어, 제거.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
