### PR TITLE
[FIX] 댓글 관련 인증/인가 버그 픽스

### DIFF
--- a/src/main/java/org/websoso/WSSServer/auth/validator/CommentAuthorizationValidator.java
+++ b/src/main/java/org/websoso/WSSServer/auth/validator/CommentAuthorizationValidator.java
@@ -1,0 +1,44 @@
+package org.websoso.WSSServer.auth.validator;
+
+import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_NOT_FOUND;
+import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_AUTHORIZED;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.websoso.WSSServer.domain.Comment;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.exception.exception.CustomCommentException;
+import org.websoso.WSSServer.exception.exception.CustomUserException;
+import org.websoso.WSSServer.repository.CommentRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CommentAuthorizationValidator implements ResourceAuthorizationValidator {
+
+    private final CommentRepository commentRepository;
+
+    @Override
+    public boolean hasPermission(Long commentId, User user) {
+        Comment comment = getCommentOrException(commentId);
+
+        if (!comment.isMine(user.getUserId())) {
+            throw new CustomUserException(INVALID_AUTHORIZED,
+                    "User with ID " + user.getUserId() + " is not the owner of comment " + comment.getCommentId());
+        }
+        return true;
+    }
+
+    private Comment getCommentOrException(Long commentId) {
+        log.info("### commentId: " + commentId);
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomCommentException(COMMENT_NOT_FOUND,
+                        "comment with the given id was not found"));
+    }
+
+    @Override
+    public Class<?> getResourceType() {
+        return Comment.class;
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -147,7 +147,8 @@ public class FeedController {
     }
 
     @PutMapping("/{feedId}/comments/{commentId}")
-    @PreAuthorize("isAuthenticated() and @authorizationService.validate(#feedId, #user, T(org.websoso.WSSServer.domain.Feed))")
+    @PreAuthorize("isAuthenticated() and @feedAccessValidator.canAccess(#feedId, #user) "
+            + "and @authorizationService.validate(#commentId, #user, T(org.websoso.WSSServer.domain.Comment))")
     public ResponseEntity<Void> updateComment(@AuthenticationPrincipal User user,
                                               @PathVariable("feedId") Long feedId,
                                               @PathVariable("commentId") Long commentId,
@@ -159,7 +160,8 @@ public class FeedController {
     }
 
     @DeleteMapping("/{feedId}/comments/{commentId}")
-    @PreAuthorize("isAuthenticated() and @authorizationService.validate(#feedId, #user, T(org.websoso.WSSServer.domain.Feed))")
+    @PreAuthorize("isAuthenticated() and @feedAccessValidator.canAccess(#feedId, #user) "
+            + "and @authorizationService.validate(#feedId, #user, T(org.websoso.WSSServer.domain.Comment))")
     public ResponseEntity<Void> deleteComment(@AuthenticationPrincipal User user,
                                               @PathVariable("feedId") Long feedId,
                                               @PathVariable("commentId") Long commentId) {

--- a/src/main/java/org/websoso/WSSServer/domain/Comment.java
+++ b/src/main/java/org/websoso/WSSServer/domain/Comment.java
@@ -92,4 +92,8 @@ public class Comment {
     public void spoiler() {
         this.isSpoiler = true;
     }
+
+    public boolean isMine(Long userId) {
+        return this.getUserId().equals(userId);
+    }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#348 -> dev
- close #348

## Key Changes
<!-- 최대한 자세히 -->
댓글 수정 삭제 시 잘못 적용되고 있던 인가 및 리소스 검증 수정

- AS-IS: FeedAuthorizationValidator
- TO-BE: FeedAccessValidator, CommentAuthorizationValidator
