### PR TITLE
[FIX] 유저 피드 조회 시 피드 이미지 추가 및 쿼리문을 통한 피드 개수 조정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.websoso.WSSServer.domain.Category;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.FeedCategory;
-import org.websoso.WSSServer.domain.FeedImage;
 import org.websoso.WSSServer.domain.Like;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.UserNovel;
@@ -28,10 +27,12 @@ public record UserFeedGetResponse(
         Boolean isPublic,
         String genre,
         Float userNovelRating,
-        List<String> feedImages
+        String thumbnailUrl,
+        Integer imageCount
 ) {
 
-    public static UserFeedGetResponse of(Feed feed, Novel novel, Long visitorId) {
+    public static UserFeedGetResponse of(Feed feed, Novel novel, Long visitorId, String thumbnailUrl,
+                                         Integer imageCount) {
         boolean isModified = !feed.getCreatedDate().equals(feed.getModifiedDate());
         Long novelRatingCount = getNovelRatingCount(novel);
         Float novelRating = getNovelRating(novel, novelRatingCount);
@@ -40,9 +41,6 @@ public record UserFeedGetResponse(
         List<String> relevantCategories = getFeedCategories(feed);
         String genreName = getNovelGenreName(novel);
         Float userNovelRating = getUserNovelRating(novel, visitorId);
-        List<String> feedImages = feed.getImages().stream()
-                .map(FeedImage::getUrl)
-                .toList();
 
         return new UserFeedGetResponse(
                 feed.getFeedId(),
@@ -64,7 +62,8 @@ public record UserFeedGetResponse(
                 feed.getIsPublic(),
                 genreName,
                 userNovelRating,
-                feedImages
+                thumbnailUrl,
+                imageCount
         );
     }
 

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.websoso.WSSServer.domain.Category;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.FeedCategory;
+import org.websoso.WSSServer.domain.FeedImage;
 import org.websoso.WSSServer.domain.Like;
 import org.websoso.WSSServer.domain.Novel;
 import org.websoso.WSSServer.domain.UserNovel;
@@ -26,7 +27,8 @@ public record UserFeedGetResponse(
         List<String> relevantCategories,
         Boolean isPublic,
         String genre,
-        Float userNovelRating
+        Float userNovelRating,
+        List<String> feedImages
 ) {
 
     public static UserFeedGetResponse of(Feed feed, Novel novel, Long visitorId) {
@@ -38,6 +40,9 @@ public record UserFeedGetResponse(
         List<String> relevantCategories = getFeedCategories(feed);
         String genreName = getNovelGenreName(novel);
         Float userNovelRating = getUserNovelRating(novel, visitorId);
+        List<String> feedImages = feed.getImages().stream()
+                .map(FeedImage::getUrl)
+                .toList();
 
         return new UserFeedGetResponse(
                 feed.getFeedId(),
@@ -58,7 +63,8 @@ public record UserFeedGetResponse(
                 relevantCategories,
                 feed.getIsPublic(),
                 genreName,
-                userNovelRating
+                userNovelRating,
+                feedImages
         );
     }
 

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
@@ -13,7 +13,8 @@ public interface FeedCustomRepository {
     List<Feed> findPopularFeedsByNovelIds(List<Long> novelIds);
 
     List<Feed> findFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size, Boolean isVisible,
-                                             Boolean isUnVisible, SortCriteria sortCriteria, List<Genre> genres);
+                                             Boolean isUnVisible, SortCriteria sortCriteria, List<Genre> genres,
+                                             Long visitorId);
 
     Slice<Feed> findRecommendedFeeds(Long lastFeedId, Long userId, PageRequest pageRequest, List<Genre> genres);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -55,7 +55,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
     @Override
     public List<Feed> findFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size, Boolean isVisible,
                                                     Boolean isUnVisible, SortCriteria sortCriteria,
-                                                    List<Genre> genres) {
+                                                    List<Genre> genres, Long visitorId) {
         return jpaQueryFactory
                 .selectFrom(feed)
                 .join(novel).on(feed.novelId.eq(novel.novelId))
@@ -66,7 +66,8 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                         ltFeedId(lastFeedId),
                         eqVisible(isVisible),
                         eqUnVisible(isUnVisible),
-                        checkGenres(genres)
+                        checkGenres(genres),
+                        checkVisible(visitorId)
                 )
                 .orderBy(
                         checkSortCriteria(sortCriteria),
@@ -172,5 +173,12 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
 
     private BooleanExpression checkHidden() {
         return feed.isHidden.eq(false);
+    }
+
+    private BooleanExpression checkVisible(Long userId) {
+        if (userId != null) {
+            return feed.isPublic.isTrue().or(feed.user.userId.eq(userId));
+        }
+        return null;
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -470,7 +470,9 @@ public class FeedService {
                     .collect(Collectors.toMap(Novel::getNovelId, novel -> novel));
 
             List<UserFeedGetResponse> userFeedGetResponseList = visibleFeeds.stream()
-                    .map(feed -> UserFeedGetResponse.of(feed, novelMap.get(feed.getNovelId()), visitorId))
+                    .map(feed -> UserFeedGetResponse.of(feed, novelMap.get(feed.getNovelId()), visitorId,
+                            getThumbnailUrl(feed),
+                            getImageCount(feed)))
                     .toList();
 
             // TODO Slice의 hasNext()로 판단하도록 수정
@@ -495,5 +497,15 @@ public class FeedService {
                     .toList();
         }
         return null;
+    }
+
+    private String getThumbnailUrl(Feed feed) {
+        Optional<FeedImage> thumbnailImage = feedImageCustomRepository.findThumbnailFeedImageByFeedId(
+                feed.getFeedId());
+        return thumbnailImage.map(FeedImage::getUrl).orElse(null);
+    }
+
+    private Integer getImageCount(Feed feed) {
+        return feedImageRepository.countByFeedId(feed.getFeedId());
     }
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -458,12 +458,8 @@ public class FeedService {
         if (owner.getIsProfilePublic() || isOwner(visitor, ownerId)) {
             List<Genre> genres = getGenres(genreNames);
 
-            List<Feed> feeds = feedRepository.findFeedsByNoOffsetPagination(owner, lastFeedId, size, isVisible,
-                    isUnVisible, sortCriteria, genres);
-
-            List<Feed> visibleFeeds = feeds.stream()
-                    .filter(feed -> feed.isVisibleTo(visitorId))
-                    .toList();
+            List<Feed> visibleFeeds = feedRepository.findFeedsByNoOffsetPagination(owner, lastFeedId, size, isVisible,
+                    isUnVisible, sortCriteria, genres, visitorId);
 
             List<Long> novelIds = visibleFeeds.stream()
                     .map(Feed::getNovelId)
@@ -478,7 +474,7 @@ public class FeedService {
                     .toList();
 
             // TODO Slice의 hasNext()로 판단하도록 수정
-            Boolean isLoadable = feeds.size() == size;
+            Boolean isLoadable = visibleFeeds.size() == size;
             int feedsCount = visibleFeeds.size();
 
             return UserFeedsGetResponse.of(isLoadable, feedsCount, userFeedGetResponseList);


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#369 -> dev
- close #369 

## Key Changes
<!-- 최대한 자세히 -->
* 사진소소에서 피드이미지를 추가함에 따라 유조 피드 조회시에도 피드 이미지를 조회할 수 있도록 유저 피드 조회 API 응답 값에 이미지 리스트를 추가했습니다.
* size를 20으로 요청했는데 그보다 더 적은 개수만큼 반환되는 이슈가 있어서 서비스 로직에 있던 조건을 쿼리문에 추가하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
* 유저 피드 API 부분만 건드린다고 건드리고 다른 부분에 영향이 없는지 한 번 확인은 해봤는데 혹시 우려되는 부분이 있으시다면 말씀해주세요 : )

## References
<!-- 참고한 자료-->
