### PR TITLE
[FIX] 유저 피드 조회 시 genreNames 값이 null인 경우 처리

### DIFF
--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -174,7 +174,10 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
     }
 
     private BooleanExpression checkGenres(List<Genre> genres) {
-        return genre.in(genres).or(feed.novelId.isNull());
+        if (genres != null && !genres.isEmpty()) {
+            return genre.in(genres).or(feed.novelId.isNull());
+        }
+        return feed.novelId.isNull();
     }
 
     private BooleanExpression checkBlocking(Long userId) {

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -177,7 +177,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
         if (genres != null && !genres.isEmpty()) {
             return genre.in(genres).or(feed.novelId.isNull());
         }
-        return feed.novelId.isNull();
+        return null;
     }
 
     private BooleanExpression checkBlocking(Long userId) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/# -> dev
- close #393 

## Key Changes
<!-- 최대한 자세히 -->
* genreNames 값을 요청하지 않으면 이에 대해서 처리를 해야했는데, checkGenres()에서 genres가 null이 오게되면 .in(null)에서 에러가 발생했습니다.
* 그래서 genre가 null이 아니고 비어있지 않은 경우는 기존의 조건문대로 genre에 속하거나 장르가 없는(연결된 작품이 없는) 피드를 반환하도록 했고, null이거나 비어있는 경우에는 null을 반환하여 아무 조건을 걸지 않았습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
