### PR TITLE
[FIX] 서재 조회 무한스크롤 방식 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -157,13 +157,13 @@ public class UserController {
                                                                                 @RequestParam(value = "query", required = false) String query,
                                                                                 @RequestParam("lastUserNovelId") Long lastUserNovelId,
                                                                                 @RequestParam("size") int size,
-                                                                                @RequestParam("sortType") String sortType,
+                                                                                @RequestParam("sortCriteria") SortCriteria sortCriteria,
                                                                                 @RequestParam(value = "updatedSince", required = false) LocalDateTime updatedSince) {
         return ResponseEntity
                 .status(OK)
                 .body(userNovelService.getUserNovelsAndNovels(
                         visitor, userId, isInterest, readStatuses, attractivePoints, novelRating, query,
-                        lastUserNovelId, size, sortType, updatedSince));
+                        lastUserNovelId, size, sortCriteria, updatedSince));
     }
 
     @GetMapping("/{userId}/feeds")

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.domain.common.Gender.M;
+import static org.websoso.WSSServer.domain.common.SortCriteria.OLD;
 import static org.websoso.WSSServer.exception.error.CustomGenreError.GENRE_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomNovelError.NOVEL_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomUserError.PRIVATE_PROFILE_STATUS;
@@ -32,6 +33,7 @@ import org.websoso.WSSServer.domain.UserNovel;
 import org.websoso.WSSServer.domain.UserNovelAttractivePoint;
 import org.websoso.WSSServer.domain.UserNovelKeyword;
 import org.websoso.WSSServer.domain.common.Gender;
+import org.websoso.WSSServer.domain.common.SortCriteria;
 import org.websoso.WSSServer.dto.keyword.KeywordGetResponse;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
 import org.websoso.WSSServer.dto.userNovel.TasteKeywordGetResponse;
@@ -277,7 +279,7 @@ public class UserNovelService {
                                                                 List<String> readStatuses,
                                                                 List<String> attractivePoints, Float novelRating,
                                                                 String query, Long lastUserNovelId, int size,
-                                                                String sortType, LocalDateTime updatedSince) {
+                                                                SortCriteria sortCriteria, LocalDateTime updatedSince) {
         User owner = userService.getUserOrException(ownerId);
 
         if (isProfileInaccessible(visitor, ownerId, owner)) {
@@ -285,7 +287,7 @@ public class UserNovelService {
         }
 
         boolean isOwner = visitor.getUserId().equals(ownerId);
-        boolean isAscending = sortType.equalsIgnoreCase(SORT_TYPE_OLDEST);
+        boolean isAscending = sortCriteria == OLD;
 
         List<UserNovel> userNovels = userNovelRepository.findFilteredUserNovels(ownerId, isInterest, readStatuses,
                 attractivePoints, novelRating, query, lastUserNovelId, size, isAscending, updatedSince);


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#365 -> dev
- close #365

## Key Changes
<!-- 최대한 자세히 -->
- 다른 api에서는 최신순, 오래된순 관계없이 초기호출 때에는 lastNovelId를 0으로 설정하면 됐었는데, 서재 조회 시에는 최신순 초기 호출 때에 lastNovelId를 9999로 설정했어야 해, 이를 수정하였습니다.
- [이전 pr](https://github.com/Team-WSS/WSS-Server/pull/356)에서 SORT TYPE을 enum으로 관리하면 좋을 것 같다는 리뷰를 남겨주셔서 sortCriteria를 사용하도록 방식을 변경하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
