### PR TITLE
[FEAT] 서재 기능 업데이트 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -147,14 +148,19 @@ public class UserController {
     @GetMapping("/{userId}/novels")
     public ResponseEntity<UserNovelAndNovelsGetResponse> getUserNovelsAndNovels(@AuthenticationPrincipal User visitor,
                                                                                 @PathVariable("userId") Long userId,
-                                                                                @RequestParam("readStatus") String readStatus,
+                                                                                @RequestParam(value = "isInterest", required = false) Boolean isInterest,
+                                                                                @RequestParam(value = "readStatuses", required = false) List<String> readStatuses,
+                                                                                @RequestParam(value = "attractivePoints", required = false) List<String> attractivePoints,
+                                                                                @RequestParam(value = "novelRating", required = false) Float novelRating,
+                                                                                @RequestParam(value = "query", required = false) String query,
                                                                                 @RequestParam("lastUserNovelId") Long lastUserNovelId,
                                                                                 @RequestParam("size") int size,
                                                                                 @RequestParam("sortType") String sortType) {
         return ResponseEntity
                 .status(OK)
                 .body(userNovelService.getUserNovelsAndNovels(
-                        visitor, userId, readStatus, lastUserNovelId, size, sortType));
+                        visitor, userId, isInterest, readStatuses, attractivePoints, novelRating, query,
+                        lastUserNovelId, size, sortType));
     }
 
     @GetMapping("/{userId}/feeds")

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelAndNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelAndNovelGetResponse.java
@@ -1,24 +1,20 @@
 package org.websoso.WSSServer.dto.userNovel;
 
