### PR TITLE
[HOTFIX] 작품 평가 시 발생하는 DataIntegrityViolationException 해결

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/UserNovel.java
+++ b/src/main/java/org/websoso/WSSServer/domain/UserNovel.java
@@ -77,6 +77,7 @@ public class UserNovel extends BaseEntity {
         this.endDate = endDate;
         this.user = user;
         this.novel = novel;
+        this.isInterest = false;
     }
 
     public static UserNovel create(ReadStatus status, Float userNovelRating, LocalDate startDate, LocalDate endDate,


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- hotfix/#374 -> dev
- close #374

## Key Changes
<!-- 최대한 자세히 -->
작품 평가 시 isInterest가 false일 경우 DataIntegrityViolationException가 발생하는 문제가 있었습니다.
- 기존 방식
  - 관심 등록이 안되어 있는 상태로 매력포인트, 키워드를 선택했을 경우 발생
  - 기존에 UserNovel에 `@Column(columnDefinition = "Boolean default false", nullable = false)`라고 명시되어 있기는 했지만, 이는 DDL(테이블 생성) 시에만 동작해서 JPA 엔티티 객체를 Java에서 생성할 때는 null이 들어감
- 해결
  - 생성자에 `isInterest = false` 추가
## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
