### PR TITLE
[FIX] 피드 삭제 시 댓글 신고기록 함께 삭제

### DIFF
--- a/src/main/java/org/websoso/WSSServer/repository/CommentRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/CommentRepository.java
@@ -1,5 +1,7 @@
 package org.websoso.WSSServer.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -14,4 +16,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Comment c SET c.userId = -1 WHERE c.userId = :userId")
     void updateUserToUnknown(Long userId);
+
+    @Query("SELECT c FROM Comment c WHERE c.feed.feedId = :feedId")
+    List<Comment> findAllByFeedId(@Param("feedId") Long feedId);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/ReportedCommentRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/ReportedCommentRepository.java
@@ -1,6 +1,10 @@
 package org.websoso.WSSServer.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.domain.Comment;
 import org.websoso.WSSServer.domain.ReportedComment;
@@ -14,4 +18,7 @@ public interface ReportedCommentRepository extends JpaRepository<ReportedComment
 
     Integer countByCommentAndReportedType(Comment comment, ReportedType reportedType);
 
+    @Modifying
+    @Query("DELETE FROM ReportedComment rc WHERE rc.comment.commentId IN :commentIds")
+    void deleteByCommentIdsIn(@Param("commentIds") List<Long> commentIds);
 }

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.websoso.WSSServer.domain.Avatar;
+import org.websoso.WSSServer.domain.Comment;
 import org.websoso.WSSServer.domain.Feed;
 import org.websoso.WSSServer.domain.FeedImage;
 import org.websoso.WSSServer.domain.Genre;
@@ -60,6 +61,7 @@ import org.websoso.WSSServer.exception.exception.CustomUserException;
 import org.websoso.WSSServer.notification.FCMService;
 import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 import org.websoso.WSSServer.repository.AvatarRepository;
+import org.websoso.WSSServer.repository.CommentRepository;
 import org.websoso.WSSServer.repository.FeedImageCustomRepository;
 import org.websoso.WSSServer.repository.FeedImageRepository;
 import org.websoso.WSSServer.repository.FeedRepository;
@@ -67,6 +69,7 @@ import org.websoso.WSSServer.repository.GenrePreferenceRepository;
 import org.websoso.WSSServer.repository.NotificationRepository;
 import org.websoso.WSSServer.repository.NotificationTypeRepository;
 import org.websoso.WSSServer.repository.NovelRepository;
+import org.websoso.WSSServer.repository.ReportedCommentRepository;
 import org.websoso.WSSServer.repository.UserNovelRepository;
 
 @Service
@@ -100,6 +103,8 @@ public class FeedService {
     private final FeedImageRepository feedImageRepository;
     private final GenreService genreService;
     private final GenrePreferenceRepository genrePreferenceRepository;
+    private final CommentRepository commentRepository;
+    private final ReportedCommentRepository reportedCommentRepository;
 
     public void createFeed(User user, FeedCreateRequest request, FeedImageCreateRequest imagesRequest) {
         List<FeedImage> feedImages = processFeedImages(imagesRequest.images());
@@ -172,6 +177,9 @@ public class FeedService {
     }
 
     public void deleteFeed(Long feedId) {
+        List<Long> commentIds = commentRepository.findAllByFeedId(feedId).stream()
+                .map(Comment::getCommentId).toList();
+        reportedCommentRepository.deleteByCommentIdsIn(commentIds);
         feedRepository.deleteById(feedId);
     }
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/# -> dev
- close #385 

## Key Changes
<!-- 최대한 자세히 -->
* 피드를 삭제하는 과정에서 피드의 댓글 중 신고 기록이 있는 경우 ReportedComment에서 참조 무결성 제약조건으로 인해 피드가 삭제되지 않는 경우가 있었습니다.
* 그래서 삭제하고자 하는 피드의 모든 댓글을 가져오고 신고된 댓글 중 해당 피드의 댓글들이 있는 경우 먼저 기록을 삭제 후 댓글을 삭제하는 코드를 작성했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
