### PR TITLE
[FIX] 유저 피드 조회 시 쿼리문 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -155,10 +155,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
     }
 
     private BooleanExpression checkGenres(List<Genre> genres) {
-        if (genres != null && !genres.isEmpty() && feed.novelId != null) {
-            return genre.in(genres);
-        }
-        return null;
+        return genre.in(genres).or(feed.novelId.isNull());
     }
 
     private BooleanExpression checkBlocking(Long userId) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/# -> dev
- close #383 

## Key Changes
<!-- 최대한 자세히 -->
* 여전히 novelId가 null인 피드가 조회되지 않아 쿼리문을 수정하였습니다.
* 기존 : novelId가 null이라는 쿼리문 조건을 java 코드 단에서 (if문) 검사
* 개선 : novelId가 null인 피드를 찾는 쿼리문 조건을 or로 검사

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
