### PR TITLE
[REFACTOR] Novel 내에 존재하는 서재 로직을 분리

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
@@ -1,8 +1,14 @@
 package org.websoso.WSSServer.application;
 
+import static org.websoso.WSSServer.exception.error.CustomGenreError.GENRE_NOT_FOUND;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -10,23 +16,46 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Genre;
+import org.websoso.WSSServer.domain.GenrePreference;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.common.AttractivePointName;
+import org.websoso.WSSServer.domain.common.GenreName;
+import org.websoso.WSSServer.dto.keyword.KeywordCountGetResponse;
 import org.websoso.WSSServer.dto.novel.FilteredNovelsGetResponse;
+import org.websoso.WSSServer.dto.novel.NovelGetResponseBasic;
+import org.websoso.WSSServer.dto.novel.NovelGetResponseInfoTab;
 import org.websoso.WSSServer.dto.novel.NovelGetResponsePreview;
 import org.websoso.WSSServer.dto.novel.SearchedNovelsGetResponse;
+import org.websoso.WSSServer.dto.userNovel.TasteNovelGetResponse;
+import org.websoso.WSSServer.dto.userNovel.TasteNovelsGetResponse;
+import org.websoso.WSSServer.exception.exception.CustomGenreException;
+import org.websoso.WSSServer.feed.repository.FeedRepository;
 import org.websoso.WSSServer.library.domain.Keyword;
 import org.websoso.WSSServer.library.domain.UserNovel;
+import org.websoso.WSSServer.library.domain.UserNovelKeyword;
+import org.websoso.WSSServer.library.service.LibraryService;
 import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.novel.domain.NovelGenre;
 import org.websoso.WSSServer.novel.service.GenreServiceImpl;
 import org.websoso.WSSServer.novel.service.KeywordServiceImpl;
 import org.websoso.WSSServer.novel.service.NovelServiceImpl;
