### PR TITLE
[REFACTOR] 피드 이미지 요구사항 변경 대응 및 버그 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedImageCreateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedImageCreateRequest.java
@@ -6,7 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 public record FeedImageCreateRequest(
-        @Size(max = 20, message = "피드 이미지는 20개를 초과할 수 없습니다.")
+        @Size(max = 5, message = "피드 이미지는 5개를 초과할 수 없습니다.")
         List<MultipartFile> images
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedImageUpdateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedImageUpdateRequest.java
@@ -6,7 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 public record FeedImageUpdateRequest(
-        @Size(max = 20, message = "피드 이미지는 20개를 초과할 수 없습니다.")
+        @Size(max = 5, message = "피드 이미지는 5개를 초과할 수 없습니다.")
         List<MultipartFile> images
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/websoso/WSSServer/exception/handler/GlobalExceptionHandler.java
@@ -23,8 +23,8 @@ import org.websoso.WSSServer.exception.common.ICustomError;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    private static final long MAX_TOTAL_FILE_SIZE_MB = 100;
-    private static final long MAX_FILE_SIZE_MB = 5;
+    private static final double MAX_TOTAL_FILE_SIZE_MB = 2.5;
+    private static final double MAX_FILE_SIZE_MB = 0.5;
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResult> MethodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
@@ -64,8 +64,8 @@ public class GlobalExceptionHandler {
         log.error("[MaxUploadSizeExceededException] exception ", e);
 
         String message = (e.getCause() instanceof SizeLimitExceededException)
-                ? String.format("업로드하는 총 파일의 용량이 %dMB를 초과할 수 없습니다.", MAX_TOTAL_FILE_SIZE_MB)
-                : String.format("업로드하는 각 파일의 용량이 %dMB를 초과할 수 없습니다.", MAX_FILE_SIZE_MB);
+                ? String.format("업로드하는 총 파일의 용량이 %.1fMB를 초과할 수 없습니다.", MAX_TOTAL_FILE_SIZE_MB)
+                : String.format("업로드하는 각 파일의 용량이 %.1fMB를 초과할 수 없습니다.", MAX_FILE_SIZE_MB);
 
         return ResponseEntity
                 .status(BAD_REQUEST)

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -4,7 +4,6 @@ import static java.lang.Boolean.TRUE;
 import static org.websoso.WSSServer.domain.common.DiscordWebhookMessageType.REPORT;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.SELF_REPORT_NOT_ALLOWED;
-import static org.websoso.WSSServer.exception.error.CustomImageError.UPLOAD_FAIL_FILE;
 import static org.websoso.WSSServer.exception.error.CustomUserError.PRIVATE_PROFILE_STATUS;
 
 import java.util.ArrayList;
@@ -55,7 +54,6 @@ import org.websoso.WSSServer.dto.feed.UserFeedsGetResponse;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseFeedTab;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
-import org.websoso.WSSServer.exception.exception.CustomImageException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
 import org.websoso.WSSServer.notification.FCMService;
 import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
@@ -155,8 +153,8 @@ public class FeedService {
                 if (!uploadedImageUrls.isEmpty()) {
                     imageService.deleteImages(uploadedImageUrls);
                 }
-                // TODO: 업로드 실패의 경우, 일반적으로 네트워크 문제이지만 상세한 사유별로 구분지어야함
-                throw new CustomImageException(UPLOAD_FAIL_FILE, "이미지 업로드에 실패했습니다.");
+
+                throw e;
             }
         }
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- refactor/#380 -> dev
- close #380

## Key Changes
<!-- 최대한 자세히 -->
### 변경된 피드 이미지 요구사항
변경된 피드 이미지 요구사항에 따라 수정이 진행되었습니다.
- **이미지 최대 개수**를 **20개에서 5개**로 변경하였습니다.
- **각 이미지 최대 용량**이 **5MB에서 0.5MB**로 변경되었습니다.

### 업로드 예외 처리 오류 수정
기존에는 업로드 중 문제가 발생할 경우, 이미지 삭제 처리 이후 **항상 500 Internal Server Error**를 반환하고 있었습니다.

예를 들어, 이미지 파일 자체의 문제나 허용되지 않은 확장자 등 클라이언트 입력에 의한 오류임에도 불구하고 500 에러가 발생했습니다.

업로드 중 발생한 예외의 원인에 따라 **적절한 상태 코드**를 반환하도록 개선하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
