### PR TITLE
[FIX] 유저(내) 피드 조회 시 총 피드 개수 반환

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedsGetResponse.java
@@ -4,11 +4,11 @@ import java.util.List;
 
 public record UserFeedsGetResponse(
         Boolean isLoadable,
-        int feedsCount,
+        long feedsCount,
         List<UserFeedGetResponse> feeds
 ) {
 
-    public static UserFeedsGetResponse of(Boolean isLoadable, int feedsCount,
+    public static UserFeedsGetResponse of(Boolean isLoadable, long feedsCount,
                                           List<UserFeedGetResponse> userFeedGetResponses) {
         return new UserFeedsGetResponse(isLoadable, feedsCount, userFeedGetResponses);
     }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
@@ -17,4 +17,8 @@ public interface FeedCustomRepository {
                                              Long visitorId);
 
     Slice<Feed> findRecommendedFeeds(Long lastFeedId, Long userId, PageRequest pageRequest, List<Genre> genres);
+
+    int countVisibleFeeds(User owner, Long lastFeedId, Boolean isVisible,
+                          Boolean isUnVisible, List<Genre> genres,
+                          Long visitorId);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepository.java
@@ -18,7 +18,7 @@ public interface FeedCustomRepository {
 
     Slice<Feed> findRecommendedFeeds(Long lastFeedId, Long userId, PageRequest pageRequest, List<Genre> genres);
 
-    int countVisibleFeeds(User owner, Long lastFeedId, Boolean isVisible,
-                          Boolean isUnVisible, List<Genre> genres,
-                          Long visitorId);
+    Long countVisibleFeeds(User owner, Long lastFeedId, Boolean isVisible,
+                           Boolean isUnVisible, List<Genre> genres,
+                           Long visitorId);
 }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -90,11 +90,12 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
     }
 
     @Override
-    public int countVisibleFeeds(User owner, Long lastFeedId, Boolean isVisible,
-                                 Boolean isUnVisible, List<Genre> genres,
-                                 Long visitorId) {
+    public Long countVisibleFeeds(User owner, Long lastFeedId, Boolean isVisible,
+                                  Boolean isUnVisible, List<Genre> genres,
+                                  Long visitorId) {
         return jpaQueryFactory
-                .selectFrom(feed)
+                .select(feed.count())
+                .from(feed)
                 .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
                 .leftJoin(novelGenre).on(novel.eq(novelGenre.novel))
                 .leftJoin(genre).on(novelGenre.genre.eq(genre))
@@ -105,8 +106,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                         checkPublic(isVisible, isUnVisible),
                         checkGenres(genres)
                 )
-                .fetch()
-                .size();
+                .fetchOne();
     }
 
     private BooleanExpression ltFeedId(Long lastFeedId) {

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -89,6 +89,26 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                 .fetchOne());
     }
 
+    @Override
+    public int countVisibleFeeds(User owner, Long lastFeedId, Boolean isVisible,
+                                 Boolean isUnVisible, List<Genre> genres,
+                                 Long visitorId) {
+        return jpaQueryFactory
+                .selectFrom(feed)
+                .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
+                .leftJoin(novelGenre).on(novel.eq(novelGenre.novel))
+                .leftJoin(genre).on(novelGenre.genre.eq(genre))
+                .where(
+                        feed.user.eq(owner),
+                        ltFeedId(lastFeedId),
+                        checkVisible(visitorId),
+                        checkPublic(isVisible, isUnVisible),
+                        checkGenres(genres)
+                )
+                .fetch()
+                .size();
+    }
+
     private BooleanExpression ltFeedId(Long lastFeedId) {
         if (lastFeedId == NO_CURSOR) {
             return null;

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -488,7 +488,7 @@ public class FeedService {
 
             // TODO Slice의 hasNext()로 판단하도록 수정
             Boolean isLoadable = visibleFeeds.size() == size;
-            int feedsCount = feedRepository.countVisibleFeeds(owner, lastFeedId, isVisible,
+            long feedsCount = feedRepository.countVisibleFeeds(owner, lastFeedId, isVisible,
                     isUnVisible, genres, visitorId);
 
             return UserFeedsGetResponse.of(isLoadable, feedsCount, userFeedGetResponseList);

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -488,7 +488,8 @@ public class FeedService {
 
             // TODO Slice의 hasNext()로 판단하도록 수정
             Boolean isLoadable = visibleFeeds.size() == size;
-            int feedsCount = visibleFeeds.size();
+            int feedsCount = feedRepository.countVisibleFeeds(owner, lastFeedId, isVisible,
+                    isUnVisible, genres, visitorId);
 
             return UserFeedsGetResponse.of(isLoadable, feedsCount, userFeedGetResponseList);
         }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/# -> dev
- close #388 

## Key Changes
<!-- 최대한 자세히 -->
* 기존에는 페이지네이션된 피드 개수를 반환했습니다.
* 전체 피드 개수를 반환하기 위해 쿼리문을 작성했습니다.
    * fetchCount()가 deprecated되어서 기존에 피드 조회에서 limit와 orderby를 제외하고 조회한 후 size()를 통해 개수를 조회했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
