### PR TITLE
[FIX] 댓글 삭제 인가 및 리소스 검증 버그 픽스

### DIFF
--- a/src/main/java/org/websoso/WSSServer/auth/validator/CommentAuthorizationValidator.java
+++ b/src/main/java/org/websoso/WSSServer/auth/validator/CommentAuthorizationValidator.java
@@ -4,7 +4,6 @@ import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_N
 import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_AUTHORIZED;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.websoso.WSSServer.domain.Comment;
 import org.websoso.WSSServer.domain.User;
@@ -12,7 +11,6 @@ import org.websoso.WSSServer.exception.exception.CustomCommentException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
 import org.websoso.WSSServer.repository.CommentRepository;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CommentAuthorizationValidator implements ResourceAuthorizationValidator {
@@ -31,7 +29,6 @@ public class CommentAuthorizationValidator implements ResourceAuthorizationValid
     }
 
     private Comment getCommentOrException(Long commentId) {
-        log.info("### commentId: " + commentId);
         return commentRepository.findById(commentId)
                 .orElseThrow(() -> new CustomCommentException(COMMENT_NOT_FOUND,
                         "comment with the given id was not found"));

--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -161,7 +161,7 @@ public class FeedController {
 
     @DeleteMapping("/{feedId}/comments/{commentId}")
     @PreAuthorize("isAuthenticated() and @feedAccessValidator.canAccess(#feedId, #user) "
-            + "and @authorizationService.validate(#feedId, #user, T(org.websoso.WSSServer.domain.Comment))")
+            + "and @authorizationService.validate(#commentId, #user, T(org.websoso.WSSServer.domain.Comment))")
     public ResponseEntity<Void> deleteComment(@AuthenticationPrincipal User user,
                                               @PathVariable("feedId") Long feedId,
                                               @PathVariable("commentId") Long commentId) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#350 -> dev
- close #350

## Key Changes
<!-- 최대한 자세히 -->
댓글 삭제 시 CommentAuthorizationValidator로 commentId가 아닌 feedId를 넘겨서 삭제 시 발생했던 문제 해결
