### PR TITLE
[FEAT] 피드 글 POST, PUT 응답에 images 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/FeedController.java
@@ -28,11 +28,12 @@ import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
 import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
-import org.websoso.WSSServer.dto.feed.FeedGetResponse;
-import org.websoso.WSSServer.dto.feed.FeedImageCreateRequest;
+import org.websoso.WSSServer.dto.feed.FeedCreateResponse;
 import org.websoso.WSSServer.dto.feed.FeedImageUpdateRequest;
+import org.websoso.WSSServer.dto.feed.FeedGetResponse;
 import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
 import org.websoso.WSSServer.dto.feed.FeedsGetResponse;
+import org.websoso.WSSServer.dto.feed.FeedImageCreateRequest;
 import org.websoso.WSSServer.dto.feed.InterestFeedsGetResponse;
 import org.websoso.WSSServer.dto.popularFeed.PopularFeedsGetResponse;
 import org.websoso.WSSServer.service.FeedService;
@@ -48,13 +49,12 @@ public class FeedController {
 
     @PostMapping
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<Void> createFeed(@AuthenticationPrincipal User user,
-                                           @Valid @RequestPart("feed") FeedCreateRequest request,
-                                           @Valid @ModelAttribute FeedImageCreateRequest requestImage) {
-        feedService.createFeed(user, request, requestImage);
+    public ResponseEntity<FeedCreateResponse> createFeed(@AuthenticationPrincipal User user,
+                                                         @Valid @RequestPart("feed") FeedCreateRequest request,
+                                                         @Valid @ModelAttribute FeedImageCreateRequest requestImage) {
         return ResponseEntity
                 .status(CREATED)
-                .build();
+                .body(feedService.createFeed(user, request, requestImage));
     }
 
     @GetMapping("/{feedId}")
@@ -79,14 +79,13 @@ public class FeedController {
 
     @PutMapping("/{feedId}")
     @PreAuthorize("isAuthenticated() and @authorizationService.validate(#feedId, #user, T(org.websoso.WSSServer.domain.Feed))")
-    public ResponseEntity<Void> updateFeed(@AuthenticationPrincipal User user,
+    public ResponseEntity<FeedCreateResponse> updateFeed(@AuthenticationPrincipal User user,
                                            @PathVariable("feedId") Long feedId,
                                            @Valid @RequestPart("feed") FeedUpdateRequest request,
                                            @Valid @ModelAttribute FeedImageUpdateRequest requestImage) {
-        feedService.updateFeed(feedId, request, requestImage);
         return ResponseEntity
-                .status(NO_CONTENT)
-                .build();
+                .status(OK)
+                .body(feedService.updateFeed(feedId, request, requestImage));
     }
 
     @DeleteMapping("/{feedId}")

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedCreateResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedCreateResponse.java
@@ -1,0 +1,21 @@
+package org.websoso.WSSServer.dto.feed;
+
+import org.websoso.WSSServer.domain.FeedImage;
+
+import java.util.Comparator;
+import java.util.List;
+
+public record FeedCreateResponse(
+        Integer imagesCount,
+        List<String> imageUrls
+) {
+    public static FeedCreateResponse of(List<FeedImage> images) {
+        return new FeedCreateResponse(
+                images.size(),
+                images.stream()
+                        .sorted(Comparator.comparing(FeedImage::getSequence))
+                        .map(FeedImage::getUrl)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/service/FeedService.java
@@ -40,18 +40,7 @@ import org.websoso.WSSServer.domain.common.SortCriteria;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
 import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
-import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
-import org.websoso.WSSServer.dto.feed.FeedGetResponse;
-import org.websoso.WSSServer.dto.feed.FeedImageCreateRequest;
-import org.websoso.WSSServer.dto.feed.FeedImageDeleteEvent;
-import org.websoso.WSSServer.dto.feed.FeedImageUpdateRequest;
-import org.websoso.WSSServer.dto.feed.FeedInfo;
-import org.websoso.WSSServer.dto.feed.FeedUpdateRequest;
-import org.websoso.WSSServer.dto.feed.FeedsGetResponse;
-import org.websoso.WSSServer.dto.feed.InterestFeedGetResponse;
-import org.websoso.WSSServer.dto.feed.InterestFeedsGetResponse;
-import org.websoso.WSSServer.dto.feed.UserFeedGetResponse;
-import org.websoso.WSSServer.dto.feed.UserFeedsGetResponse;
+import org.websoso.WSSServer.dto.feed.*;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseFeedTab;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
@@ -104,7 +93,7 @@ public class FeedService {
     private final CommentRepository commentRepository;
     private final ReportedCommentRepository reportedCommentRepository;
 
-    public void createFeed(User user, FeedCreateRequest request, FeedImageCreateRequest imagesRequest) {
+    public FeedCreateResponse createFeed(User user, FeedCreateRequest request, FeedImageCreateRequest imagesRequest) {
         List<FeedImage> feedImages = processFeedImages(imagesRequest.images());
 
         Optional.ofNullable(request.novelId())
@@ -118,9 +107,11 @@ public class FeedService {
                 feedImages);
         feedRepository.save(feed);
         feedCategoryService.createFeedCategory(feed, request.relevantCategories());
+
+        return FeedCreateResponse.of(feedImages);
     }
 
-    public void updateFeed(Long feedId, FeedUpdateRequest request, FeedImageUpdateRequest imagesRequest) {
+    public FeedCreateResponse updateFeed(Long feedId, FeedUpdateRequest request, FeedImageUpdateRequest imagesRequest) {
         Feed feed = getFeedOrException(feedId);
 
         List<FeedImage> oldImages = new ArrayList<>(feed.getImages());
@@ -143,6 +134,8 @@ public class FeedService {
                 .map(FeedImage::getUrl)
                 .toList();
         eventPublisher.publishEvent(new FeedImageDeleteEvent(oldImageUrls));
+
+        return FeedCreateResponse.of(feedImages);
     }
 
     private List<FeedImage> processFeedImages(List<MultipartFile> images) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#404 -> dev
- close #404

## Key Changes
<!-- 최대한 자세히 -->
- (클라이언트 측 요청) 피드 생성, 수정 직후 클라이언트에서 변경된 이미지 목록을 바로 사용할 수 있도록 했습니다.
  - 피드 생성 API (`POST /api/feeds`) 응답에 생성된 피드의 이미지 URL 리스트(`images`) 추가
  - 피드 수정 API (`PUT /api/feeds/{feedId}`) 응답에 수정된 피드의 이미지 URL 리스트(`images`) 추가

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 노션 API 명세서에 반영해두었습니다.

## References
<!-- 참고한 자료-->