+import org.websoso.WSSServer.repository.GenrePreferenceRepository;
 
 @Service
 @RequiredArgsConstructor
 public class SearchNovelApplication {
 
+    private static final int ATTRACTIVE_POINT_SIZE = 3;
+    private static final int KEYWORD_SIZE = 5;
+
     private final NovelServiceImpl novelService;
     private final GenreServiceImpl genreService;
     private final KeywordServiceImpl keywordService;
+    private final LibraryService libraryService;
+
+    // TODO: 삭제될 레포지토리 의존성
+    private final FeedRepository feedRepository;
+    private final GenrePreferenceRepository genrePreferenceRepository;
 
     /**
      * 검색어(소셜명, 작가명)에 해당하는 소설 찾기
@@ -70,6 +99,61 @@ public class SearchNovelApplication {
         return FilteredNovelsGetResponse.of(novels.getTotalElements(), novels.hasNext(), novelGetResponsePreviews);
     }
 
+    @Transactional(readOnly = true)
+    public NovelGetResponseBasic getNovelInfoBasic(User user, Long novelId) {
+        Novel novel = novelService.getNovelOrException(novelId);
+
+        // TODO: Novel에 List<NovelGenre> 있는데 굳이?
+        List<NovelGenre> novelGenres = novelService.getGenresByNovel(novel);
+
+        int novelRatingCount = libraryService.getRatingCount(novel);
+
+        Float novelRating = novelRatingCount == 0 ? 0.0f
+                : Math.round(libraryService.getRatingSum(novel) / novelRatingCount * 10.0f) / 10.0f;
+        return NovelGetResponseBasic.of(
+                novel,
+                libraryService.getUserNovelOrNull(user, novel),
+                getNovelGenreNames(novelGenres),
+                getRandomNovelGenreImage(novelGenres),
+                libraryService.getInterestCount(novel),
+                novelRating,
+                novelRatingCount,
+                feedRepository.countByNovelId(novelId)
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public NovelGetResponseInfoTab getNovelInfoInfoTab(Long novelId) {
+        Novel novel = novelService.getNovelOrException(novelId);
+
+        return NovelGetResponseInfoTab.of(
+                novel,
+                novelService.getPlatforms(novel),
+                getAttractivePoints(novel),
+                getKeywords2(novel),
+                libraryService.getWatchingCount(novel),
+                libraryService.getWatchedCount(novel),
+                libraryService.getQuitCount(novel)
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public TasteNovelsGetResponse getTasteNovels(User user) {
+        // TODO: 선호하는 장르 리스트는 유저에서 가져오도록 해야함
+        List<Genre> preferGenres = genrePreferenceRepository.findByUser(user)
+                .stream()
+                .map(GenrePreference::getGenre)
+                .toList();
+
+        List<Novel> tasteNovels = libraryService.getTasteNovels(preferGenres);
+
+        List<TasteNovelGetResponse> tasteNovelGetResponses = tasteNovels.stream()
+                .map(TasteNovelGetResponse::of)
+                .toList();
+
+        return TasteNovelsGetResponse.of(tasteNovelGetResponses);
+    }
+
     private NovelGetResponsePreview convertToDTO(Novel novel) {
         // TODO: UserNovel 리스트 개수를 세는것이 아닌, 개수를 세는 쿼리가 필요
         List<UserNovel> userNovels = novel.getUserNovels();
@@ -97,6 +181,7 @@ public class SearchNovelApplication {
         );
     }
 
+    // TODO: for 문으로 장르를 데이터베이스에서 읽어오는 부분 개선해야함
     private List<Genre> getGenres(List<String> genreNames) {
         genreNames = genreNames == null
                 ? Collections.emptyList()
@@ -112,6 +197,7 @@ public class SearchNovelApplication {
         return genres;
     }
 
+    // TODO: for 문으로 키워드를 데이터베이스에서 읽어오는 부분 개선해야함
     private List<Keyword> getKeywords(List<Integer> keywordIds) {
         keywordIds = keywordIds == null
                 ? Collections.emptyList()
@@ -126,5 +212,102 @@ public class SearchNovelApplication {
 
         return keywords;
     }
+
+    private List<KeywordCountGetResponse> getKeywords2(Novel novel) {
+        List<UserNovelKeyword> userNovelKeywords = libraryService.getKeywords(novel);
+
+        if (userNovelKeywords.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Map<Keyword, Long> keywordFrequencyMap = userNovelKeywords.stream()
+                .collect(Collectors.groupingBy(UserNovelKeyword::getKeyword, Collectors.counting()));
+
+        return keywordFrequencyMap.entrySet().stream()
+                .sorted(Map.Entry.<Keyword, Long>comparingByValue().reversed())
+                .limit(KEYWORD_SIZE)
+                .map(entry -> KeywordCountGetResponse.of(entry.getKey(), entry.getValue().intValue()))
+                .toList();
+    }
+
+    private String getNovelGenreNames(List<NovelGenre> novelGenres) {
+        return novelGenres.stream()
+                .map(novelGenre -> getKoreanGenreName(novelGenre.getGenre().getGenreName()))
+                .collect(Collectors.joining("/"));
+    }
+
+    private String getKoreanGenreName(String englishGenreName) {
+        return Arrays.stream(GenreName.values())
+                .filter(genreName -> genreName.getLabel().equalsIgnoreCase(englishGenreName))
+                .findFirst()
+                .map(GenreName::getKoreanLabel)
+                .orElseThrow(
+                        () -> new CustomGenreException(GENRE_NOT_FOUND, "Genre with the given genreName is not found"));
+    }
+
+    private String getRandomNovelGenreImage(List<NovelGenre> novelGenres) {
+        Random random = new Random();
+        return novelGenres.get(random.nextInt(novelGenres.size())).getGenre().getGenreImage();
+    }
+
+
+    private List<String> getAttractivePoints(Novel novel) {
+        Map<String, Integer> attractivePointMap = makeAttractivePointMapExcludingZero(novel);
+
+        if (attractivePointMap.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return getTOP3AttractivePoints(attractivePointMap);
+    }
+
+    private Map<String, Integer> makeAttractivePointMapExcludingZero(Novel novel) {
+        Map<String, Integer> attractivePointMap = new HashMap<>();
+
+        for (AttractivePointName point : AttractivePointName.values()) {
+            attractivePointMap.put(point.getLabel(), libraryService.getAttractivePointCount(novel, point));
+        }
+
+        attractivePointMap.entrySet().removeIf(entry -> entry.getValue() == 0);
+
+        return attractivePointMap;
+    }
+
+    private List<String> getTOP3AttractivePoints(Map<String, Integer> attractivePointMap) {
+        Map<Integer, List<String>> groupedByValue = groupAttractivePointByValue(attractivePointMap);
+
+        List<String> result = new ArrayList<>();
+        List<Integer> sortedKeys = new ArrayList<>(groupedByValue.keySet());
+        sortedKeys.sort(Collections.reverseOrder());
+
+        Random random = new Random();
+
+        for (Integer key : sortedKeys) {
+            List<String> items = groupedByValue.get(key);
+            if (result.size() + items.size() > ATTRACTIVE_POINT_SIZE) {
+                Collections.shuffle(items, random);
+                items = items.subList(0, ATTRACTIVE_POINT_SIZE - result.size());
+            }
+            result.addAll(items);
+            if (result.size() >= ATTRACTIVE_POINT_SIZE) {
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    private Map<Integer, List<String>> groupAttractivePointByValue(Map<String, Integer> attractivePointMap) {
+        Map<Integer, List<String>> groupedByValue = new HashMap<>();
+
+        for (Map.Entry<String, Integer> entry : attractivePointMap.entrySet()) {
+            groupedByValue
+                    .computeIfAbsent(entry.getValue(), k -> new ArrayList<>())
+                    .add(entry.getKey());
+        }
+
+        return groupedByValue;
+    }
+
 
 }

--- a/src/main/java/org/websoso/WSSServer/controller/LibraryController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/LibraryController.java
@@ -1,0 +1,58 @@
+package org.websoso.WSSServer.controller;
+
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.library.service.LibraryService;
+
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class LibraryController {
+
+    private final LibraryService libraryService;
+
+    /**
+     * 관심있어요 등록
+     *
+     * @param user    로그인 유저 객체
+     * @param novelId 소설 ID
+     * @return 204 NO_CONTENT
+     */
+    @PostMapping("/novels/{novelId}/is-interest")
+    @PreAuthorize("isAuthenticated() and @authorizationService.validate(#novelId, #user, T(org.websoso.WSSServer.novel.domain.Novel))")
+    public ResponseEntity<Void> registerAsInterest(@AuthenticationPrincipal User user,
+                                                   @PathVariable("novelId") Long novelId) {
+        libraryService.registerAsInterest(user, novelId);
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
+    }
+
+    /**
+     * 관심있어요 삭제
+     *
+     * @param user    로그인 유저 객체
+     * @param novelId 소설 ID
+     * @return 204 NO_CONTENT
+     */
+    @DeleteMapping("/novels/{novelId}/is-interest")
+    @PreAuthorize("isAuthenticated() and @authorizationService.validate(#novelId, #user, T(org.websoso.WSSServer.library.domain.UserNovel))")
+    public ResponseEntity<Void> unregisterAsInterest(@AuthenticationPrincipal User user,
+                                                     @PathVariable("novelId") Long novelId) {
+        libraryService.unregisterAsInterest(user, novelId);
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
+    }
+
+}

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -1,6 +1,5 @@
 package org.websoso.WSSServer.controller;
 
