### PR TITLE
[FIX] 추천 피드 조회 시 작품 연결 안 된 피드도 조회

### DIFF
--- a/src/main/java/org/websoso/WSSServer/repository/FeedCategoryCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCategoryCustomRepositoryImpl.java
@@ -35,10 +35,10 @@ public class FeedCategoryCustomRepositoryImpl implements FeedCategoryCustomRepos
         List<Feed> results = jpaQueryFactory
                 .select(feedCategory.feed)
                 .from(feedCategory)
-                .join(feedCategory.feed, feed)
-                .join(novel).on(feed.novelId.eq(novel.novelId))
-                .join(novelGenre).on(novel.eq(novelGenre.novel))
-                .join(genre).on(novelGenre.genre.eq(genre))
+                .leftJoin(feedCategory.feed, feed)
+                .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
+                .leftJoin(novelGenre).on(novel.eq(novelGenre.novel))
+                .leftJoin(genre).on(novelGenre.genre.eq(genre))
                 .where(
                         ltFeedId(lastFeedId),
                         checkCategory(category),
@@ -87,7 +87,7 @@ public class FeedCategoryCustomRepositoryImpl implements FeedCategoryCustomRepos
 
     private BooleanExpression checkGenres(List<Genre> genres) {
         if (genres != null && !genres.isEmpty()) {
-            return genre.in(genres);
+            return genre.in(genres).or(feed.novelId.isNull());
         }
         return null;
     }

--- a/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/repository/FeedCustomRepositoryImpl.java
@@ -142,9 +142,9 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
     public Slice<Feed> findRecommendedFeeds(Long lastFeedId, Long userId, PageRequest pageRequest, List<Genre> genres) {
         List<Feed> feeds = jpaQueryFactory
                 .selectFrom(feed)
-                .join(novel).on(feed.novelId.eq(novel.novelId))
-                .join(novelGenre).on(novel.eq(novelGenre.novel))
-                .join(genre).on(novelGenre.genre.eq(genre))
+                .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
+                .leftJoin(novelGenre).on(novel.eq(novelGenre.novel))
+                .leftJoin(genre).on(novelGenre.genre.eq(genre))
                 .where(
                         ltFeedId(lastFeedId),
                         checkPopularFeed(),


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/# -> dev
- close #400 

## Key Changes
<!-- 최대한 자세히 -->
* 내(유저) 피드 조회시에도 작품이 연결되지 않은 피드가 조회되지 않는 문제가 있었는데, 피드 조회시 추천피드를 조회하는 과정에서 작품이 연결되지 않는 피드가 조회하지 못하는 문제가 있었습니다.
* join하는 과정에서 작품이 연결되지 않은 피드의 novel이 null이기 때문에 아에 조회되지 않습니다. 따라서 left join을 이용했습니다. 
* 카테고리를 조회하는 과정에서 novelId가 null인 경우에 맞게 조건을 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
