### PR TITLE
[FIX] 선호 장르 기반 웹소설 추천 화면 좋아요 개수 오류 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
@@ -31,7 +31,7 @@ public record TasteNovelGetResponse(
     private static Long getInterestCount(Novel tasteNovel) {
         return tasteNovel.getUserNovels()
                 .stream()
-                .map(UserNovel::getIsInterest)
+                .filter(UserNovel::getIsInterest)
                 .count();
     }
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#313 -> dev
- close #313

## Key Changes
<!-- 최대한 자세히 -->
홈화면에서 선호 장르를 기반으로 웹소설을 추천해주는 "이 웹소설은 어때요?" 부분에서 관심 수를 가져오는 함수를 고쳤습니다.
isInterest가 true인 것만 가져와야 하는데, map만 해놓고 false인 것까지 가져오고 있어 filter로 바꿔줬습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
