### PR TITLE
[FEAT] 안드/아요 서재 조회 응답 분리

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -43,6 +43,7 @@ import org.websoso.WSSServer.dto.user.UserInfoGetResponse;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
 import org.websoso.WSSServer.dto.userNovel.UserGenrePreferencesGetResponse;
 import org.websoso.WSSServer.dto.userNovel.UserNovelAndNovelsGetResponse;
+import org.websoso.WSSServer.dto.userNovel.UserNovelAndNovelsGetResponseLegacy;
 import org.websoso.WSSServer.dto.userNovel.UserTasteAttractivePointPreferencesAndKeywordsGetResponse;
 import org.websoso.WSSServer.service.FeedService;
 import org.websoso.WSSServer.service.UserNovelService;
@@ -164,6 +165,20 @@ public class UserController {
                 .body(userNovelService.getUserNovelsAndNovels(
                         visitor, userId, isInterest, readStatuses, attractivePoints, novelRating, query,
                         lastUserNovelId, size, sortCriteria, updatedSince));
+    }
+
+    @GetMapping("/{userId}/novels/legacy")
+    public ResponseEntity<UserNovelAndNovelsGetResponseLegacy> getUserNovelsAndNovelsOld(
+            @AuthenticationPrincipal User visitor,
+            @PathVariable("userId") Long userId,
+            @RequestParam("readStatus") String readStatus,
+            @RequestParam("lastUserNovelId") Long lastUserNovelId,
+            @RequestParam("size") int size,
+            @RequestParam("sortCriteria") SortCriteria sortCriteria) {
+        return ResponseEntity
+                .status(OK)
+                .body(userNovelService.getUserNovelsAndNovelsLegacy(visitor, userId, readStatus, lastUserNovelId, size,
+                        sortCriteria));
     }
 
     @GetMapping("/{userId}/feeds")

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelAndNovelGetResponseLegacy.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelAndNovelGetResponseLegacy.java
@@ -1,0 +1,23 @@
+package org.websoso.WSSServer.dto.userNovel;
+
+import org.websoso.WSSServer.domain.UserNovel;
+
+public record UserNovelAndNovelGetResponseLegacy(
+        Long userNovelId,
+        Long novelId,
+        String author,
+        String novelImage,
+        String title,
+        Float novelRating
+) {
+    public static UserNovelAndNovelGetResponseLegacy of(UserNovel userNovel) {
+        return new UserNovelAndNovelGetResponseLegacy(
+                userNovel.getUserNovelId(),
+                userNovel.getNovel().getNovelId(),
+                userNovel.getNovel().getAuthor(),
+                userNovel.getNovel().getNovelImage(),
+                userNovel.getNovel().getTitle(),
+                userNovel.getUserNovelRating()
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelAndNovelsGetResponseLegacy.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/UserNovelAndNovelsGetResponseLegacy.java
@@ -1,0 +1,15 @@
+package org.websoso.WSSServer.dto.userNovel;
+
+import java.util.List;
+
+public record UserNovelAndNovelsGetResponseLegacy(
+        Long userNovelCount,
+        Boolean isLoadable,
+        List<UserNovelAndNovelGetResponseLegacy> userNovels
+) {
+    public static UserNovelAndNovelsGetResponseLegacy of(Long userNovelCount, Boolean isLoadable,
+                                                         List<UserNovelAndNovelGetResponseLegacy> userNovelAndNovelGetResponseLegacies) {
+        return new UserNovelAndNovelsGetResponseLegacy(userNovelCount, isLoadable,
+                userNovelAndNovelGetResponseLegacies);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
+++ b/src/main/java/org/websoso/WSSServer/service/UserNovelService.java
@@ -316,12 +316,19 @@ public class UserNovelService {
         }
 
         boolean isAscending = sortCriteria.isOld();
-        List<String> readStatuses = List.of(readStatus);
+        List<String> readStatuses = null;
+        Boolean isInterest = null;
 
-        List<UserNovel> userNovels = userNovelRepository.findFilteredUserNovels(ownerId, null, readStatuses,
+        if ("INTEREST".equalsIgnoreCase(readStatus)) {
+            isInterest = true;
+        } else {
+            readStatuses = List.of(readStatus);
+        }
+
+        List<UserNovel> userNovels = userNovelRepository.findFilteredUserNovels(ownerId, isInterest, readStatuses,
                 null, null, null, lastUserNovelId, size, isAscending, null);
 
-        Long totalCount = userNovelRepository.countByUserIdAndFilters(ownerId, null, readStatuses,
+        Long totalCount = userNovelRepository.countByUserIdAndFilters(ownerId, isInterest, readStatuses,
                 null, null, null, null);
 
         boolean isLoadable = userNovels.size() == size;


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#395 -> dev
- close #395

## Key Changes
<!-- 최대한 자세히 -->
iOS에서 서재 관련 업데이트가 늦어져 이전 api를 복원시켰습니다.
다만 아요에서도 추후 안드와 같이 최신 버전으로 합칠 예정이기 때문에
+) 아요와 안드가 응답값도, 필수로 받아야 하는 값도 꽤 다르기 때문에
나중에 통째로 몇줄만 삭제하면 되도록 api를 아예 분리하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
- [API 명세서](https://www.notion.so/kimmjabc/API-iOS-24f9e64a4532800b9d4cf935c83c76e1?v=f81077f028d944e9a106e595e489d20f&source=copy_link)