-import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.util.List;
@@ -8,10 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -53,6 +50,17 @@ public class NovelController {
                 .body(searchNovelApplication.searchNovels(query, page, size));
     }
 
+    /**
+     * 상세 탐색 API
+     *
+     * @param genres      장르 리스트
+     * @param isCompleted 완결 여부
+     * @param novelRating 소설 평점
+     * @param keywordIds  키워드 리스트
+     * @param page        페이지
+     * @param size        사이즈
+     * @return FilteredNovelsGetResponse
+     */
     @GetMapping("/filtered")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<FilteredNovelsGetResponse> getFilteredNovels(
@@ -68,6 +76,34 @@ public class NovelController {
                         size));
     }
 
+    /**
+     * 작품정보 조회 API (기본)
+     *
+     * @param user    로그인 유저 객체
+     * @param novelId 소설 ID
+     * @return NovelGetResponseBasic
+     */
+    @GetMapping("/{novelId}")
+    public ResponseEntity<NovelGetResponseBasic> getNovelInfoBasic(@AuthenticationPrincipal User user,
+                                                                   @PathVariable Long novelId) {
+        return ResponseEntity
+                .status(OK)
+                .body(searchNovelApplication.getNovelInfoBasic(user, novelId));
+    }
+
+    /**
+     * 작품정보 조회 API (정보탭)
+     *
+     * @param novelId 소설 ID
+     * @return NovelGetResponseInfoTab
+     */
+    @GetMapping("/{novelId}/info")
+    public ResponseEntity<NovelGetResponseInfoTab> getNovelInfoInfoTab(@PathVariable Long novelId) {
+        return ResponseEntity
+                .status(OK)
+                .body(searchNovelApplication.getNovelInfoInfoTab(novelId));
+    }
+
     @GetMapping("/popular")
     public ResponseEntity<PopularNovelsGetResponse> getTodayPopularNovels(@AuthenticationPrincipal User user) {
         //TODO 차단 관계에 있는 유저의 피드글 처리
@@ -81,24 +117,10 @@ public class NovelController {
     public ResponseEntity<TasteNovelsGetResponse> getTasteNovels(@AuthenticationPrincipal User user) {
         return ResponseEntity
                 .status(OK)
-                .body(novelService.getTasteNovels(user));
+                .body(searchNovelApplication.getTasteNovels(user));
     }
 
-    @GetMapping("/{novelId}")
-    public ResponseEntity<NovelGetResponseBasic> getNovelInfoBasic(@AuthenticationPrincipal User user,
-                                                                   @PathVariable Long novelId) {
-        return ResponseEntity
-                .status(OK)
-                .body(novelService.getNovelInfoBasic(user, novelId));
-    }
-
-    @GetMapping("/{novelId}/info")
-    public ResponseEntity<NovelGetResponseInfoTab> getNovelInfoInfoTab(@PathVariable Long novelId) {
-        return ResponseEntity
-                .status(OK)
-                .body(novelService.getNovelInfoInfoTab(novelId));
-    }
-
+    // TODO: Feed Controller로 이동해야함
     @GetMapping("/{novelId}/feeds")
     public ResponseEntity<NovelGetResponseFeedTab> getFeedsByNovel(@AuthenticationPrincipal User user,
                                                                    @PathVariable Long novelId,
@@ -107,25 +129,5 @@ public class NovelController {
         return ResponseEntity
                 .status(OK)
                 .body(feedService.getFeedsByNovel(user, novelId, lastFeedId, size));
-    }
-
-    @PostMapping("/{novelId}/is-interest")
-    @PreAuthorize("isAuthenticated() and @authorizationService.validate(#novelId, #user, T(org.websoso.WSSServer.novel.domain.Novel))")
-    public ResponseEntity<Void> registerAsInterest(@AuthenticationPrincipal User user,
-                                                   @PathVariable("novelId") Long novelId) {
-        novelService.registerAsInterest(user, novelId);
-        return ResponseEntity
-                .status(NO_CONTENT)
-                .build();
-    }
-
-    @DeleteMapping("/{novelId}/is-interest")
-    @PreAuthorize("isAuthenticated() and @authorizationService.validate(#novelId, #user, T(org.websoso.WSSServer.library.domain.UserNovel))")
-    public ResponseEntity<Void> unregisterAsInterest(@AuthenticationPrincipal User user,
-                                                     @PathVariable("novelId") Long novelId) {
-        novelService.unregisterAsInterest(user, novelId);
-        return ResponseEntity
-                .status(NO_CONTENT)
-                .build();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/novel/service/NovelService.java
+++ b/src/main/java/org/websoso/WSSServer/novel/service/NovelService.java
@@ -1,90 +1,39 @@
 package org.websoso.WSSServer.novel.service;
 
-import static org.websoso.WSSServer.domain.common.ReadStatus.QUIT;
-import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHED;
-import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHING;
-import static org.websoso.WSSServer.exception.error.CustomGenreError.GENRE_NOT_FOUND;
-import static org.websoso.WSSServer.exception.error.CustomNovelError.NOVEL_NOT_FOUND;
-import static org.websoso.WSSServer.exception.error.CustomUserNovelError.ALREADY_INTERESTED;
-import static org.websoso.WSSServer.exception.error.CustomUserNovelError.NOT_INTERESTED;
 
+import static org.websoso.WSSServer.exception.error.CustomNovelError.NOVEL_NOT_FOUND;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Avatar;
 import org.websoso.WSSServer.feed.domain.Feed;
-import org.websoso.WSSServer.domain.Genre;
-import org.websoso.WSSServer.domain.GenrePreference;
-import org.websoso.WSSServer.library.domain.Keyword;
 import org.websoso.WSSServer.novel.domain.Novel;
-import org.websoso.WSSServer.novel.domain.NovelGenre;
 import org.websoso.WSSServer.domain.PopularNovel;
-import org.websoso.WSSServer.domain.User;
-import org.websoso.WSSServer.library.domain.UserNovel;
-import org.websoso.WSSServer.library.domain.UserNovelKeyword;
-import org.websoso.WSSServer.domain.common.AttractivePointName;
-import org.websoso.WSSServer.domain.common.GenreName;
-import org.websoso.WSSServer.dto.keyword.KeywordCountGetResponse;
-import org.websoso.WSSServer.dto.novel.FilteredNovelsGetResponse;
-import org.websoso.WSSServer.dto.novel.NovelGetResponseBasic;
-import org.websoso.WSSServer.dto.novel.NovelGetResponseInfoTab;
-import org.websoso.WSSServer.dto.novel.NovelGetResponsePreview;
-import org.websoso.WSSServer.dto.novel.SearchedNovelsGetResponse;
-import org.websoso.WSSServer.dto.platform.PlatformGetResponse;
 import org.websoso.WSSServer.dto.popularNovel.PopularNovelGetResponse;
 import org.websoso.WSSServer.dto.popularNovel.PopularNovelsGetResponse;
-import org.websoso.WSSServer.dto.userNovel.TasteNovelGetResponse;
-import org.websoso.WSSServer.dto.userNovel.TasteNovelsGetResponse;
-import org.websoso.WSSServer.exception.exception.CustomGenreException;
 import org.websoso.WSSServer.exception.exception.CustomNovelException;
-import org.websoso.WSSServer.exception.exception.CustomUserNovelException;
 import org.websoso.WSSServer.repository.AvatarRepository;
 import org.websoso.WSSServer.feed.repository.FeedRepository;
 import org.websoso.WSSServer.repository.GenrePreferenceRepository;
-import org.websoso.WSSServer.novel.repository.NovelGenreRepository;
-import org.websoso.WSSServer.novel.repository.NovelPlatformRepository;
 import org.websoso.WSSServer.novel.repository.NovelRepository;
 import org.websoso.WSSServer.repository.PopularNovelRepository;
-import org.websoso.WSSServer.library.repository.UserNovelAttractivePointRepository;
-import org.websoso.WSSServer.library.repository.UserNovelKeywordRepository;
 import org.websoso.WSSServer.library.repository.UserNovelRepository;
-import org.websoso.WSSServer.service.GenreService;
-import org.websoso.WSSServer.library.service.KeywordService;
-import org.websoso.WSSServer.library.service.UserNovelService;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class NovelService {
 
-    private static final int ATTRACTIVE_POINT_SIZE = 3;
-    private static final int KEYWORD_SIZE = 5;
-
     private final NovelRepository novelRepository;
-    private final UserNovelService userNovelService;
-    private final UserNovelRepository userNovelRepository;
-    private final NovelPlatformRepository novelPlatformRepository;
-    private final UserNovelAttractivePointRepository userNovelAttractivePointRepository;
     private final FeedRepository feedRepository;
-    private final NovelGenreRepository novelGenreRepository;
-    private final UserNovelKeywordRepository userNovelKeywordRepository;
-    private final KeywordService keywordService;
-    private final GenreService genreService;
     private final PopularNovelRepository popularNovelRepository;
     private final AvatarRepository avatarRepository;
-    private final GenrePreferenceRepository genrePreferenceRepository;
 
     @Transactional(readOnly = true)
     public Novel getNovelOrException(Long novelId) {
@@ -93,271 +42,6 @@ public class NovelService {
                         "novel with the given id is not found"));
     }
 
-    //이건 상위 계층에서 처리
-    @Transactional(readOnly = true)
-    public NovelGetResponseBasic getNovelInfoBasic(User user, Long novelId) {
-        Novel novel = getNovelOrException(novelId);
-        List<NovelGenre> novelGenres = novelGenreRepository.findAllByNovel(novel);
-        Integer novelRatingCount = userNovelRepository.countByNovelAndUserNovelRatingNot(novel, 0.0f);
-        Float novelRating = novelRatingCount == 0 ? 0.0f
-                : Math.round(userNovelRepository.sumUserNovelRatingByNovel(novel) / novelRatingCount * 10.0f) / 10.0f;
-        return NovelGetResponseBasic.of(
-                novel,
-                userNovelService.getUserNovelOrNull(user, novel),
-                getNovelGenreNames(novelGenres),
-                getRandomNovelGenreImage(novelGenres),
-                userNovelRepository.countByNovelAndIsInterestTrue(novel),
-                novelRating,
-                novelRatingCount,
-                feedRepository.countByNovelId(novelId)
-        );
-    }
-
-    private String getNovelGenreNames(List<NovelGenre> novelGenres) {
-        return novelGenres.stream()
-                .map(novelGenre -> getKoreanGenreName(novelGenre.getGenre().getGenreName()))
-                .collect(Collectors.joining("/"));
-    }
-
-    private String getKoreanGenreName(String englishGenreName) {
-        return Arrays.stream(GenreName.values())
-                .filter(genreName -> genreName.getLabel().equalsIgnoreCase(englishGenreName))
-                .findFirst()
-                .map(GenreName::getKoreanLabel)
-                .orElseThrow(
-                        () -> new CustomGenreException(GENRE_NOT_FOUND, "Genre with the given genreName is not found"));
-    }
-
-    private String getRandomNovelGenreImage(List<NovelGenre> novelGenres) {
-        Random random = new Random();
-        return novelGenres.get(random.nextInt(novelGenres.size())).getGenre().getGenreImage();
-    }
-
-    public void registerAsInterest(User user, Long novelId) {
-        Novel novel = getNovelOrException(novelId);
-        UserNovel userNovel = userNovelService.getUserNovelOrNull(user, novel);
-
-        if (userNovel != null && userNovel.getIsInterest()) {
-            throw new CustomUserNovelException(ALREADY_INTERESTED, "already registered as interested");
-        }
-
-        if (userNovel == null) {
-            try {
-                userNovel = userNovelService.createUserNovelByInterest(user, novel);
-            } catch (DataIntegrityViolationException e) {
-                userNovel = userNovelService.getUserNovelOrException(user, novelId);
-            }
-        }
-
-        userNovel.setIsInterest(true);
-    }
-
-    public void unregisterAsInterest(User user, Long novelId) {
-        UserNovel userNovel = userNovelService.getUserNovelOrException(user, novelId);
-
-        if (!userNovel.getIsInterest()) {
-            throw new CustomUserNovelException(NOT_INTERESTED, "not registered as interest");
-        }
-
-        userNovel.setIsInterest(false);
-
-        if (isUserNovelOnlyByInterest(userNovel)) {
-            userNovelRepository.delete(userNovel);
-        }
-
-    }
-
-    private Boolean isUserNovelOnlyByInterest(UserNovel userNovel) {
-        return userNovel.getStatus() == null;
-    }
-
-    @Transactional(readOnly = true)
-    public NovelGetResponseInfoTab getNovelInfoInfoTab(Long novelId) {
-        Novel novel = getNovelOrException(novelId);
-        return NovelGetResponseInfoTab.of(
-                novel,
-                getPlatforms(novel),
-                getAttractivePoints(novel),
-                getKeywords(novel),
-                userNovelRepository.countByNovelAndStatus(novel, WATCHING),
-                userNovelRepository.countByNovelAndStatus(novel, WATCHED),
-                userNovelRepository.countByNovelAndStatus(novel, QUIT)
-        );
-    }
-
-    private List<PlatformGetResponse> getPlatforms(Novel novel) {
-        return novelPlatformRepository.findAllByNovel(novel).stream()
-                .map(PlatformGetResponse::of)
-                .collect(Collectors.toList());
-    }
-
-    private List<String> getAttractivePoints(Novel novel) {
-        Map<String, Integer> attractivePointMap = makeAttractivePointMapExcludingZero(novel);
-
-        if (attractivePointMap.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        return getTOP3AttractivePoints(attractivePointMap);
-    }
-
-    private Map<String, Integer> makeAttractivePointMapExcludingZero(Novel novel) {
-        Map<String, Integer> attractivePointMap = new HashMap<>();
-
-        for (AttractivePointName point : AttractivePointName.values()) {
-            attractivePointMap.put(point.getLabel(),
-                    userNovelAttractivePointRepository.countByUserNovel_NovelAndAttractivePoint_AttractivePointName(
-                            novel, point.getLabel()));
-        }
-
-        attractivePointMap.entrySet().removeIf(entry -> entry.getValue() == 0);
-
-        return attractivePointMap;
-    }
-
-    private List<String> getTOP3AttractivePoints(Map<String, Integer> attractivePointMap) {
-        Map<Integer, List<String>> groupedByValue = groupAttractivePointByValue(attractivePointMap);
-
-        List<String> result = new ArrayList<>();
-        List<Integer> sortedKeys = new ArrayList<>(groupedByValue.keySet());
-        Collections.sort(sortedKeys, Collections.reverseOrder());
-
-        Random random = new Random();
-
-        for (Integer key : sortedKeys) {
-            List<String> items = groupedByValue.get(key);
-            if (result.size() + items.size() > ATTRACTIVE_POINT_SIZE) {
-                Collections.shuffle(items, random);
-                items = items.subList(0, ATTRACTIVE_POINT_SIZE - result.size());
-            }
-            result.addAll(items);
-            if (result.size() >= ATTRACTIVE_POINT_SIZE) {
-                break;
-            }
-        }
-
-        return result;
-    }
-
-    private Map<Integer, List<String>> groupAttractivePointByValue(Map<String, Integer> attractivePointMap) {
-        Map<Integer, List<String>> groupedByValue = new HashMap<>();
-
-        for (Map.Entry<String, Integer> entry : attractivePointMap.entrySet()) {
-            groupedByValue
-                    .computeIfAbsent(entry.getValue(), k -> new ArrayList<>())
-                    .add(entry.getKey());
-        }
-
-        return groupedByValue;
-    }
-
-    private List<KeywordCountGetResponse> getKeywords(Novel novel) {
-        List<UserNovelKeyword> userNovelKeywords = userNovelKeywordRepository.findAllByUserNovel_Novel(novel);
-
-        if (userNovelKeywords.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        Map<Keyword, Long> keywordFrequencyMap = userNovelKeywords.stream()
-                .collect(Collectors.groupingBy(UserNovelKeyword::getKeyword, Collectors.counting()));
-
-        return keywordFrequencyMap.entrySet().stream()
-                .sorted(Map.Entry.<Keyword, Long>comparingByValue().reversed())
-                .limit(KEYWORD_SIZE)
-                .map(entry -> KeywordCountGetResponse.of(entry.getKey(), entry.getValue().intValue()))
-                .collect(Collectors.toList());
-    }
-
-    @Transactional(readOnly = true)
-    public FilteredNovelsGetResponse getFilteredNovels(List<String> genreNames, Boolean isCompleted, Float novelRating,
-                                                       List<Integer> keywordIds, int page, int size) {
-        PageRequest pageRequest = PageRequest.of(page, size);
-        List<Genre> genres = getGenres(genreNames);
-        List<Keyword> keywords = getKeywords(keywordIds);
-
-        Page<Novel> novels = novelRepository.findFilteredNovels(pageRequest, genres, isCompleted, novelRating,
-                keywords);
-
-        List<NovelGetResponsePreview> novelGetResponsePreviews = novels.stream()
-                .map(this::convertToDTO)
-                .collect(Collectors.toList());
-
-        return FilteredNovelsGetResponse.of(novels.getTotalElements(), novels.hasNext(), novelGetResponsePreviews);
-    }
-
-    @Transactional(readOnly = true)
-    public SearchedNovelsGetResponse searchNovels(String query, int page, int size) {
-        PageRequest pageRequest = PageRequest.of(page, size);
-        String searchQuery = query.replaceAll("\\s+", "").replaceAll("[^a-zA-Z0-9가-힣]", "");
-
-        if (searchQuery.isBlank()) {
-            return SearchedNovelsGetResponse.of(0L, false, Collections.emptyList());
-        }
-
-        Page<Novel> novels = novelRepository.findSearchedNovels(pageRequest, searchQuery);
-
-        List<NovelGetResponsePreview> novelGetResponsePreviews = novels.stream()
-                .map(this::convertToDTO)
-                .collect(Collectors.toList());
-
-        return SearchedNovelsGetResponse.of(novels.getTotalElements(), novels.hasNext(), novelGetResponsePreviews);
-    }
-
-    private List<Genre> getGenres(List<String> genreNames) {
-        genreNames = genreNames == null
-                ? Collections.emptyList()
-                : genreNames;
-
-        List<Genre> genres = new ArrayList<>();
-        if (!genreNames.isEmpty()) {
-            for (String genreName : genreNames) {
-                genres.add(genreService.getGenreOrException(genreName));
-            }
-        }
-
-        return genres;
-    }
-
-    private List<Keyword> getKeywords(List<Integer> keywordIds) {
-        keywordIds = keywordIds == null
-                ? Collections.emptyList()
-                : keywordIds;
-
-        List<Keyword> keywords = new ArrayList<>();
-        if (!keywordIds.isEmpty()) {
-            for (Integer keywordId : keywordIds) {
-                keywords.add(keywordService.getKeywordOrException(keywordId));
-            }
-        }
-
-        return keywords;
-    }
-
-    private NovelGetResponsePreview convertToDTO(Novel novel) {
-        List<UserNovel> userNovels = novel.getUserNovels();
-
-        long interestCount = userNovels.stream()
-                .filter(UserNovel::getIsInterest)
-                .count();
-        long novelRatingCount = userNovels.stream()
-                .filter(un -> un.getUserNovelRating() != 0.0f)
-                .count();
-        double novelRatingSum = userNovels.stream()
-                .filter(un -> un.getUserNovelRating() != 0.0f)
-                .mapToDouble(UserNovel::getUserNovelRating)
-                .sum();
-
-        Float novelRatingAverage = novelRatingCount == 0
-                ? 0.0f
-                : Math.round((float) (novelRatingSum / novelRatingCount) * 10.0f) / 10.0f;
-
-        return NovelGetResponsePreview.of(
-                novel,
-                interestCount,
-                novelRatingAverage,
-                novelRatingCount
-        );
-    }
 
     @Transactional(readOnly = true)
     public PopularNovelsGetResponse getTodayPopularNovels() {
@@ -426,19 +110,4 @@ public class NovelService {
         return new PopularNovelsGetResponse(popularNovelResponses);
     }
 
-    @Transactional(readOnly = true)
-    public TasteNovelsGetResponse getTasteNovels(User user) {
-        List<Genre> preferGenres = genrePreferenceRepository.findByUser(user)
-                .stream()
-                .map(GenrePreference::getGenre)
-                .toList();
-
-        List<Novel> tasteNovels = userNovelRepository.findTasteNovels(preferGenres);
-
-        List<TasteNovelGetResponse> tasteNovelGetResponses = tasteNovels.stream()
-                .map(TasteNovelGetResponse::of)
-                .toList();
-
-        return TasteNovelsGetResponse.of(tasteNovelGetResponses);
-    }
 }

--- a/src/main/java/org/websoso/WSSServer/novel/service/NovelServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/service/NovelServiceImpl.java
@@ -9,9 +9,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Genre;
+import org.websoso.WSSServer.dto.platform.PlatformGetResponse;
 import org.websoso.WSSServer.exception.exception.CustomNovelException;
 import org.websoso.WSSServer.library.domain.Keyword;
 import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.novel.domain.NovelGenre;
+import org.websoso.WSSServer.novel.repository.NovelGenreRepository;
+import org.websoso.WSSServer.novel.repository.NovelPlatformRepository;
 import org.websoso.WSSServer.novel.repository.NovelRepository;
 
 @Service
@@ -19,11 +23,14 @@ import org.websoso.WSSServer.novel.repository.NovelRepository;
 public class NovelServiceImpl {
 
     private final NovelRepository novelRepository;
+    private final NovelGenreRepository novelGenreRepository;
+    private final NovelPlatformRepository novelPlatformRepository;
 
     @Transactional(readOnly = true)
-    public Novel getNovel(Long novelId) {
-        return novelRepository.findById(novelId).orElseThrow(() -> new CustomNovelException(NOVEL_NOT_FOUND,
-                "novel with the given id is not found"));
+    public Novel getNovelOrException(Long novelId) {
+        return novelRepository.findById(novelId)
+                .orElseThrow(() -> new CustomNovelException(NOVEL_NOT_FOUND,
+                        "novel with the given id is not found"));
     }
 
     public Page<Novel> searchNovels(PageRequest pageRequest, String searchQuery) {
@@ -34,6 +41,16 @@ public class NovelServiceImpl {
                                           Boolean isCompleted, Float novelRating) {
         return novelRepository.findFilteredNovels(pageRequest, genres, isCompleted, novelRating,
                 keywords);
+    }
+
+    public List<NovelGenre> getGenresByNovel(Novel novel) {
+        return novelGenreRepository.findAllByNovel(novel);
+    }
+
+    public List<PlatformGetResponse> getPlatforms(Novel novel) {
+        return novelPlatformRepository.findAllByNovel(novel).stream()
+                .map(PlatformGetResponse::of)
+                .toList();
     }
 
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/# -> dev
- close #

## Key Changes
<!-- 최대한 자세히 -->
- Novel 내에 포함되어 있는 서재 로직을 분리했습니다.
  - 서재 Service 클래스 생성
  - 서재 Controller 클래스 생성

- Novel에서 사용하는 외부 의존성들은 Application에서 Repository에서 불러오도록 변경해놨습니다.
  - 추후, 내부 API를 작성하면 해당 API를 통해 가져오도록 변경 예정

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
