### PR TITLE
[FIX] 서재에서 오래된 순 정렬 시 lastUserNovelId 오류 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/common/SortCriteria.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/SortCriteria.java
@@ -17,4 +17,8 @@ public enum SortCriteria {
         throw new CustomFilteringException(SORT_CRITERIA_NOT_FOUND,
                 "given sort criteria does not exist");
     }
+
+    public boolean isOld() {
+        return this == OLD;
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/UserNovelCustomRepositoryImpl.java
@@ -114,17 +114,21 @@ public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository 
 
         applyFilters(queryBuilder, isInterest, readStatuses, attractivePoints, novelRating, query, updatedSince);
 
-        queryBuilder.where(ltUserNovelId(lastUserNovelId));
+        queryBuilder.where(checkLastUserNovelId(lastUserNovelId, isAscending));
         queryBuilder.orderBy(checkSortOrder(isAscending));
 
         return queryBuilder.limit(size).fetch();
     }
 
-    private BooleanExpression ltUserNovelId(Long lastUserNovelId) {
+    private BooleanExpression checkLastUserNovelId(Long lastUserNovelId, boolean isAscending) {
         if (lastUserNovelId == NO_CURSOR) {
             return null;
         }
-        return userNovel.userNovelId.lt(lastUserNovelId);
+        if (isAscending) {
+            return userNovel.userNovelId.gt(lastUserNovelId);
+        } else {
+            return userNovel.userNovelId.lt(lastUserNovelId);
+        }
     }
 
     private OrderSpecifier<?> checkSortOrder(boolean isAscending) {

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -1,7 +1,6 @@
 package org.websoso.WSSServer.service;
 
 import static org.websoso.WSSServer.domain.common.Gender.M;
-import static org.websoso.WSSServer.domain.common.SortCriteria.OLD;
 import static org.websoso.WSSServer.exception.error.CustomGenreError.GENRE_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomNovelError.NOVEL_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomUserError.PRIVATE_PROFILE_STATUS;
@@ -287,7 +286,7 @@ public class UserNovelService {
         }
 
         boolean isOwner = visitor.getUserId().equals(ownerId);
-        boolean isAscending = sortCriteria == OLD;
+        boolean isAscending = sortCriteria.isOld();
 
         List<UserNovel> userNovels = userNovelRepository.findFilteredUserNovels(ownerId, isInterest, readStatuses,
                 attractivePoints, novelRating, query, lastUserNovelId, size, isAscending, updatedSince);


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#368 -> dev
- close #368

## Key Changes
<!-- 최대한 자세히 -->
서재 조회 시, OLD로 sortCriteria를 설정하면 lastUserNovelId가 작동하지 않는 오류가 있어 해당 사항을 수정했습니다.
- 기존에는 오래된 순, 최신 순 두 정렬 모두 lastUserNovelId에 비해 lessThan으로 비교하고 있어 의도하지 않은 결과가 있었습니다.
- 이에 정렬 방식에 따라 다르게 처리하도록 변경하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 이전에 기중님이 남겨주신 pr을 반영해 isOld() 함수를 만들어 적용했습니다.

## References
<!-- 참고한 자료-->