-import org.websoso.WSSServer.domain.UserNovel;
+import java.util.List;
 
 public record UserNovelAndNovelGetResponse(
         Long userNovelId,
         Long novelId,
-        String author,
-        String novelImage,
         String title,
-        Float novelRating
+        String novelImage,
+        Float novelRating,
+        String readStatus,
+        Boolean isInterest,
+        Float userNovelRating,
+        List<String> attractivePoints,
+        String startDate,
+        String endDate,
+        List<String> keywords,
+        List<String> myFeeds
 ) {
-
-    public static UserNovelAndNovelGetResponse of(UserNovel userNovel) {
-        return new UserNovelAndNovelGetResponse(
-                userNovel.getUserNovelId(),
-                userNovel.getNovel().getNovelId(),
-                userNovel.getNovel().getAuthor(),
-                userNovel.getNovel().getNovelImage(),
-                userNovel.getNovel().getTitle(),
-                userNovel.getUserNovelRating()
-        );
-    }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelAndNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelAndNovelGetResponse.java
@@ -1,6 +1,12 @@
 package org.websoso.WSSServer.dto.userNovel;
 
 import java.util.List;
+import org.websoso.WSSServer.domain.AttractivePoint;
+import org.websoso.WSSServer.domain.Keyword;
+import org.websoso.WSSServer.domain.Novel;
+import org.websoso.WSSServer.domain.UserNovel;
+import org.websoso.WSSServer.domain.UserNovelAttractivePoint;
+import org.websoso.WSSServer.domain.UserNovelKeyword;
 
 public record UserNovelAndNovelGetResponse(
         Long userNovelId,
@@ -17,4 +23,33 @@ public record UserNovelAndNovelGetResponse(
         List<String> keywords,
         List<String> myFeeds
 ) {
+    public static UserNovelAndNovelGetResponse from(UserNovel userNovel, Float novelRatingAvg, List<String> feeds) {
+        Novel novel = userNovel.getNovel();
+
+        List<String> attractivePoints = userNovel.getUserNovelAttractivePoints().stream()
+                .map(UserNovelAttractivePoint::getAttractivePoint)
+                .map(AttractivePoint::getAttractivePointName)
+                .toList();
+
+        List<String> keywords = userNovel.getUserNovelKeywords().stream()
+                .map(UserNovelKeyword::getKeyword)
+                .map(Keyword::getKeywordName)
+                .toList();
+
+        return new UserNovelAndNovelGetResponse(
+                userNovel.getUserNovelId(),
+                novel.getNovelId(),
+                novel.getTitle(),
+                novel.getNovelImage(),
+                novelRatingAvg,
+                userNovel.getStatus() != null ? userNovel.getStatus().name() : null,
+                userNovel.getIsInterest(),
+                userNovel.getUserNovelRating(),
+                attractivePoints,
+                userNovel.getStartDate() != null ? userNovel.getStartDate().toString() : null,
+                userNovel.getEndDate() != null ? userNovel.getEndDate().toString() : null,
+                keywords,
+                feeds
+        );
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelAndNovelsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelAndNovelsGetResponse.java
@@ -4,14 +4,12 @@ import java.util.List;
 
 public record UserNovelAndNovelsGetResponse(
         Long userNovelCount,
-        Float userNovelRating,
         Boolean isLoadable,
         List<UserNovelAndNovelGetResponse> userNovels
 ) {
 
-    public static UserNovelAndNovelsGetResponse of(Long userNovelCount, Float userNovelRating, Boolean isLoadable,
+    public static UserNovelAndNovelsGetResponse of(Long userNovelCount, Boolean isLoadable,
                                                    List<UserNovelAndNovelGetResponse> userNovelAndNovelGetResponses) {
-        return new UserNovelAndNovelsGetResponse(userNovelCount, userNovelRating, isLoadable,
-                userNovelAndNovelGetResponses);
+        return new UserNovelAndNovelsGetResponse(userNovelCount, isLoadable, userNovelAndNovelGetResponses);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
@@ -39,7 +39,8 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedCustomRep
     @Query("UPDATE Feed f SET f.user.userId = -1 WHERE f.user.userId = :userId")
     void updateUserToUnknown(Long userId);
 
-    List<Feed> findByUserUserIdAndNovelIdAndIsHiddenFalse(Long userId, Long novelId);
+    List<Feed> findByUserUserIdAndIsHiddenFalseAndNovelIdIn(Long userId, List<Long> novelIds);
 
-    List<Feed> findByUserUserIdAndNovelIdAndIsHiddenFalseAndIsPublicTrueAndIsSpoilerFalse(Long userId, Long novelId);
+    List<Feed> findByUserUserIdAndIsHiddenFalseAndNovelIdInAndIsPublicTrueAndIsSpoilerFalse(Long userId,
+                                                                                            List<Long> novelIds);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedRepository.java
@@ -38,4 +38,8 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedCustomRep
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Feed f SET f.user.userId = -1 WHERE f.user.userId = :userId")
     void updateUserToUnknown(Long userId);
+
+    List<Feed> findByUserUserIdAndNovelIdAndIsHiddenFalse(Long userId, Long novelId);
+
+    List<Feed> findByUserUserIdAndNovelIdAndIsHiddenFalseAndIsPublicTrueAndIsSpoilerFalse(Long userId, Long novelId);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepository.java
@@ -20,4 +20,11 @@ public interface UserNovelCustomRepository {
     List<UserNovel> findByUserAndReadStatus(User owner, String readStatus);
 
     List<Novel> findTasteNovels(List<Genre> preferGenres);
+
+    List<UserNovel> findFilteredUserNovels(Long userId, Boolean isInterest, List<String> readStatuses,
+                                           List<String> attractivePoints, Float novelRating, String query,
+                                           Long lastNovelId, int size, boolean isAscending);
+
+    Long countByUserIdAndFilters(Long userId, Boolean isInterest, List<String> readStatuses,
+                                 List<String> attractivePoints, Float novelRating, String query);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepository.java
@@ -4,7 +4,6 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.websoso.WSSServer.domain.Genre;
 import org.websoso.WSSServer.domain.Novel;
-import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
 
@@ -13,11 +12,6 @@ public interface UserNovelCustomRepository {
     UserNovelCountGetResponse findUserNovelStatistics(Long userId);
 
     List<Long> findTodayPopularNovelsId(Pageable pageable);
-
-    List<UserNovel> findUserNovelsByNoOffsetPagination(User owner, Long lastUserNovelId, int size,
-                                                       String readStatus, String sortType);
-
-    List<UserNovel> findByUserAndReadStatus(User owner, String readStatus);
 
     List<Novel> findTasteNovels(List<Genre> preferGenres);
 

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
@@ -7,9 +7,7 @@ import static org.websoso.WSSServer.domain.common.ReadStatus.QUIT;
 import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHED;
 import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHING;
 
-import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
@@ -19,7 +17,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Genre;
 import org.websoso.WSSServer.domain.Novel;
-import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.domain.common.ReadStatus;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
@@ -62,66 +59,6 @@ public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository 
                 .from(userNovel)
                 .where(userNovel.user.userId.eq(userId))
                 .fetchOne();
-    }
-
-    @Override
-    public List<UserNovel> findUserNovelsByNoOffsetPagination(User owner, Long lastUserNovelId, int size,
-                                                              String readStatus, String sortType) {
-        return jpaQueryFactory
-                .selectFrom(userNovel)
-                .where(
-                        userNovel.user.eq(owner),
-                        generateReadStatusCondition(readStatus),
-                        compareFeedId(lastUserNovelId, sortType)
-                )
-                .orderBy(getSortOrder(sortType))
-                .limit(size)
-                .fetch();
-    }
-
-    private BooleanExpression compareFeedId(Long lastUserNovelId, String sortType) {
-        if (lastUserNovelId == 0) {
-            return null;
-        }
-
-        // TODO 잘못된 sortType이 오는 경우 default null로 return이 아닌 예외 처리
-        if ("NEWEST".equalsIgnoreCase(sortType)) {
-            return userNovel.userNovelId.lt(lastUserNovelId);
-        } else if ("OLDEST".equalsIgnoreCase(sortType)) {
-            return userNovel.userNovelId.gt(lastUserNovelId);
-        }
-
-        return null;
-    }
-
-    private BooleanExpression generateReadStatusCondition(String readStatus) {
-        // TODO 잘못된 readStatus가 오는 경우 예외 처리
-        if (readStatus.equals("INTEREST")) {
-            return userNovel.isInterest.isTrue();
-        } else {
-            ReadStatus status = ReadStatus.valueOf(readStatus);
-            return userNovel.status.eq(status);
-        }
-    }
-
-    private OrderSpecifier<?> getSortOrder(String sortType) {
-        // TODO 잘못된 sortType이 오는 경우 default desc가 아닌 예외 처리
-        if ("NEWEST".equalsIgnoreCase(sortType)) {
-            return userNovel.userNovelId.desc();
-        } else if ("OLDEST".equalsIgnoreCase(sortType)) {
-            return userNovel.userNovelId.asc();
-        }
-        return userNovel.userNovelId.desc();
-    }
-
-    @Override
-    public List<UserNovel> findByUserAndReadStatus(User owner, String readStatus) {
-        return jpaQueryFactory
-                .selectFrom(userNovel)
-                .where(userNovel.user.eq(owner),
-                        generateReadStatusCondition(readStatus)
-                )
-                .fetch();
     }
 
     public List<Long> findTodayPopularNovelsId(Pageable pageable) {

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
@@ -1,11 +1,9 @@
 package org.websoso.WSSServer.repository;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
@@ -31,10 +29,4 @@ public interface UserNovelRepository extends JpaRepository<UserNovel, Long>, Use
     List<UserNovel> findUserNovelByUser(User user);
 
     Optional<UserNovel> findByNovel_NovelIdAndUser(Long novelId, User user);
-
-    @Query("SELECT new map(un.novel.novelId as novelId, AVG(un.userNovelRating) as avgRating) " +
-            "FROM UserNovel un " +
-            "WHERE un.userNovelRating > 0 AND un.novel.novelId IN :novelIds " +
-            "GROUP BY un.novel.novelId")
-    Map<Long, Float> findAverageRatingsForNovels(@Param("novelIds") List<Long> novelIds);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelRepository.java
@@ -1,9 +1,11 @@
 package org.websoso.WSSServer.repository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.User;
@@ -29,4 +31,10 @@ public interface UserNovelRepository extends JpaRepository<UserNovel, Long>, Use
     List<UserNovel> findUserNovelByUser(User user);
 
     Optional<UserNovel> findByNovel_NovelIdAndUser(Long novelId, User user);
+
+    @Query("SELECT new map(un.novel.novelId as novelId, AVG(un.userNovelRating) as avgRating) " +
+            "FROM UserNovel un " +
+            "WHERE un.userNovelRating > 0 AND un.novel.novelId IN :novelIds " +
+            "GROUP BY un.novel.novelId")
+    Map<Long, Float> findAverageRatingsForNovels(@Param("novelIds") List<Long> novelIds);
 }

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -278,7 +278,8 @@ public class UserNovelService {
         return userNovels.stream()
                 .map(userNovel -> {
                     Long novelId = userNovel.getNovel().getNovelId();
-                    Float novelRating = novelRatingMap.getOrDefault(novelId, 0.0f);
+                    Float novelRatingRaw = novelRatingMap.getOrDefault(novelId, 0.0f);
+                    Float novelRating = roundToFirstDecimal(novelRatingRaw);
                     List<String> feeds = feedMap.getOrDefault(novelId, List.of());
                     return UserNovelAndNovelGetResponse.from(userNovel, novelRating, feeds);
                 })
@@ -299,6 +300,10 @@ public class UserNovelService {
         return feeds.stream()
                 .collect(Collectors.groupingBy(Feed::getNovelId,
                         Collectors.mapping(Feed::getFeedContent, Collectors.toList())));
+    }
+
+    private float roundToFirstDecimal(float value) {
+        return Math.round(value * 10.0f) / 10.0f;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -276,8 +276,8 @@ public class UserNovelService {
                             userNovel.getNovel(), 0.0f);
                     Float novelRatingAvg = novelRatingCount == 0
                             ? 0.0f
-                            : Math.round(userNovelRepository.sumUserNovelRatingByNovel(userNovel.getNovel())
-                                    / novelRatingCount * 10.0f) / 10.0f;
+                            : roundToFirstDecimal(userNovelRepository.sumUserNovelRatingByNovel(userNovel.getNovel())
+                                    / novelRatingCount);
                     List<String> feeds = feedMap.getOrDefault(novelId, List.of());
                     return UserNovelAndNovelGetResponse.from(userNovel, novelRatingAvg, feeds);
                 })


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#352 -> dev
- close #352 

## Key Changes
<!-- 최대한 자세히 -->
**서재소소**(2차 사일로) 관련 기능입니다.
서재(유저 보관함)가 업데이트 되어 기능을 다시 구현하였습니다.
- 서재 내에서 필터링 및 검색 기능이 추가되었습니다.
- 작품 별로 유저가 작성한 피드도 함께 내려줘야 하는데, 이때 아래와 같은 조건이 있습니다.
  - **자기 자신의 서재 조회인 경우)** `isHidden`을 제외한 모든 피드 응답
  - **타인의 서재인 경우)** `isPublic`이 true이고, `isSpoiler`가 false여야 하는 추가사항
- 또한 성능 최적화를 위해 피드는 한번의 쿼리로 일괄 조회하여 사용하도록 하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 클라에서 작업하기 위해 빨리 넘겨주려고 해서 검색(query) 관련 로직은 아직 구현하지 않았습니다! 검색은 추후 pr에서 확인 부탁드립니다아~

## References
<!-- 참고한 자료-->
- [기능명세서](https://www.notion.so/kimmjabc/1f39e64a453281ad8c45ce4f48aa06e0?v=1f39e64a45328139a8d5000cabb3ff40&pvs=4)
- [API 명세서](https://www.notion.so/kimmjabc/API-1f79e64a453280ba938ee2d784aacfc7?pvs=4)