### PR TITLE
[FEAT] 서재 변경 조회 기능 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -156,12 +157,13 @@ public class UserController {
                                                                                 @RequestParam(value = "query", required = false) String query,
                                                                                 @RequestParam("lastUserNovelId") Long lastUserNovelId,
                                                                                 @RequestParam("size") int size,
-                                                                                @RequestParam("sortType") String sortType) {
+                                                                                @RequestParam("sortType") String sortType,
+                                                                                @RequestParam(value = "updatedSince", required = false) LocalDateTime updatedSince) {
         return ResponseEntity
                 .status(OK)
                 .body(userNovelService.getUserNovelsAndNovels(
                         visitor, userId, isInterest, readStatuses, attractivePoints, novelRating, query,
-                        lastUserNovelId, size, sortType));
+                        lastUserNovelId, size, sortType, updatedSince));
     }
 
     @GetMapping("/{userId}/feeds")

--- a/src/main/java/org/websoso/WSSServer/domain/UserNovelAttractivePoint.java
+++ b/src/main/java/org/websoso/WSSServer/domain/UserNovelAttractivePoint.java
@@ -4,6 +4,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -12,10 +13,12 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.websoso.WSSServer.domain.common.ParentTouchListener;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(ParentTouchListener.class)
 public class UserNovelAttractivePoint {
 
     @Id

--- a/src/main/java/org/websoso/WSSServer/domain/UserNovelKeyword.java
+++ b/src/main/java/org/websoso/WSSServer/domain/UserNovelKeyword.java
@@ -4,6 +4,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -12,10 +13,12 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.websoso.WSSServer.domain.common.ParentTouchListener;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(ParentTouchListener.class)
 public class UserNovelKeyword {
 
     @Id

--- a/src/main/java/org/websoso/WSSServer/domain/common/BaseEntity.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/BaseEntity.java
@@ -35,4 +35,7 @@ public abstract class BaseEntity {
         this.modifiedDate = LocalDateTime.now();
     }
 
+    public void touch() {
+        this.modifiedDate = LocalDateTime.now();
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/domain/common/ParentTouchListener.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/ParentTouchListener.java
@@ -1,0 +1,20 @@
+package org.websoso.WSSServer.domain.common;
+
+import jakarta.persistence.PostPersist;
+import jakarta.persistence.PostRemove;
+import jakarta.persistence.PostUpdate;
+import org.websoso.WSSServer.domain.UserNovelAttractivePoint;
+import org.websoso.WSSServer.domain.UserNovelKeyword;
+
+public class ParentTouchListener {
+    @PostPersist
+    @PostRemove
+    @PostUpdate
+    public void touchParent(Object child) {
+        if (child instanceof UserNovelKeyword uk) {
+            uk.getUserNovel().touch();
+        } else if (child instanceof UserNovelAttractivePoint ap) {
+            ap.getUserNovel().touch();
+        }
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepository.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.websoso.WSSServer.domain.Genre;
@@ -17,8 +18,9 @@ public interface UserNovelCustomRepository {
 
     List<UserNovel> findFilteredUserNovels(Long userId, Boolean isInterest, List<String> readStatuses,
                                            List<String> attractivePoints, Float novelRating, String query,
-                                           Long lastNovelId, int size, boolean isAscending);
+                                           Long lastNovelId, int size, boolean isAscending, LocalDateTime updatedSince);
 
     Long countByUserIdAndFilters(Long userId, Boolean isInterest, List<String> readStatuses,
-                                 List<String> attractivePoints, Float novelRating, String query);
+                                 List<String> attractivePoints, Float novelRating, String query,
+                                 LocalDateTime updatedSince);
 }

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -18,7 +18,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,7 +57,6 @@ import org.websoso.WSSServer.repository.UserNovelRepository;
 @Service
 @RequiredArgsConstructor
 @Transactional
-@Slf4j
 public class UserNovelService {
 
     private final NovelRepository novelRepository;

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -9,6 +9,7 @@ import static org.websoso.WSSServer.exception.error.CustomUserNovelError.USER_NO
 import static org.websoso.WSSServer.exception.error.CustomUserNovelError.USER_NOVEL_NOT_FOUND;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -17,6 +18,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,6 +58,7 @@ import org.websoso.WSSServer.repository.UserNovelRepository;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class UserNovelService {
 
     private final NovelRepository novelRepository;
@@ -123,50 +126,83 @@ public class UserNovelService {
     }
 
     private void updateAssociations(UserNovel userNovel, UserNovelUpdateRequest request) {
-        Set<AttractivePoint> previousAttractivePoints = getPreviousAttractivePoints(userNovel);
-        Set<Keyword> previousKeywords = getPreviousKeywords(userNovel);
-
-        manageAttractivePoints(userNovel, request.attractivePoints(), previousAttractivePoints);
-        manageKeywords(userNovel, request.keywordIds(), previousKeywords);
-
-        userNovelAttractivePointRepository.deleteByAttractivePointsAndUserNovel(previousAttractivePoints, userNovel);
-        userNovelKeywordRepository.deleteByKeywordsAndUserNovel(previousKeywords, userNovel);
+        updateAttractivePoints(userNovel, request.attractivePoints());
+        updateKeywords(userNovel, request.keywordIds());
     }
 
-    private Set<AttractivePoint> getPreviousAttractivePoints(UserNovel userNovel) {
-        return userNovel.getUserNovelAttractivePoints()
+    private void updateAttractivePoints(UserNovel userNovel, List<String> attractivePoints) {
+        Map<AttractivePoint, UserNovelAttractivePoint> currentPointMap = userNovel.getUserNovelAttractivePoints()
                 .stream()
-                .map(UserNovelAttractivePoint::getAttractivePoint)
+                .collect(Collectors.toMap(UserNovelAttractivePoint::getAttractivePoint, it -> it));
+
+        Set<AttractivePoint> requestedPoints = attractivePoints.stream()
+                .map(attractivePointService::getAttractivePointByString)
                 .collect(Collectors.toSet());
+
+        addUserNovelAttractivePoints(userNovel, currentPointMap, requestedPoints);
+        deleteUserNovelAttractivePoints(userNovel, currentPointMap, requestedPoints);
     }
 
-    private Set<Keyword> getPreviousKeywords(UserNovel userNovel) {
-        return userNovel.getUserNovelKeywords()
-                .stream()
-                .map(UserNovelKeyword::getKeyword)
-                .collect(Collectors.toSet());
-    }
-
-    private void manageAttractivePoints(UserNovel userNovel, List<String> attractivePoints,
-                                        Set<AttractivePoint> previousAttractivePoints) {
-        for (String stringAttractivePoint : attractivePoints) {
-            AttractivePoint attractivePoint = attractivePointService.getAttractivePointByString(stringAttractivePoint);
-            if (previousAttractivePoints.contains(attractivePoint)) {
-                previousAttractivePoints.remove(attractivePoint);
-            } else {
-                userNovelAttractivePointRepository.save(UserNovelAttractivePoint.create(userNovel, attractivePoint));
+    private void addUserNovelAttractivePoints(UserNovel userNovel,
+                                              Map<AttractivePoint, UserNovelAttractivePoint> currentPointMap,
+                                              Set<AttractivePoint> requestedPoints) {
+        for (AttractivePoint requested : requestedPoints) {
+            if (!currentPointMap.containsKey(requested)) {
+                userNovelAttractivePointRepository.save(UserNovelAttractivePoint.create(userNovel, requested));
             }
         }
     }
 
-    private void manageKeywords(UserNovel userNovel, List<Integer> keywordIds, Set<Keyword> previousKeywords) {
-        for (Integer keywordId : keywordIds) {
-            Keyword keyword = keywordService.getKeywordOrException(keywordId);
-            if (previousKeywords.contains(keyword)) {
-                previousKeywords.remove(keyword);
-            } else {
-                userNovelKeywordRepository.save(UserNovelKeyword.create(userNovel, keyword));
+    private void deleteUserNovelAttractivePoints(UserNovel userNovel,
+                                                 Map<AttractivePoint, UserNovelAttractivePoint> currentPointMap,
+                                                 Set<AttractivePoint> requestedPoints) {
+        List<UserNovelAttractivePoint> toDelete = new ArrayList<>();
+        for (Map.Entry<AttractivePoint, UserNovelAttractivePoint> entry : currentPointMap.entrySet()) {
+            if (!requestedPoints.contains(entry.getKey())) {
+                toDelete.add(entry.getValue());
             }
+        }
+        if (!toDelete.isEmpty()) {
+            userNovel.getUserNovelAttractivePoints().removeAll(toDelete);
+            userNovel.touch();
+        }
+    }
+
+    private void updateKeywords(UserNovel userNovel, List<Integer> keywordIds) {
+        Map<Keyword, UserNovelKeyword> currentKeywordMap = userNovel.getUserNovelKeywords()
+                .stream()
+                .collect(Collectors.toMap(UserNovelKeyword::getKeyword, it -> it));
+
+        Set<Keyword> requestedKeywords = keywordIds.stream()
+                .map(keywordService::getKeywordOrException)
+                .collect(Collectors.toSet());
+
+        addUserNovelKeywords(userNovel, currentKeywordMap, requestedKeywords);
+        deleteUserNovelKeywords(userNovel, currentKeywordMap, requestedKeywords);
+    }
+
+    private void addUserNovelKeywords(UserNovel userNovel,
+                                      Map<Keyword, UserNovelKeyword> currentKeywordMap,
+                                      Set<Keyword> requestedKeywords) {
+        for (Keyword requested : requestedKeywords) {
+            if (!currentKeywordMap.containsKey(requested)) {
+                userNovelKeywordRepository.save(UserNovelKeyword.create(userNovel, requested));
+            }
+        }
+    }
+
+    private void deleteUserNovelKeywords(UserNovel userNovel,
+                                         Map<Keyword, UserNovelKeyword> currentKeywordMap,
+                                         Set<Keyword> requestedKeywords) {
+        List<UserNovelKeyword> toDelete = new ArrayList<>();
+        for (Map.Entry<Keyword, UserNovelKeyword> entry : currentKeywordMap.entrySet()) {
+            if (!requestedKeywords.contains(entry.getKey())) {
+                toDelete.add(entry.getValue());
+            }
+        }
+        if (!toDelete.isEmpty()) {
+            userNovel.getUserNovelKeywords().removeAll(toDelete);
+            userNovel.touch();
         }
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -8,6 +8,7 @@ import static org.websoso.WSSServer.exception.error.CustomUserNovelError.NOT_EVA
 import static org.websoso.WSSServer.exception.error.CustomUserNovelError.USER_NOVEL_ALREADY_EXISTS;
 import static org.websoso.WSSServer.exception.error.CustomUserNovelError.USER_NOVEL_NOT_FOUND;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -242,7 +243,7 @@ public class UserNovelService {
                                                                 List<String> readStatuses,
                                                                 List<String> attractivePoints, Float novelRating,
                                                                 String query, Long lastUserNovelId, int size,
-                                                                String sortType) {
+                                                                String sortType, LocalDateTime updatedSince) {
         User owner = userService.getUserOrException(ownerId);
 
         if (isProfileInaccessible(visitor, ownerId, owner)) {
@@ -253,10 +254,10 @@ public class UserNovelService {
         boolean isAscending = sortType.equalsIgnoreCase(SORT_TYPE_OLDEST);
 
         List<UserNovel> userNovels = userNovelRepository.findFilteredUserNovels(ownerId, isInterest, readStatuses,
-                attractivePoints, novelRating, query, lastUserNovelId, size, isAscending);
+                attractivePoints, novelRating, query, lastUserNovelId, size, isAscending, updatedSince);
 
         Long totalCount = userNovelRepository.countByUserIdAndFilters(ownerId, isInterest, readStatuses,
-                attractivePoints, novelRating, query);
+                attractivePoints, novelRating, query, updatedSince);
 
         boolean isLoadable = userNovels.size() == size;
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/# -> dev
- close #358

## Key Changes
<!-- 최대한 자세히 -->
- 클라이언트 측에서 로컬디비를 사용하기 위한 증분 동기화 api를 요청하여 기존 api에 `updatedSince` RequestParam을 추가하였습니다.
특정 시간을 기준으로 사용자가 변경한 서재 작품만 서버에서 받아 반영하기 위함입니다.
- 다만 기존에 평가에서 키워드를 변경하거나 매력포인트를 변경할 때에는 UserNovel의 `modifiedDate`가 변경되지 않아, `ParentTouchListener`를 만들어 해당 요소들에 변화가 있을 때에도 `modifiedDate`가 변경되도록 하였습니다.


## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 아직 시험이 끝나지 않아 . . . 꼭 고쳐야 하는 사항이 아니라면 남겨주신 리뷰는 이전 pr(#356)에 남겨주신 리뷰와 함께 다음주에 새로운 pr로 리팩토링해 리뷰 요청드리도록 하겠습니다. 😭
- 현재 서재에서 아예 삭제 해버리는 경우는 반환하지 못하고 있습니다. 이 또한 필요하지만 후순위로 작업해도 된다 하여 이번 pr을 먼저 머지하고 관련 기능을 추가로 구현할 예정인데, 소프트딜리트로 피드 제거 방식을 바꿀지, 혹은 피드삭제로그 테이블을 새로 만들지, 어떤 방식이 좋을지 추천 부탁드립니다~!

## References
<!-- 참고한 자료-->
