### PR TITLE
[REFACTOR] 오늘의 발견 API 리팩토링

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -114,7 +114,9 @@ public class NovelController {
 
     @GetMapping("/popular")
     public ResponseEntity<PopularNovelsGetResponse> getTodayPopularNovels(Principal principal) {
-        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
+        User user = principal == null
+                ? null
+                : userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
                 .status(OK)
                 .body(novelService.getTodayPopularNovels(user));

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -114,10 +114,10 @@ public class NovelController {
 
     @GetMapping("/popular")
     public ResponseEntity<PopularNovelsGetResponse> getTodayPopularNovels(Principal principal) {
-        //TODO 차단 관계에 있는 유저의 피드글 처리
+        User user = userService.getUserOrException(Long.valueOf(principal.getName()));
         return ResponseEntity
                 .status(OK)
-                .body(novelService.getTodayPopularNovels());
+                .body(novelService.getTodayPopularNovels(user));
     }
 
     @GetMapping("/taste")

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
@@ -1,12 +1,13 @@
 package org.websoso.WSSServer.repository;
 
 import java.util.List;
+import java.util.Map;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.User;
 
 public interface FeedCustomRepository {
 
-    List<Feed> findPopularFeedsByNovelIds(User user, List<Long> novelIds);
+    Map<Long, Feed> findPopularFeedsByNovelIds(User user, List<Long> novelIds);
 
     List<Feed> findFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
@@ -6,7 +6,7 @@ import org.websoso.WSSServer.domain.User;
 
 public interface FeedCustomRepository {
 
-    List<Feed> findPopularFeedsByNovelIds(List<Long> novelIds);
+    List<Feed> findPopularFeedsByNovelIds(User user, List<Long> novelIds);
 
     List<Feed> findFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -7,6 +7,7 @@ import static org.websoso.WSSServer.domain.QLike.like;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -23,11 +24,13 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
 
     @Override
     public List<Feed> findPopularFeedsByNovelIds(User user, List<Long> novelIds) {
-        List<Long> blockedUserIds = jpaQueryFactory
-                .select(block.blockedId)
-                .from(block)
-                .where(block.blockingId.eq(user.getUserId()))
-                .fetch();
+        List<Long> blockedUserIds = (user != null) ?
+                jpaQueryFactory
+                        .select(block.blockedId)
+                        .from(block)
+                        .where(block.blockingId.eq(user.getUserId()))
+                        .fetch()
+                : Collections.emptyList();
 
         return novelIds.stream()
                 .map(novelId -> jpaQueryFactory

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -32,9 +32,14 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
         List<Long> blockedUserIds = (user != null) ? jpaQueryFactory.select(block.blockedId).from(block)
                 .where(block.blockingId.eq(user.getUserId())).fetch() : Collections.emptyList();
 
-        List<Tuple> results = jpaQueryFactory.select(feed, like.count()).from(feed).leftJoin(feed.likes, like)
-                .where(feed.novelId.in(novelIds).and(feed.user.userId.notIn(blockedUserIds))).groupBy(feed.feedId)
-                .orderBy(like.count().desc()).fetch();
+        List<Tuple> results = jpaQueryFactory
+                .select(feed, like.count())
+                .from(feed)
+                .leftJoin(feed.likes, like)
+                .where(feed.novelId.in(novelIds).and(feed.user.userId.notIn(blockedUserIds)))
+                .groupBy(feed.feedId)
+                .orderBy(like.count().desc())
+                .fetch();
 
         return results
                 .stream()
@@ -48,8 +53,15 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
 
     @Override
     public List<Feed> findFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size) {
-        return jpaQueryFactory.selectFrom(feed).where(feed.user.eq(owner), ltFeedId(lastFeedId))
-                .orderBy(feed.feedId.desc()).limit(size).fetch();
+        return jpaQueryFactory
+                .selectFrom(feed)
+                .where(
+                        feed.user.eq(owner),
+                        ltFeedId(lastFeedId)
+                )
+                .orderBy(feed.feedId.desc())
+                .limit(size)
+                .fetch();
     }
 
     private BooleanExpression ltFeedId(Long lastFeedId) {

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -352,11 +352,12 @@ public class NovelService {
     }
 
     @Transactional(readOnly = true)
-    public PopularNovelsGetResponse getTodayPopularNovels() {
+    public PopularNovelsGetResponse getTodayPopularNovels(User user) {
         List<Long> novelIdsFromPopularNovel = getNovelIdsFromPopularNovel();
         List<Long> selectedNovelIdsFromPopularNovel = getSelectedNovelIdsFromPopularNovel(novelIdsFromPopularNovel);
         List<Novel> popularNovels = getSelectedPopularNovels(selectedNovelIdsFromPopularNovel);
-        List<Feed> popularFeedsFromPopularNovels = getPopularFeedsFromPopularNovels(selectedNovelIdsFromPopularNovel);
+        List<Feed> popularFeedsFromPopularNovels = getPopularFeedsFromPopularNovels(user,
+                selectedNovelIdsFromPopularNovel);
 
         Map<Long, Feed> feedMap = createFeedMap(popularFeedsFromPopularNovels);
         Map<Byte, Avatar> avatarMap = createAvatarMap(feedMap);
@@ -382,8 +383,8 @@ public class NovelService {
         return novelRepository.findAllById(selectedPopularNovelIds);
     }
 
-    private List<Feed> getPopularFeedsFromPopularNovels(List<Long> selectedPopularNovelIds) {
-        return feedRepository.findPopularFeedsByNovelIds(selectedPopularNovelIds);
+    private List<Feed> getPopularFeedsFromPopularNovels(User user, List<Long> selectedPopularNovelIds) {
+        return feedRepository.findPopularFeedsByNovelIds(user, selectedPopularNovelIds);
     }
 
     private static Map<Long, Feed> createFeedMap(List<Feed> popularFeedsFromPopularNovels) {

--- a/src/main/java/org/websoso/WSSServer/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/NovelService.java
@@ -356,10 +356,7 @@ public class NovelService {
         List<Long> novelIdsFromPopularNovel = getNovelIdsFromPopularNovel();
         List<Long> selectedNovelIdsFromPopularNovel = getSelectedNovelIdsFromPopularNovel(novelIdsFromPopularNovel);
         List<Novel> popularNovels = getSelectedPopularNovels(selectedNovelIdsFromPopularNovel);
-        List<Feed> popularFeedsFromPopularNovels = getPopularFeedsFromPopularNovels(user,
-                selectedNovelIdsFromPopularNovel);
-
-        Map<Long, Feed> feedMap = createFeedMap(popularFeedsFromPopularNovels);
+        Map<Long, Feed> feedMap = getPopularFeedsFromPopularNovels(user, selectedNovelIdsFromPopularNovel);
         Map<Byte, Avatar> avatarMap = createAvatarMap(feedMap);
 
         return createPopularNovelsGetResponse(popularNovels, feedMap, avatarMap);
@@ -383,13 +380,8 @@ public class NovelService {
         return novelRepository.findAllById(selectedPopularNovelIds);
     }
 
-    private List<Feed> getPopularFeedsFromPopularNovels(User user, List<Long> selectedPopularNovelIds) {
+    private Map<Long, Feed> getPopularFeedsFromPopularNovels(User user, List<Long> selectedPopularNovelIds) {
         return feedRepository.findPopularFeedsByNovelIds(user, selectedPopularNovelIds);
-    }
-
-    private static Map<Long, Feed> createFeedMap(List<Feed> popularFeedsFromPopularNovels) {
-        return popularFeedsFromPopularNovels.stream()
-                .collect(Collectors.toMap(Feed::getNovelId, feed -> feed));
     }
 
     private Map<Byte, Avatar> createAvatarMap(Map<Long, Feed> feedMap) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- refactor/#322 -> dev
- close #322

## Key Changes
<!-- 최대한 자세히 -->
- 차단 유저의 피드는 오늘의 발견에 뜨지 않도록 하였습니다.
  - 인기작의 가장 인기있는 피드가 차단한 유저의 피드일 경우 -> 다음으로 인기있는 피드 보여줌
  - 가장 있기 있는 피드가 차단한 유저의 피드 && 작품의 피드가 그거 하나 뿐이라면 -> 작품 소개 보여줌
- 원래 비로그인 시에도 호출하는 API이기 때문에, Principal이 null인 경우도 처리해주었습니다.
- `findPopularFeedsByNovelIds()` 함수에서 쿼리 최적화를 진행해보았습니다.
  - 기존에는 novelId마다 쿼리를 날렸었기 때문에, 작품 개수에 따라 쿼리가 많아지지 않도록 한번에 쿼리를 날리는 방식으로 수정하였습니다.
  - 이 과정에서 `findPopularFeedsByNovelIds()`에서 바로 Map을 반환하게 하여 `createFeedMap()` 함수를 제거했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
