### PR TITLE
[FIX] 피드 비공개 기능 - 누락된 기능 추가 반영 및 리뷰 반영

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -20,7 +20,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
-import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 
 @Getter
 @DynamicInsert
@@ -87,11 +86,11 @@ public class Feed {
         return new Feed(feedContent, novelId, isSpoiler, isPublic, user);
     }
 
-    public void updateFeed(FeedUpdateRequest request) {
-        this.feedContent = request.feedContent();
-        this.isSpoiler = request.isSpoiler();
-        this.isPublic = request.isPublic();
-        this.novelId = request.novelId();
+    public void updateFeed(String feedContent, Boolean isSpoiler, Boolean isPublic, Long novelId) {
+        this.feedContent = feedContent;
+        this.isSpoiler = isSpoiler;
+        this.isPublic = isPublic;
+        this.novelId = novelId;
         this.modifiedDate = LocalDateTime.now();
     }
 

--- a/src/main/java/org/websoso/WSSServer/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Feed.java
@@ -20,7 +20,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
-import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 
 @Getter
@@ -74,18 +73,18 @@ public class Feed {
     @OneToOne(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private PopularFeed popularFeed;
 
-    private Feed(FeedCreateRequest request, User user) {
-        this.feedContent = request.feedContent();
-        this.novelId = request.novelId();
-        this.isSpoiler = request.isSpoiler();
-        this.isPublic = request.isPublic();
+    private Feed(String feedContent, Long novelId, Boolean isSpoiler, Boolean isPublic, User user) {
+        this.feedContent = feedContent;
+        this.novelId = novelId;
+        this.isSpoiler = isSpoiler;
+        this.isPublic = isPublic;
         this.user = user;
         this.createdDate = LocalDateTime.now();
         this.modifiedDate = this.createdDate;
     }
 
-    public static Feed create(FeedCreateRequest request, User user) {
-        return new Feed(request, user);
+    public static Feed create(String feedContent, Long novelId, Boolean isSpoiler, Boolean isPublic, User user) {
+        return new Feed(feedContent, novelId, isSpoiler, isPublic, user);
     }
 
     public void updateFeed(FeedUpdateRequest request) {

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -71,5 +71,4 @@ public record FeedGetResponse(
         }
         return Math.round((novelRatingSum / (float) novelRatingCount) * 10) / 10.0f;
     }
-
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -24,8 +24,8 @@ public record FeedGetResponse(
         List<String> relevantCategories,
         Boolean isSpoiler,
         Boolean isModified,
-        Boolean isMyFeed
-
+        Boolean isMyFeed,
+        Boolean isPublic
 ) {
     public static FeedGetResponse of(Feed feed, UserBasicInfo userBasicInfo, Novel novel, Boolean isLiked,
                                      List<String> relevantCategories, Boolean isMyFeed) {
@@ -60,7 +60,8 @@ public record FeedGetResponse(
                 relevantCategories,
                 feed.getIsSpoiler(),
                 !feed.getCreatedDate().equals(feed.getModifiedDate()),
-                isMyFeed
+                isMyFeed,
+                feed.getIsPublic()
         );
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -83,7 +83,12 @@ public class FeedService {
     public void createFeed(User user, FeedCreateRequest request) {
         Optional.ofNullable(request.novelId())
                 .ifPresent(novelService::getNovelOrException);
-        Feed feed = Feed.create(request, user);
+        Feed feed = Feed.create(
+                request.feedContent(),
+                request.novelId(),
+                request.isSpoiler(),
+                request.isPublic(),
+                user);
         feedRepository.save(feed);
         feedCategoryService.createFeedCategory(feed, request.relevantCategories());
     }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -99,7 +99,11 @@ public class FeedService {
         if (request.novelId() != null && feed.isNovelChanged(request.novelId())) {
             novelService.getNovelOrException(request.novelId());
         }
-        feed.updateFeed(request);
+        feed.updateFeed(
+                request.feedContent(),
+                request.isSpoiler(),
+                request.isPublic(),
+                request.novelId());
         feedCategoryService.updateFeedCategory(feed, request.relevantCategories());
     }
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#338 -> dev
- close #338

## Key Changes
<!-- 최대한 자세히 -->
- 피드 단건 조회 api 누락된 isPublic 프로퍼티 추가
- 이전 PR 리뷰 일부 반영

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 추후 반영 예정
  1. 무한 스크롤 size 만큼 응답 안내려주는 거 -> size 만큼 내려주도록 수정
  2. 비로그인 사용자 null인지 분기하는거 -> 컨트롤러단에서 체크하고 다른 서비스 메서드 호출하기
