### PR TITLE
[FIX] 작품 미연결 피드 조회 및 소소피드 전체 조회시 피드 작성자의 별점 조회

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedInfo.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedInfo.java
@@ -30,7 +30,8 @@ public record FeedInfo(
         String thumbnailUrl,
         Integer imageCount,
         String genreName,
-        Float userNovelRating
+        Float userNovelRating,
+        Float feedWriterNovelRating
 ) {
     public static FeedInfo of(Feed feed, UserBasicInfo userBasicInfo, Novel novel, Boolean isLiked,
                               List<String> relevantCategories, Boolean isMyFeed, String thumbnailUrl,
@@ -40,6 +41,7 @@ public record FeedInfo(
         Float novelRating = null;
         String genreName = null;
         Float userNovelRating = null;
+        Float feedWriterNovelRating = null;
 
         if (novel != null) {
             List<UserNovel> userNovels = novel.getUserNovels().stream().filter(un -> un.getUserNovelRating() > 0.0)
@@ -51,6 +53,7 @@ public record FeedInfo(
                     novelRatingCount);
             genreName = getNovelGenreName(novel);
             userNovelRating = getUserNovelRating(novel, user);
+            feedWriterNovelRating = getFeedWriterNovelRating(novel, feed.getUser().getUserId());
         }
 
         return new FeedInfo(
@@ -75,7 +78,8 @@ public record FeedInfo(
                 thumbnailUrl,
                 imageCount,
                 genreName,
-                userNovelRating
+                userNovelRating,
+                feedWriterNovelRating
         );
     }
 
@@ -102,6 +106,19 @@ public record FeedInfo(
         return novel.getUserNovels()
                 .stream()
                 .filter(userNovel -> userNovel.getUser().getUserId().equals(user.getUserId()))
+                .findFirst()
+                .map(UserNovel::getUserNovelRating)
+                .orElse(null);
+    }
+
+    private static Float getFeedWriterNovelRating(Novel novel, Long feedWriterId) {
+        if (novel == null) {
+            return null;
+        }
+
+        return novel.getUserNovels()
+                .stream()
+                .filter(userNovel -> userNovel.getUser().getUserId().equals(feedWriterId))
                 .findFirst()
                 .map(UserNovel::getUserNovelRating)
                 .orElse(null);

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -28,7 +28,8 @@ public record UserFeedGetResponse(
         String genre,
         Float userNovelRating,
         String thumbnailUrl,
-        Integer imageCount
+        Integer imageCount,
+        Float feedWriterNovelRating
 ) {
 
     public static UserFeedGetResponse of(Feed feed, Novel novel, Long visitorId, String thumbnailUrl,
@@ -41,6 +42,7 @@ public record UserFeedGetResponse(
         List<String> relevantCategories = getFeedCategories(feed);
         String genreName = getNovelGenreName(novel);
         Float userNovelRating = getUserNovelRating(novel, visitorId);
+        Float feedWriterNovelRating = getFeedWriterNovelRating(novel, feed.getUser().getUserId());
 
         return new UserFeedGetResponse(
                 feed.getFeedId(),
@@ -63,7 +65,8 @@ public record UserFeedGetResponse(
                 genreName,
                 userNovelRating,
                 thumbnailUrl,
-                imageCount
+                imageCount,
+                feedWriterNovelRating
         );
     }
 
@@ -130,6 +133,19 @@ public record UserFeedGetResponse(
         return novel.getUserNovels()
                 .stream()
                 .filter(userNovel -> userNovel.getUser().getUserId().equals(visitorId))
+                .findFirst()
+                .map(UserNovel::getUserNovelRating)
+                .orElse(null);
+    }
+
+    private static Float getFeedWriterNovelRating(Novel novel, Long feedWriterId) {
+        if (novel == null) {
+            return null;
+        }
+
+        return novel.getUserNovels()
+                .stream()
+                .filter(userNovel -> userNovel.getUser().getUserId().equals(feedWriterId))
                 .findFirst()
                 .map(UserNovel::getUserNovelRating)
                 .orElse(null);

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -155,7 +155,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
     }
 
     private BooleanExpression checkGenres(List<Genre> genres) {
-        if (genres != null && !genres.isEmpty()) {
+        if (genres != null && !genres.isEmpty() && feed.novelId != null) {
             return genre.in(genres);
         }
         return null;


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#376 -> dev
- close #376

## Key Changes
<!-- 최대한 자세히 -->
* 작품이 연결되지 않는 피드가 여전히 조회되지 않는 문제가 있었습니다.
    * 쿼리문을 작성했을 때 Left Join으로 작품이 연결되지 않은 피드도 불려와지는 것은 확인했지만 장르를 체크하는 부분에서 장르가 null이기 때문에 조건을 만족하지 않아 필터링 되는 것을 확인했습니다.
    * 이에 따라 장르를 체크할 때 피드의 작품이 연결, 즉 피드의 novelId가 null이 아닐 때의 조건을 추가했습니다.

* 피드 전체 및 유저 피드 조회 시 피드 작성자의 별점을 응답 값에 추가했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
