### PR TITLE
[FIX] 유저 피드 조회 시 작품과 연결된 피드 포함 조회 및 비공개 로직 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -11,6 +11,7 @@ import static org.websoso.WSSServer.domain.QNovelGenre.novelGenre;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -64,8 +65,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                 .where(
                         feed.user.eq(owner),
                         ltFeedId(lastFeedId),
-                        eqVisible(isVisible),
-                        eqUnVisible(isUnVisible),
+                        checkPublic(isVisible, isUnVisible),
                         checkGenres(genres)
                 )
                 .orderBy(
@@ -95,16 +95,30 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
         return feed.feedId.lt(lastFeedId);
     }
 
-    private BooleanExpression eqVisible(Boolean isVisible) {
-        if (isVisible != null) {
-            return feed.isPublic.eq(isVisible);
+    private BooleanExpression checkPublic(Boolean isVisible, Boolean isUnVisible) {
+        if (Boolean.TRUE.equals(isVisible) && Boolean.TRUE.equals(isUnVisible)) {
+            return null;
         }
-        return null;
-    }
-
-    private BooleanExpression eqUnVisible(Boolean isUnVisible) {
-        if (isUnVisible != null) {
-            return feed.isPublic.eq(!isUnVisible);
+        if (Boolean.TRUE.equals(isVisible) && Boolean.FALSE.equals(isUnVisible)) {
+            return feed.isPublic.eq(true);
+        }
+        if (Boolean.FALSE.equals(isVisible) && Boolean.TRUE.equals(isUnVisible)) {
+            return feed.isPublic.eq(false);
+        }
+        if (Boolean.FALSE.equals(isVisible) && Boolean.FALSE.equals(isUnVisible)) {
+            return Expressions.FALSE;
+        }
+        if (Boolean.TRUE.equals(isVisible)) {
+            return feed.isPublic.eq(true);
+        }
+        if (Boolean.FALSE.equals(isVisible)) {
+            return feed.isPublic.eq(false);
+        }
+        if (Boolean.TRUE.equals(isUnVisible)) {
+            return feed.isPublic.eq(false);
+        }
+        if (Boolean.FALSE.equals(isUnVisible)) {
+            return feed.isPublic.eq(true);
         }
         return null;
     }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -65,7 +65,6 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                 .where(
                         feed.user.eq(owner),
                         ltFeedId(lastFeedId),
-                        checkGenres(genres),
                         checkVisible(visitorId),
                         checkPublic(isVisible, isUnVisible),
                         checkGenres(genres)

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -58,9 +58,9 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                                                     List<Genre> genres) {
         return jpaQueryFactory
                 .selectFrom(feed)
-                .join(novel).on(feed.novelId.eq(novel.novelId))
-                .join(novelGenre).on(novel.eq(novelGenre.novel))
-                .join(genre).on(novelGenre.genre.eq(genre))
+                .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
+                .leftJoin(novelGenre).on(novel.eq(novelGenre.novel))
+                .leftJoin(genre).on(novelGenre.genre.eq(genre))
                 .where(
                         feed.user.eq(owner),
                         ltFeedId(lastFeedId),

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -104,7 +104,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
 
     private BooleanExpression eqUnVisible(Boolean isUnVisible) {
         if (isUnVisible != null) {
-            return feed.isPublic.eq(isUnVisible);
+            return feed.isPublic.eq(!isUnVisible);
         }
         return null;
     }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -99,26 +99,14 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
         if (Boolean.TRUE.equals(isVisible) && Boolean.TRUE.equals(isUnVisible)) {
             return null;
         }
-        if (Boolean.TRUE.equals(isVisible) && Boolean.FALSE.equals(isUnVisible)) {
-            return feed.isPublic.eq(true);
-        }
-        if (Boolean.FALSE.equals(isVisible) && Boolean.TRUE.equals(isUnVisible)) {
-            return feed.isPublic.eq(false);
-        }
         if (Boolean.FALSE.equals(isVisible) && Boolean.FALSE.equals(isUnVisible)) {
             return Expressions.FALSE;
         }
         if (Boolean.TRUE.equals(isVisible)) {
             return feed.isPublic.eq(true);
         }
-        if (Boolean.FALSE.equals(isVisible)) {
-            return feed.isPublic.eq(false);
-        }
         if (Boolean.TRUE.equals(isUnVisible)) {
             return feed.isPublic.eq(false);
-        }
-        if (Boolean.FALSE.equals(isUnVisible)) {
-            return feed.isPublic.eq(true);
         }
         return null;
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#371 -> dev
- close #371 

## Key Changes
<!-- 최대한 자세히 -->
* 유저 피드를 조회하는 경우 작품이 등록되지 않은 피드는 조회가 되지 않는 문제가 있었습니다. 
      => 쿼리문에서 사용되는 join대신 leftJoin을 사용하여 작품이 없는 경우에도 피드는 불려와질 수 있도록 수정하였습니다.


* isVisible과 isUnVisible로 공개 및 비공개 피드를 구별하려고 했는데 IsUnVisible이 true, 즉 비공개 여부 피드를 보고 싶을 때 true값이 들어가 isPublic이 true인 공개 피드만이 보이는 경우가 있었습니다. 
* 또한 isVisible과 isUnVisible이 true, false인 경우 표현식에서는 이를 동시에 만족시키는 피드를 찾으려 하는데 그런 피드는 존재하지 않기 때문에 의도와 다르게 아무것도 표시되지 않는 경우가 있었습니다.
      => 각 상황에 맞는 표현식이 적용되도록 수정을 하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
* 표현식이 조금 길어졌는데 더 간단히 또는 좋은 방법이 있으시다면 편하게 말씀해주시면 감사하겠습니다 : )

## References
<!-- 참고한 자료-->
