### PR TITLE
[FEAT] 피드 비공개 기능 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
+import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 
 @Getter
 @DynamicInsert
@@ -85,11 +86,11 @@ public class Feed {
         return new Feed(request, user);
     }
 
-    public void updateFeed(String feedContent, Boolean isSpoiler, Boolean isPublic, Long novelId) {
-        this.feedContent = feedContent;
-        this.isSpoiler = isSpoiler;
-        this.isPublic = isPublic;
-        this.novelId = novelId;
+    public void updateFeed(FeedUpdateRequest request) {
+        this.feedContent = request.feedContent();
+        this.isSpoiler = request.isSpoiler();
+        this.isPublic = request.isPublic();
+        this.novelId = request.novelId();
         this.modifiedDate = LocalDateTime.now();
     }
 

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -109,4 +109,8 @@ public class Feed {
     public boolean isMine(Long userId) {
         return this.user.getUserId().equals(userId);
     }
+
+    public boolean isVisibleTo(Long userId) {
+        return this.isPublic || this.user.getUserId().equals(userId);
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -107,7 +107,7 @@ public class Feed {
     }
 
     public boolean isMine(Long userId) {
-        return this.user.getUserId().equals(userId);
+        return this.getWriterId().equals(userId);
     }
 
     public boolean isVisibleTo(Long userId) {

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -85,9 +85,10 @@ public class Feed {
         return new Feed(request, user);
     }
 
-    public void updateFeed(String feedContent, Boolean isSpoiler, Long novelId) {
+    public void updateFeed(String feedContent, Boolean isSpoiler, Boolean isPublic, Long novelId) {
         this.feedContent = feedContent;
         this.isSpoiler = isSpoiler;
+        this.isPublic = isPublic;
         this.novelId = novelId;
         this.modifiedDate = LocalDateTime.now();
     }

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -111,6 +111,6 @@ public class Feed {
     }
 
     public boolean isVisibleTo(Long userId) {
-        return this.isPublic || this.user.getUserId().equals(userId);
+        return this.isPublic || this.isMine(userId);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -20,6 +20,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
+import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
 
 @Getter
 @DynamicInsert
@@ -72,16 +73,16 @@ public class Feed {
     @OneToOne(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private PopularFeed popularFeed;
 
-    private Feed(String feedContent, Long novelId, Boolean isSpoiler, Boolean isPublic, User user) {
-        this.feedContent = feedContent;
-        this.novelId = novelId;
-        this.isSpoiler = isSpoiler;
-        this.isPublic = isPublic;
+    private Feed(FeedCreateRequest request, User user) {
+        this.feedContent = request.feedContent();
+        this.novelId = request.novelId();
+        this.isSpoiler = request.isSpoiler();
+        this.isPublic = request.isPublic();
         this.user = user;
     }
 
-    public static Feed create(String feedContent, Long novelId, Boolean isSpoiler, Boolean isPublic, User user) {
-        return new Feed(feedContent, novelId, isSpoiler, isPublic, user);
+    public static Feed create(FeedCreateRequest request, User user) {
+        return new Feed(request, user);
     }
 
     public void updateFeed(String feedContent, Boolean isSpoiler, Long novelId) {

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -44,6 +44,9 @@ public class Feed {
     @Column(nullable = false)
     private Boolean isSpoiler;
 
+    @Column(columnDefinition = "Boolean default true", nullable = false)
+    private Boolean isPublic;
+
     @Column(nullable = false)
     private LocalDateTime createdDate;
 

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -72,15 +72,16 @@ public class Feed {
     @OneToOne(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private PopularFeed popularFeed;
 
-    private Feed(String feedContent, Long novelId, Boolean isSpoiler, User user) {
+    private Feed(String feedContent, Long novelId, Boolean isSpoiler, Boolean isPublic, User user) {
         this.feedContent = feedContent;
         this.novelId = novelId;
         this.isSpoiler = isSpoiler;
+        this.isPublic = isPublic;
         this.user = user;
     }
 
-    public static Feed create(String feedContent, Long novelId, Boolean isSpoiler, User user) {
-        return new Feed(feedContent, novelId, isSpoiler, user);
+    public static Feed create(String feedContent, Long novelId, Boolean isSpoiler, Boolean isPublic, User user) {
+        return new Feed(feedContent, novelId, isSpoiler, isPublic, user);
     }
 
     public void updateFeed(String feedContent, Boolean isSpoiler, Long novelId) {

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedCreateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedCreateRequest.java
@@ -15,6 +15,8 @@ public record FeedCreateRequest(
         String feedContent,
         Long novelId,
         @NotNull(message = "스포일러 여부는 null일 수 없습니다.")
-        Boolean isSpoiler
+        Boolean isSpoiler,
+
+        Boolean isPublic
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedCreateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedCreateRequest.java
@@ -10,10 +10,13 @@ public record FeedCreateRequest(
         @NotNull(message = "카테고리는 null일 수 없습니다.")
         @NotEmpty(message = "카테고리는 1개 이상 선택해야 합니다.")
         List<String> relevantCategories,
+
         @NotBlank(message = "피드 내용은 비어 있거나, 공백일 수 없습니다.")
         @Size(max = 2000, message = "피드 내용은 2000자를 초과할 수 없습니다.")
         String feedContent,
+
         Long novelId,
+
         @NotNull(message = "스포일러 여부는 null일 수 없습니다.")
         Boolean isSpoiler,
 

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedCreateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedCreateRequest.java
@@ -17,6 +17,7 @@ public record FeedCreateRequest(
         @NotNull(message = "스포일러 여부는 null일 수 없습니다.")
         Boolean isSpoiler,
 
+        @NotNull(message = "공개 여부는 null일 수 없습니다.")
         Boolean isPublic
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedInfo.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedInfo.java
@@ -24,8 +24,8 @@ public record FeedInfo(
         List<String> relevantCategories,
         Boolean isSpoiler,
         Boolean isModified,
-        Boolean isMyFeed
-
+        Boolean isMyFeed,
+        Boolean isPublic
 ) {
     public static FeedInfo of(Feed feed, UserBasicInfo userBasicInfo, Novel novel, Boolean isLiked,
                               List<String> relevantCategories, Boolean isMyFeed) {
@@ -60,7 +60,8 @@ public record FeedInfo(
                 relevantCategories,
                 feed.getIsSpoiler(),
                 !feed.getCreatedDate().equals(feed.getModifiedDate()),
-                isMyFeed
+                isMyFeed,
+                feed.getIsPublic()
         );
     }
 

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedUpdateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedUpdateRequest.java
@@ -10,10 +10,13 @@ public record FeedUpdateRequest(
         @NotNull(message = "카테고리는 null일 수 없습니다.")
         @NotEmpty(message = "카테고리는 1개 이상 선택해야 합니다.")
         List<String> relevantCategories,
+
         @NotBlank(message = "피드 내용은 비어 있거나, 공백일 수 없습니다.")
         @Size(max = 2000, message = "피드 내용은 2000자를 초과할 수 없습니다.")
         String feedContent,
+
         Long novelId,
+
         @NotNull(message = "스포일러 여부는 null일 수 없습니다.")
         Boolean isSpoiler
 ) {

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedUpdateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedUpdateRequest.java
@@ -20,6 +20,7 @@ public record FeedUpdateRequest(
         @NotNull(message = "스포일러 여부는 null일 수 없습니다.")
         Boolean isSpoiler,
 
+        @NotNull(message = "공개 여부는 null일 수 없습니다.")
         Boolean isPublic
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedUpdateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedUpdateRequest.java
@@ -18,6 +18,8 @@ public record FeedUpdateRequest(
         Long novelId,
 
         @NotNull(message = "스포일러 여부는 null일 수 없습니다.")
-        Boolean isSpoiler
+        Boolean isSpoiler,
+
+        Boolean isPublic
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/InterestFeedGetResponse.java
@@ -12,6 +12,7 @@ public record InterestFeedGetResponse(
         String novelImage,
         Float novelRating,
         Long novelRatingCount,
+        Boolean isPublic,
         String nickname,
         String avatarImage,
         String feedContent
@@ -27,6 +28,7 @@ public record InterestFeedGetResponse(
                 novel.getNovelImage(),
                 novelRating,
                 novelRatingCount,
+                feed.getIsPublic(),
                 user.getNickname(),
                 avatar.getAvatarImage(),
                 feed.getFeedContent()

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -23,7 +23,8 @@ public record UserFeedGetResponse(
         String title,
         Float novelRating,
         Long novelRatingCount,
-        List<String> relevantCategories
+        List<String> relevantCategories,
+        Boolean isPublic
 ) {
 
     public static UserFeedGetResponse of(Feed feed, Novel novel, Long visitorId) {
@@ -50,7 +51,8 @@ public record UserFeedGetResponse(
                         null : novel.getTitle(),
                 novelRating,
                 novelRatingCount,
-                relevantCategories
+                relevantCategories,
+                feed.getIsPublic()
         );
     }
 

--- a/src/main/java/org/websoso/WSSServer/dto/popularFeed/PopularFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/popularFeed/PopularFeedGetResponse.java
@@ -7,7 +7,8 @@ public record PopularFeedGetResponse(
         String feedContent,
         Integer likeCount,
         Integer commentCount,
-        Boolean isSpoiler
+        Boolean isSpoiler,
+        Boolean isPublic
 ) {
 
     public static PopularFeedGetResponse of(PopularFeed popularFeed) {
@@ -16,7 +17,8 @@ public record PopularFeedGetResponse(
                 popularFeed.getFeed().getFeedContent(),
                 popularFeed.getFeed().getLikes().size(),
                 popularFeed.getFeed().getComments().size(),
-                popularFeed.getFeed().getIsSpoiler()
+                popularFeed.getFeed().getIsSpoiler(),
+                popularFeed.getFeed().getIsPublic()
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -339,7 +339,9 @@ public class FeedService {
         Slice<Feed> feeds = feedRepository.findFeedsByNovelId(novelId, lastFeedId, userIdOrNull,
                 PageRequest.of(DEFAULT_PAGE_NUMBER, size));
 
-        List<FeedInfo> feedGetResponses = feeds.getContent().stream()
+        List<FeedInfo> feedGetResponses = feeds.getContent()
+                .stream()
+                .filter(feed -> feed.isVisibleTo(userIdOrNull))
                 .map(feed -> createFeedInfo(feed, user))
                 .toList();
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -322,6 +322,7 @@ public class FeedService {
                 .collect(Collectors.toMap(Avatar::getAvatarId, avatar -> avatar));
 
         List<InterestFeedGetResponse> interestFeedGetResponses = interestFeeds.stream()
+                .filter(feed -> feed.isVisibleTo(user.getUserId()))
                 .map(feed -> {
                     Novel novel = novelMap.get(feed.getNovelId());
                     Avatar avatar = avatarMap.get(feed.getUser().getAvatarId());

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -193,14 +193,19 @@ public class FeedService {
 
     @Transactional(readOnly = true)
     public FeedsGetResponse getFeeds(User user, String category, Long lastFeedId, int size) {
-        Slice<Feed> feeds = findFeedsByCategoryLabel(category == null ? DEFAULT_CATEGORY : category,
+        Slice<Feed> feeds = findFeedsByCategoryLabel(getChosenCategoryOrDefault(category),
                 lastFeedId, user == null ? null : user.getUserId(), PageRequest.of(DEFAULT_PAGE_NUMBER, size));
 
         List<FeedInfo> feedGetResponses = feeds.getContent()
                 .stream()
                 .map(feed -> createFeedInfo(feed, user)).toList();
 
-        return FeedsGetResponse.of(category == null ? DEFAULT_CATEGORY : category, feeds.hasNext(), feedGetResponses);
+        return FeedsGetResponse.of(getChosenCategoryOrDefault(category), feeds.hasNext(), feedGetResponses);
+    }
+
+    private static String getChosenCategoryOrDefault(String category) {
+        return Optional.ofNullable(category)
+                .orElse(DEFAULT_CATEGORY);
     }
 
     public void createComment(User user, Long feedId, CommentCreateRequest request) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -333,10 +333,9 @@ public class FeedService {
     }
 
     public NovelGetResponseFeedTab getFeedsByNovel(User user, Long novelId, Long lastFeedId, int size) {
-        Long userIdOrNull = user == null
-                ? null
-                : user.getUserId();
-
+        Long userIdOrNull = Optional.ofNullable(user)
+                .map(User::getUserId)
+                .orElse(null);
         Slice<Feed> feeds = feedRepository.findFeedsByNovelId(novelId, lastFeedId, userIdOrNull,
                 PageRequest.of(DEFAULT_PAGE_NUMBER, size));
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -200,8 +200,7 @@ public class FeedService {
                 .stream()
                 .map(feed -> createFeedInfo(feed, user)).toList();
 
-        return FeedsGetResponse.of(category == null ? DEFAULT_CATEGORY : category, feeds.hasNext(),
-                feedGetResponses);
+        return FeedsGetResponse.of(category == null ? DEFAULT_CATEGORY : category, feeds.hasNext(), feedGetResponses);
     }
 
     public void createComment(User user, Long feedId, CommentCreateRequest request) {

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -193,8 +193,12 @@ public class FeedService {
 
     @Transactional(readOnly = true)
     public FeedsGetResponse getFeeds(User user, String category, Long lastFeedId, int size) {
+        Long userIdOrNull = Optional.ofNullable(user)
+                .map(User::getUserId)
+                .orElse(null);
+
         Slice<Feed> feeds = findFeedsByCategoryLabel(getChosenCategoryOrDefault(category),
-                lastFeedId, user == null ? null : user.getUserId(), PageRequest.of(DEFAULT_PAGE_NUMBER, size));
+                lastFeedId, userIdOrNull, PageRequest.of(DEFAULT_PAGE_NUMBER, size));
 
         List<FeedInfo> feedGetResponses = feeds.getContent()
                 .stream()

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -94,7 +94,7 @@ public class FeedService {
         if (request.novelId() != null && feed.isNovelChanged(request.novelId())) {
             novelService.getNovelOrException(request.novelId());
         }
-        feed.updateFeed(request.feedContent(), request.isSpoiler(), request.isPublic(), request.novelId());
+        feed.updateFeed(request);
         feedCategoryService.updateFeedCategory(feed, request.relevantCategories());
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -196,7 +196,8 @@ public class FeedService {
         Slice<Feed> feeds = findFeedsByCategoryLabel(category == null ? DEFAULT_CATEGORY : category,
                 lastFeedId, user == null ? null : user.getUserId(), PageRequest.of(DEFAULT_PAGE_NUMBER, size));
 
-        List<FeedInfo> feedGetResponses = feeds.getContent().stream()
+        List<FeedInfo> feedGetResponses = feeds.getContent()
+                .stream()
                 .map(feed -> createFeedInfo(feed, user)).toList();
 
         return FeedsGetResponse.of(category == null ? DEFAULT_CATEGORY : category, feeds.hasNext(),

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -357,7 +357,11 @@ public class FeedService {
         if (owner.getIsProfilePublic() || isOwner(visitor, ownerId)) {
             List<Feed> feeds = feedRepository.findFeedsByNoOffsetPagination(owner, lastFeedId, size);
 
-            List<Long> novelIds = feeds.stream()
+            List<Feed> visibleFeeds = feeds.stream()
+                    .filter(feed -> feed.isVisibleTo(visitorId))
+                    .toList();
+
+            List<Long> novelIds = visibleFeeds.stream()
                     .map(Feed::getNovelId)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
@@ -365,7 +369,7 @@ public class FeedService {
                     .stream()
                     .collect(Collectors.toMap(Novel::getNovelId, novel -> novel));
 
-            List<UserFeedGetResponse> userFeedGetResponseList = feeds.stream()
+            List<UserFeedGetResponse> userFeedGetResponseList = visibleFeeds.stream()
                     .map(feed -> UserFeedGetResponse.of(feed, novelMap.get(feed.getNovelId()), visitorId))
                     .toList();
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -202,6 +202,7 @@ public class FeedService {
 
         List<FeedInfo> feedGetResponses = feeds.getContent()
                 .stream()
+                .filter(feed -> feed.isVisibleTo(userIdOrNull))
                 .map(feed -> createFeedInfo(feed, user))
                 .toList();
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -202,7 +202,8 @@ public class FeedService {
 
         List<FeedInfo> feedGetResponses = feeds.getContent()
                 .stream()
-                .map(feed -> createFeedInfo(feed, user)).toList();
+                .map(feed -> createFeedInfo(feed, user))
+                .toList();
 
         return FeedsGetResponse.of(getChosenCategoryOrDefault(category), feeds.hasNext(), feedGetResponses);
     }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -83,7 +83,7 @@ public class FeedService {
     public void createFeed(User user, FeedCreateRequest request) {
         Optional.ofNullable(request.novelId())
                 .ifPresent(novelService::getNovelOrException);
-        Feed feed = Feed.create(request.feedContent(), request.novelId(), request.isSpoiler(), user);
+        Feed feed = Feed.create(request.feedContent(), request.novelId(), request.isSpoiler(), request.isPublic(), user);
         feedRepository.save(feed);
         feedCategoryService.createFeedCategory(feed, request.relevantCategories());
     }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -350,9 +350,9 @@ public class FeedService {
     @Transactional(readOnly = true)
     public UserFeedsGetResponse getUserFeeds(User visitor, Long ownerId, Long lastFeedId, int size) {
         User owner = userService.getUserOrException(ownerId);
-        Long visitorId = visitor == null
-                ? null
-                : visitor.getUserId();
+        Long visitorId = Optional.ofNullable(visitor)
+                .map(User::getUserId)
+                .orElse(null);
 
         if (owner.getIsProfilePublic() || isOwner(visitor, ownerId)) {
             List<Feed> feedsByNoOffsetPagination =

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -355,10 +355,9 @@ public class FeedService {
                 .orElse(null);
 
         if (owner.getIsProfilePublic() || isOwner(visitor, ownerId)) {
-            List<Feed> feedsByNoOffsetPagination =
-                    feedRepository.findFeedsByNoOffsetPagination(owner, lastFeedId, size);
+            List<Feed> feeds = feedRepository.findFeedsByNoOffsetPagination(owner, lastFeedId, size);
 
-            List<Long> novelIds = feedsByNoOffsetPagination.stream()
+            List<Long> novelIds = feeds.stream()
                     .map(Feed::getNovelId)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
@@ -366,12 +365,12 @@ public class FeedService {
                     .stream()
                     .collect(Collectors.toMap(Novel::getNovelId, novel -> novel));
 
-            List<UserFeedGetResponse> userFeedGetResponseList = feedsByNoOffsetPagination.stream()
+            List<UserFeedGetResponse> userFeedGetResponseList = feeds.stream()
                     .map(feed -> UserFeedGetResponse.of(feed, novelMap.get(feed.getNovelId()), visitorId))
                     .toList();
 
             // TODO Slice의 hasNext()로 판단하도록 수정
-            Boolean isLoadable = feedsByNoOffsetPagination.size() == size;
+            Boolean isLoadable = feeds.size() == size;
 
             return UserFeedsGetResponse.of(isLoadable, userFeedGetResponseList);
         }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -83,7 +83,7 @@ public class FeedService {
     public void createFeed(User user, FeedCreateRequest request) {
         Optional.ofNullable(request.novelId())
                 .ifPresent(novelService::getNovelOrException);
-        Feed feed = Feed.create(request.feedContent(), request.novelId(), request.isSpoiler(), request.isPublic(), user);
+        Feed feed = Feed.create(request, user);
         feedRepository.save(feed);
         feedCategoryService.createFeedCategory(feed, request.relevantCategories());
     }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -94,7 +94,7 @@ public class FeedService {
         if (request.novelId() != null && feed.isNovelChanged(request.novelId())) {
             novelService.getNovelOrException(request.novelId());
         }
-        feed.updateFeed(request.feedContent(), request.isSpoiler(), request.novelId());
+        feed.updateFeed(request.feedContent(), request.isSpoiler(), request.isPublic(), request.novelId());
         feedCategoryService.updateFeedCategory(feed, request.relevantCategories());
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -5,7 +5,6 @@ import static java.lang.Boolean.TRUE;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Feed;

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -128,4 +128,8 @@ public class PopularFeedService {
                 .map(PopularFeedGetResponse::of)
                 .toList();
     }
+
+    private static boolean isVisibleToUser(Feed feed, Long currentUserId) {
+        return feed.getIsPublic() || feed.getWriterId().equals(currentUserId);
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -111,7 +111,10 @@ public class PopularFeedService {
         List<PopularFeed> popularFeeds = Optional.ofNullable(user)
                 .map(u -> findPopularFeedsWithUser(u.getUserId()))
                 .orElseGet(this::findPopularFeedsWithoutUser);
-        List<PopularFeedGetResponse> popularFeedGetResponses = mapToPopularFeedGetResponseList(popularFeeds);
+
+        List<PopularFeedGetResponse> popularFeedGetResponses =
+                mapToPopularFeedGetResponseList(popularFeeds, currentUserId);
+
         return new PopularFeedsGetResponse(popularFeedGetResponses);
     }
 
@@ -123,7 +126,8 @@ public class PopularFeedService {
         return popularFeedRepository.findTop9ByOrderByPopularFeedIdDesc();
     }
 
-    private static List<PopularFeedGetResponse> mapToPopularFeedGetResponseList(List<PopularFeed> popularFeeds) {
+    private static List<PopularFeedGetResponse> mapToPopularFeedGetResponseList(List<PopularFeed> popularFeeds,
+                                                                                Long currentUserId) {
         return popularFeeds.stream()
                 .map(PopularFeedGetResponse::of)
                 .toList();

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -104,6 +104,10 @@ public class PopularFeedService {
 
     @Transactional(readOnly = true)
     public PopularFeedsGetResponse getPopularFeeds(User user) {
+        Long currentUserId = Optional.ofNullable(user)
+                .map(User::getUserId)
+                .orElse(null);
+
         List<PopularFeed> popularFeeds = Optional.ofNullable(user)
                 .map(u -> findPopularFeedsWithUser(u.getUserId()))
                 .orElseGet(this::findPopularFeedsWithoutUser);

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -129,7 +129,7 @@ public class PopularFeedService {
     private static List<PopularFeedGetResponse> mapToPopularFeedGetResponseList(List<PopularFeed> popularFeeds,
                                                                                 Long currentUserId) {
         return popularFeeds.stream()
-                .filter(pf -> isVisibleToUser(pf.getFeed(), currentUserId))
+                .filter(pf -> pf.getFeed().isVisibleTo(currentUserId))
                 .map(PopularFeedGetResponse::of)
                 .toList();
     }

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -129,6 +129,7 @@ public class PopularFeedService {
     private static List<PopularFeedGetResponse> mapToPopularFeedGetResponseList(List<PopularFeed> popularFeeds,
                                                                                 Long currentUserId) {
         return popularFeeds.stream()
+                .filter(pf -> isVisibleToUser(pf.getFeed(), currentUserId))
                 .map(PopularFeedGetResponse::of)
                 .toList();
     }

--- a/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/PopularFeedService.java
@@ -133,8 +133,4 @@ public class PopularFeedService {
                 .map(PopularFeedGetResponse::of)
                 .toList();
     }
-
-    private static boolean isVisibleToUser(Feed feed, Long currentUserId) {
-        return feed.getIsPublic() || feed.getWriterId().equals(currentUserId);
-    }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#330 -> dev
- close #330

## Key Changes
<!-- 최대한 자세히 -->
- isPublic이 필요한 response에서 쓰이는 DTO에 필드가 추가되었습니다.
  - isPublic을 reference type으로 받은 이유: primitive type인 경우, client-side에서 null로 준 경우 validation을 할 수 없는 문제가 있습니다.
- 기중님이 이전 PR에서 중점적으로 리뷰주셨던 것처럼, 도메인 메서드를 사용하려고 해보았습니다.
- Java 17을 쓰는 만큼 Optional을 통한 함수형 프로그래밍을 하려고 노력했습니다. (삼항연산자를 좀 걷어냈습니다)

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 페이지네이션을 위해 DB에서 size만큼 레코드를 조회해오고, 그것들을 가지고 공개여부를 판단하다 보니 size만큼 응답으로 내려가지 않을 수 있는 문제가 있습니다. 어떻게 처리하는 것이 좋을까요?
- isPublic을 reference type으로 받은 이유: primitive type인 경우, client-side에서 null로 준 경우 validation을 할 수 없는 문제가 있습니다.
