### PR TITLE
[FIX] 피드 단건 조회 시 피드 작성자의 별점 반환

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -32,7 +32,7 @@ public record FeedGetResponse(
         String novelThumbnailImage,
         String novelGenre,
         String novelAuthor,
-        Float userNovelRating,
+        Float feedWriterNovelRating,
         String novelDescription
 ) {
     public static FeedGetResponse of(Feed feed, UserBasicInfo feedUserBasicInfo, Novel novel, Boolean isLiked,
@@ -43,7 +43,7 @@ public record FeedGetResponse(
         String novelThumbnailImage = null;
         String novelGenre = null;
         String novelAuthor = null;
-        Float userNovelRating = null;
+        Float feedWriterNovelRating = null;
         String novelDescription = null;
 
         if (novel != null) {
@@ -60,7 +60,7 @@ public record FeedGetResponse(
             novelThumbnailImage = novel.getNovelImage();
             novelGenre = novel.getNovelGenres().get(0).getGenre().getGenreName();
             novelAuthor = novel.getAuthor();
-            userNovelRating = getUserNovelRating(novel, user.getUserId());
+            feedWriterNovelRating = getFeedWriterNovelRating(novel, feed.getUser().getUserId());
             novelDescription = novel.getNovelDescription();
         }
 
@@ -91,7 +91,7 @@ public record FeedGetResponse(
                 novelThumbnailImage,
                 novelGenre,
                 novelAuthor,
-                userNovelRating,
+                feedWriterNovelRating,
                 novelDescription
         );
     }
@@ -103,14 +103,14 @@ public record FeedGetResponse(
         return Math.round((novelRatingSum / (float) novelRatingCount) * 10) / 10.0f;
     }
 
-    private static Float getUserNovelRating(Novel novel, Long visitorId) {
+    private static Float getFeedWriterNovelRating(Novel novel, Long feedWriterId) {
         if (novel == null) {
             return null;
         }
 
         return novel.getUserNovels()
                 .stream()
-                .filter(userNovel -> userNovel.getUser().getUserId().equals(visitorId))
+                .filter(userNovel -> userNovel.getUser().getUserId().equals(feedWriterId))
                 .findFirst()
                 .map(UserNovel::getUserNovelRating)
                 .orElse(null);

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.FeedImage;
 import org.websoso.WSSServer.domain.Novel;
-import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 
@@ -36,7 +35,7 @@ public record FeedGetResponse(
         String novelDescription
 ) {
     public static FeedGetResponse of(Feed feed, UserBasicInfo feedUserBasicInfo, Novel novel, Boolean isLiked,
-                                     List<String> relevantCategories, Boolean isMyFeed, User user) {
+                                     List<String> relevantCategories, Boolean isMyFeed) {
         String title = null;
         Integer novelRatingCount = null;
         Float novelRating = null;

--- a/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
@@ -106,7 +106,7 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 
     private NumberExpression<Double> getAverageRating(QNovel novel) {
         return Expressions.numberTemplate(Double.class,
-                "(SELECT AVG(un.userNovelRating) FROM UserNovel un WHERE un.novel = {0} AND un.userNovelRating <> 0)",
+                "(SELECT AVG(un.feedWriterNovelRating) FROM UserNovel un WHERE un.novel = {0} AND un.feedWriterNovelRating <> 0)",
                 novel);
     }
 

--- a/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/NovelCustomRepositoryImpl.java
@@ -106,7 +106,7 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 
     private NumberExpression<Double> getAverageRating(QNovel novel) {
         return Expressions.numberTemplate(Double.class,
-                "(SELECT AVG(un.feedWriterNovelRating) FROM UserNovel un WHERE un.novel = {0} AND un.feedWriterNovelRating <> 0)",
+                "(SELECT AVG(un.userNovelRating) FROM UserNovel un WHERE un.novel = {0} AND un.userNovelRating <> 0)",
                 novel);
     }
 

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -248,7 +248,7 @@ public class FeedService {
         List<String> relevantCategories = feedCategoryService.getRelevantCategoryNames(feed.getFeedCategories());
         Boolean isMyFeed = isUserFeedOwner(feed.getUser(), user);
 
-        return FeedGetResponse.of(feed, feedUserBasicInfo, novel, isLiked, relevantCategories, isMyFeed, user);
+        return FeedGetResponse.of(feed, feedUserBasicInfo, novel, isLiked, relevantCategories, isMyFeed);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/# -> dev
- close #360 

## Key Changes
<!-- 최대한 자세히 -->
* 피드 단건 조회 API 응답값 중 유저(로그인 한 현재 유저)의 별점이 아닌 피드 작성자의 별점을 반환하도록 수정했습니다.
* 응답 값 네이밍이 변경되었으므로 머지되기 전에 API 명세서 수정과 변경점 노티가 필요합니다!

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
* 파라미터로 전달한 user가 사용되지 않고 있어서 삭제해도 좋을지가 궁금합니다 : )

## References
<!-- 참고한 자료-->
