### PR TITLE
[REFACTOR] 댓글 관련 Application 생성

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/CommentFindApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/CommentFindApplication.java
@@ -1,0 +1,62 @@
+package org.websoso.WSSServer.application;
+
+import static org.websoso.WSSServer.exception.error.CustomAvatarError.AVATAR_NOT_FOUND;
+import static org.websoso.WSSServer.exception.error.CustomUserError.USER_NOT_FOUND;
+
+import java.util.AbstractMap;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.dto.comment.CommentGetResponse;
+import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
+import org.websoso.WSSServer.dto.user.UserBasicInfo;
+import org.websoso.WSSServer.exception.exception.CustomAvatarException;
+import org.websoso.WSSServer.exception.exception.CustomUserException;
+import org.websoso.WSSServer.feed.domain.Feed;
+import org.websoso.WSSServer.feed.service.FeedServiceImpl;
+import org.websoso.WSSServer.repository.AvatarRepository;
+import org.websoso.WSSServer.repository.BlockRepository;
+import org.websoso.WSSServer.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommentFindApplication {
+
+    private final FeedServiceImpl feedServiceImpl;
+
+    //ToDo : 의존성 제거 필요 부분
+    private final UserRepository userRepository;
+    private final BlockRepository blockRepository;
+    private final AvatarRepository avatarRepository;
+
+    @Transactional(readOnly = true)
+    public CommentsGetResponse getComments(User user, Long feedId) {
+        Feed feed = feedServiceImpl.getFeedOrException(feedId);
+        List<CommentGetResponse> responses = feed.getComments().stream()
+                .map(comment -> new AbstractMap.SimpleEntry<>(comment, userRepository.findById(comment.getUserId())
+                        .orElseThrow(
+                                () -> new CustomUserException(USER_NOT_FOUND, "user with the given id was not found"))))
+                .map(entry -> CommentGetResponse.of(getUserBasicInfo(entry.getValue()), entry.getKey(),
+                        isUserCommentOwner(entry.getValue(), user), entry.getKey().getIsSpoiler(),
+                        isBlocked(user, entry.getValue()), entry.getKey().getIsHidden())).toList();
+
+        return CommentsGetResponse.of(responses);
+    }
+
+    private Boolean isUserCommentOwner(User createdUser, User user) {
+        return createdUser.equals(user);
+    }
+
+    private Boolean isBlocked(User user, User createdFeedUser) {
+        return blockRepository.existsByBlockingIdAndBlockedId(user.getUserId(), createdFeedUser.getUserId());
+    }
+
+    private UserBasicInfo getUserBasicInfo(User user) {
+        return user.getUserBasicInfo(
+                avatarRepository.findById(user.getAvatarId()).orElseThrow(() ->
+                                new CustomAvatarException(AVATAR_NOT_FOUND, "avatar with the given id was not found"))
+                        .getAvatarImage());
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/application/CommentManagementApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/CommentManagementApplication.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.application;
 
 import static java.lang.Boolean.TRUE;
+import static org.websoso.WSSServer.domain.common.Action.DELETE;
 import static org.websoso.WSSServer.domain.common.Action.UPDATE;
 import static org.websoso.WSSServer.exception.error.CustomNovelError.NOVEL_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomUserError.USER_NOT_FOUND;
@@ -156,5 +157,14 @@ public class CommentManagementApplication {
         comment.validateFeedAssociation(feed);
         comment.validateUserAuthorization(user.getUserId(), UPDATE);
         commentServiceImpl.updateComment(comment, request);
+    }
+
+    @Transactional
+    public void deleteComment(User user, Long feedId, Long commentId) {
+        Feed feed = feedServiceImpl.getFeedOrException(feedId);
+        Comment comment = commentServiceImpl.findComment(commentId);
+        comment.validateFeedAssociation(feed);
+        comment.validateUserAuthorization(user.getUserId(), DELETE);
+        commentServiceImpl.deleteComment(comment);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/application/CommentManagementApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/CommentManagementApplication.java
@@ -63,6 +63,7 @@ public class CommentManagementApplication {
             return;
         }
 
+        // ToDo : 해당 로직 NotificationSerivce에서 처리하도록 수정
         NotificationType notificationTypeComment = notificationTypeRepository.findByNotificationTypeName("댓글");
 
         String notificationTitle = createNotificationTitle(feed);
@@ -106,6 +107,7 @@ public class CommentManagementApplication {
             return;
         }
 
+        // ToDo : 해당 로직 NotificationSerivce에서 처리하도록 수정
         NotificationType notificationTypeComment = notificationTypeRepository.findByNotificationTypeName("댓글");
 
         String notificationTitle = createNotificationTitle(feed);

--- a/src/main/java/org/websoso/WSSServer/application/CommentManagementApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/CommentManagementApplication.java
@@ -3,7 +3,6 @@ package org.websoso.WSSServer.application;
 import static java.lang.Boolean.TRUE;
 import static org.websoso.WSSServer.domain.common.Action.DELETE;
 import static org.websoso.WSSServer.domain.common.Action.UPDATE;
-import static org.websoso.WSSServer.exception.error.CustomNovelError.NOVEL_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomUserError.USER_NOT_FOUND;
 
 import java.util.List;
@@ -16,7 +15,6 @@ import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserDevice;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
-import org.websoso.WSSServer.exception.exception.CustomNovelException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
 import org.websoso.WSSServer.feed.domain.Comment;
 import org.websoso.WSSServer.feed.domain.Feed;
@@ -25,7 +23,7 @@ import org.websoso.WSSServer.feed.service.FeedServiceImpl;
 import org.websoso.WSSServer.notification.FCMClient;
 import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
 import org.websoso.WSSServer.novel.domain.Novel;
-import org.websoso.WSSServer.novel.repository.NovelRepository;
+import org.websoso.WSSServer.novel.service.NovelServiceImpl;
 import org.websoso.WSSServer.repository.BlockRepository;
 import org.websoso.WSSServer.repository.NotificationRepository;
 import org.websoso.WSSServer.repository.NotificationTypeRepository;
@@ -37,6 +35,7 @@ public class CommentManagementApplication {
 
     private final CommentServiceImpl commentServiceImpl;
     private final FeedServiceImpl feedServiceImpl;
+    private final NovelServiceImpl novelServiceImpl;
     private final FCMClient fcmClient;
 
     private static final int NOTIFICATION_TITLE_MAX_LENGTH = 12;
@@ -46,7 +45,6 @@ public class CommentManagementApplication {
     private final BlockRepository blockRepository;
     private final NotificationRepository notificationRepository;
     private final NotificationTypeRepository notificationTypeRepository;
-    private final NovelRepository novelRepository;
     private final UserRepository userRepository;
 
     @Transactional
@@ -145,8 +143,7 @@ public class CommentManagementApplication {
                     : feedContent.substring(NOTIFICATION_TITLE_MIN_LENGTH, NOTIFICATION_TITLE_MAX_LENGTH);
             return "'" + feedContent + "...'";
         }
-        Novel novel = novelRepository.findById(feed.getNovelId())
-                .orElseThrow(() -> new CustomNovelException(NOVEL_NOT_FOUND, "novel with the given id is not found"));
+        Novel novel = novelServiceImpl.getNovelOrException(feed.getNovelId());
         return novel.getTitle();
     }
 

--- a/src/main/java/org/websoso/WSSServer/application/CommentManagementApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/CommentManagementApplication.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.application;
 
 import static java.lang.Boolean.TRUE;
+import static org.websoso.WSSServer.domain.common.Action.UPDATE;
 import static org.websoso.WSSServer.exception.error.CustomNovelError.NOVEL_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomUserError.USER_NOT_FOUND;
 
@@ -13,6 +14,7 @@ import org.websoso.WSSServer.domain.NotificationType;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.domain.UserDevice;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
+import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
 import org.websoso.WSSServer.exception.exception.CustomNovelException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
 import org.websoso.WSSServer.feed.domain.Comment;
@@ -143,5 +145,14 @@ public class CommentManagementApplication {
         Novel novel = novelRepository.findById(feed.getNovelId())
                 .orElseThrow(() -> new CustomNovelException(NOVEL_NOT_FOUND, "novel with the given id is not found"));
         return novel.getTitle();
+    }
+
+    @Transactional
+    public void updateComment(User user, Long feedId, Long commentId, CommentUpdateRequest request) {
+        Feed feed = feedServiceImpl.getFeedOrException(feedId);
+        Comment comment = commentServiceImpl.findComment(commentId);
+        comment.validateFeedAssociation(feed);
+        comment.validateUserAuthorization(user.getUserId(), UPDATE);
+        commentServiceImpl.updateComment(comment, request);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/application/CommentManagementApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/CommentManagementApplication.java
@@ -1,0 +1,147 @@
+package org.websoso.WSSServer.application;
+
+import static java.lang.Boolean.TRUE;
+import static org.websoso.WSSServer.exception.error.CustomNovelError.NOVEL_NOT_FOUND;
+import static org.websoso.WSSServer.exception.error.CustomUserError.USER_NOT_FOUND;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.domain.Notification;
+import org.websoso.WSSServer.domain.NotificationType;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.domain.UserDevice;
+import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
+import org.websoso.WSSServer.exception.exception.CustomNovelException;
+import org.websoso.WSSServer.exception.exception.CustomUserException;
+import org.websoso.WSSServer.feed.domain.Comment;
+import org.websoso.WSSServer.feed.domain.Feed;
+import org.websoso.WSSServer.feed.service.CommentServiceImpl;
+import org.websoso.WSSServer.feed.service.FeedServiceImpl;
+import org.websoso.WSSServer.notification.FCMClient;
+import org.websoso.WSSServer.notification.dto.FCMMessageRequest;
+import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.novel.repository.NovelRepository;
+import org.websoso.WSSServer.repository.BlockRepository;
+import org.websoso.WSSServer.repository.NotificationRepository;
+import org.websoso.WSSServer.repository.NotificationTypeRepository;
+import org.websoso.WSSServer.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommentManagementApplication {
+
+    private final CommentServiceImpl commentServiceImpl;
+    private final FeedServiceImpl feedServiceImpl;
+    private final FCMClient fcmClient;
+
+    private static final int NOTIFICATION_TITLE_MAX_LENGTH = 12;
+    private static final int NOTIFICATION_TITLE_MIN_LENGTH = 0;
+
+    //ToDo : 의존성 제거 필요 부분
+    private final BlockRepository blockRepository;
+    private final NotificationRepository notificationRepository;
+    private final NotificationTypeRepository notificationTypeRepository;
+    private final NovelRepository novelRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void createComment(User user, Long feedId, CommentCreateRequest request) {
+        Feed feed = feedServiceImpl.getFeedOrException(feedId);
+        commentServiceImpl.createComment(user, feed, request);
+        sendCommentPushMessageToFeedOwner(user, feed);
+        sendCommentPushMessageToCommenters(user, feed);
+    }
+
+    private void sendCommentPushMessageToFeedOwner(User user, Feed feed) {
+        User feedOwner = feed.getUser();
+        if (user.equals(feedOwner) || blockRepository.existsByBlockingIdAndBlockedId(feedOwner.getUserId(),
+                user.getUserId())) {
+            return;
+        }
+
+        NotificationType notificationTypeComment = notificationTypeRepository.findByNotificationTypeName("댓글");
+
+        String notificationTitle = createNotificationTitle(feed);
+        String notificationBody = String.format("%s님이 내 글에 댓글을 남겼어요.", user.getNickname());
+        Long feedId = feed.getFeedId();
+
+        Notification notification = Notification.create(notificationTitle, notificationBody, null,
+                feedOwner.getUserId(), feedId, notificationTypeComment);
+        notificationRepository.save(notification);
+
+        if (!TRUE.equals(feedOwner.getIsPushEnabled())) {
+            return;
+        }
+
+        List<UserDevice> feedOwnerDevices = feedOwner.getUserDevices();
+        if (feedOwnerDevices.isEmpty()) {
+            return;
+        }
+
+        FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(notificationTitle, notificationBody,
+                String.valueOf(feedId), "feedDetail", String.valueOf(notification.getNotificationId()));
+
+        List<String> targetFCMTokens = feedOwnerDevices.stream().map(UserDevice::getFcmToken).toList();
+
+        fcmClient.sendMulticastPushMessage(targetFCMTokens, fcmMessageRequest);
+    }
+
+    private void sendCommentPushMessageToCommenters(User user, Feed feed) {
+        User feedOwner = feed.getUser();
+
+        List<User> commenters = feed.getComments().stream().map(Comment::getUserId)
+                .filter(userId -> !userId.equals(user.getUserId()))
+                .filter(userId -> !userId.equals(feedOwner.getUserId()))
+                .filter(userId -> !blockRepository.existsByBlockingIdAndBlockedId(userId, user.getUserId())
+                        && !blockRepository.existsByBlockingIdAndBlockedId(userId, feed.getUser().getUserId()))
+                .distinct().map(userId -> userRepository.findById(userId).orElseThrow(
+                        () -> new CustomUserException(USER_NOT_FOUND, "user with the given id was not found")))
+                .toList();
+
+        if (commenters.isEmpty()) {
+            return;
+        }
+
+        NotificationType notificationTypeComment = notificationTypeRepository.findByNotificationTypeName("댓글");
+
+        String notificationTitle = createNotificationTitle(feed);
+        String notificationBody = "내가 댓글 단 글에 또 다른 댓글이 달렸어요.";
+        Long feedId = feed.getFeedId();
+
+        commenters.forEach(commenter -> {
+            Notification notification = Notification.create(notificationTitle, notificationBody, null,
+                    commenter.getUserId(), feedId, notificationTypeComment);
+            notificationRepository.save(notification);
+
+            if (!TRUE.equals(commenter.getIsPushEnabled())) {
+                return;
+            }
+
+            List<UserDevice> commenterDevices = commenter.getUserDevices();
+            if (commenterDevices.isEmpty()) {
+                return;
+            }
+
+            List<String> targetFCMTokens = commenterDevices.stream().map(UserDevice::getFcmToken).distinct().toList();
+
+            FCMMessageRequest fcmMessageRequest = FCMMessageRequest.of(notificationTitle, notificationBody,
+                    String.valueOf(feedId), "feedDetail", String.valueOf(notification.getNotificationId()));
+            fcmClient.sendMulticastPushMessage(targetFCMTokens, fcmMessageRequest);
+        });
+    }
+
+
+    private String createNotificationTitle(Feed feed) {
+        if (feed.getNovelId() == null) {
+            String feedContent = feed.getFeedContent();
+            feedContent = feedContent.length() <= NOTIFICATION_TITLE_MAX_LENGTH ? feedContent
+                    : feedContent.substring(NOTIFICATION_TITLE_MIN_LENGTH, NOTIFICATION_TITLE_MAX_LENGTH);
+            return "'" + feedContent + "...'";
+        }
+        Novel novel = novelRepository.findById(feed.getNovelId())
+                .orElseThrow(() -> new CustomNovelException(NOVEL_NOT_FOUND, "novel with the given id is not found"));
+        return novel.getTitle();
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/feed/controller/CommentController.java
+++ b/src/main/java/org/websoso/WSSServer/feed/controller/CommentController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.websoso.WSSServer.application.CommentManagementApplication;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
@@ -28,12 +29,13 @@ import org.websoso.WSSServer.feed.service.CommentService;
 public class CommentController {
 
     private final CommentService commentService;
+    private final CommentManagementApplication commentManagementApplication;
 
     @PostMapping("/{feedId}/comments")
     @PreAuthorize("isAuthenticated() and @feedAccessValidator.canAccess(#feedId, #user)")
     public ResponseEntity<Void> createComment(@AuthenticationPrincipal User user, @PathVariable("feedId") Long feedId,
                                               @Valid @RequestBody CommentCreateRequest request) {
-        commentService.createComment(user, feedId, request);
+        commentManagementApplication.createComment(user, feedId, request);
         return ResponseEntity.status(NO_CONTENT).build();
     }
 

--- a/src/main/java/org/websoso/WSSServer/feed/controller/CommentController.java
+++ b/src/main/java/org/websoso/WSSServer/feed/controller/CommentController.java
@@ -16,20 +16,20 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.websoso.WSSServer.application.CommentFindApplication;
 import org.websoso.WSSServer.application.CommentManagementApplication;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
 import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
 import org.websoso.WSSServer.dto.comment.CommentsGetResponse;
-import org.websoso.WSSServer.feed.service.CommentService;
 
 @RequestMapping("/feeds")
 @RestController
 @RequiredArgsConstructor
 public class CommentController {
 
-    private final CommentService commentService;
     private final CommentManagementApplication commentManagementApplication;
+    private final CommentFindApplication commentFindApplication;
 
     @PostMapping("/{feedId}/comments")
     @PreAuthorize("isAuthenticated() and @feedAccessValidator.canAccess(#feedId, #user)")
@@ -43,33 +43,25 @@ public class CommentController {
     @PreAuthorize("isAuthenticated() and @feedAccessValidator.canAccess(#feedId, #user)")
     public ResponseEntity<CommentsGetResponse> getComments(@AuthenticationPrincipal User user,
                                                            @PathVariable("feedId") Long feedId) {
-        return ResponseEntity
-                .status(OK)
-                .body(commentService.getComments(user, feedId));
+        return ResponseEntity.status(OK).body(commentFindApplication.getComments(user, feedId));
     }
 
     @PutMapping("/{feedId}/comments/{commentId}")
     @PreAuthorize("isAuthenticated() and @feedAccessValidator.canAccess(#feedId, #user) "
             + "and @authorizationService.validate(#commentId, #user, T(org.websoso.WSSServer.feed.domain.Comment))")
-    public ResponseEntity<Void> updateComment(@AuthenticationPrincipal User user,
-                                              @PathVariable("feedId") Long feedId,
+    public ResponseEntity<Void> updateComment(@AuthenticationPrincipal User user, @PathVariable("feedId") Long feedId,
                                               @PathVariable("commentId") Long commentId,
                                               @Valid @RequestBody CommentUpdateRequest request) {
         commentManagementApplication.updateComment(user, feedId, commentId, request);
-        return ResponseEntity
-                .status(NO_CONTENT)
-                .build();
+        return ResponseEntity.status(NO_CONTENT).build();
     }
 
     @DeleteMapping("/{feedId}/comments/{commentId}")
     @PreAuthorize("isAuthenticated() and @feedAccessValidator.canAccess(#feedId, #user) "
             + "and @authorizationService.validate(#commentId, #user, T(org.websoso.WSSServer.feed.domain.Comment))")
-    public ResponseEntity<Void> deleteComment(@AuthenticationPrincipal User user,
-                                              @PathVariable("feedId") Long feedId,
+    public ResponseEntity<Void> deleteComment(@AuthenticationPrincipal User user, @PathVariable("feedId") Long feedId,
                                               @PathVariable("commentId") Long commentId) {
         commentManagementApplication.deleteComment(user, feedId, commentId);
-        return ResponseEntity
-                .status(NO_CONTENT)
-                .build();
+        return ResponseEntity.status(NO_CONTENT).build();
     }
 }

--- a/src/main/java/org/websoso/WSSServer/feed/controller/CommentController.java
+++ b/src/main/java/org/websoso/WSSServer/feed/controller/CommentController.java
@@ -67,7 +67,7 @@ public class CommentController {
     public ResponseEntity<Void> deleteComment(@AuthenticationPrincipal User user,
                                               @PathVariable("feedId") Long feedId,
                                               @PathVariable("commentId") Long commentId) {
-        commentService.deleteComment(user, feedId, commentId);
+        commentManagementApplication.deleteComment(user, feedId, commentId);
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();

--- a/src/main/java/org/websoso/WSSServer/feed/controller/CommentController.java
+++ b/src/main/java/org/websoso/WSSServer/feed/controller/CommentController.java
@@ -55,7 +55,7 @@ public class CommentController {
                                               @PathVariable("feedId") Long feedId,
                                               @PathVariable("commentId") Long commentId,
                                               @Valid @RequestBody CommentUpdateRequest request) {
-        commentService.updateComment(user, feedId, commentId, request);
+        commentManagementApplication.updateComment(user, feedId, commentId, request);
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();

--- a/src/main/java/org/websoso/WSSServer/feed/service/CommentServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/service/CommentServiceImpl.java
@@ -1,9 +1,14 @@
 package org.websoso.WSSServer.feed.service;
 
+import static org.websoso.WSSServer.exception.error.CustomCommentError.COMMENT_NOT_FOUND;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.User;
 import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
+import org.websoso.WSSServer.dto.comment.CommentUpdateRequest;
+import org.websoso.WSSServer.exception.exception.CustomCommentException;
 import org.websoso.WSSServer.feed.domain.Comment;
 import org.websoso.WSSServer.feed.domain.Feed;
 import org.websoso.WSSServer.feed.repository.CommentRepository;
@@ -14,7 +19,19 @@ public class CommentServiceImpl {
 
     private final CommentRepository commentRepository;
 
+    @Transactional
     public void createComment(User user, Feed feed, CommentCreateRequest request) {
         commentRepository.save(Comment.create(user.getUserId(), feed, request.commentContent()));
+    }
+
+    @Transactional(readOnly = true)
+    public Comment findComment(Long commentId) {
+        return commentRepository.findById(commentId).orElseThrow(
+                () -> new CustomCommentException(COMMENT_NOT_FOUND, "comment with the given id was not found"));
+    }
+
+    @Transactional
+    public void updateComment(Comment comment, CommentUpdateRequest request) {
+        comment.updateContent(request.commentContent());
     }
 }

--- a/src/main/java/org/websoso/WSSServer/feed/service/CommentServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/service/CommentServiceImpl.java
@@ -34,4 +34,9 @@ public class CommentServiceImpl {
     public void updateComment(Comment comment, CommentUpdateRequest request) {
         comment.updateContent(request.commentContent());
     }
+
+    @Transactional
+    public void deleteComment(Comment comment) {
+        commentRepository.delete(comment);
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/feed/service/CommentServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/service/CommentServiceImpl.java
@@ -1,0 +1,20 @@
+package org.websoso.WSSServer.feed.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.websoso.WSSServer.domain.User;
+import org.websoso.WSSServer.dto.comment.CommentCreateRequest;
+import org.websoso.WSSServer.feed.domain.Comment;
+import org.websoso.WSSServer.feed.domain.Feed;
+import org.websoso.WSSServer.feed.repository.CommentRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl {
+
+    private final CommentRepository commentRepository;
+
+    public void createComment(User user, Feed feed, CommentCreateRequest request) {
+        commentRepository.save(Comment.create(user.getUserId(), feed, request.commentContent()));
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/feed/service/FeedServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/service/FeedServiceImpl.java
@@ -1,0 +1,23 @@
+package org.websoso.WSSServer.feed.service;
+
+import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOUND;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.exception.exception.CustomFeedException;
+import org.websoso.WSSServer.feed.domain.Feed;
+import org.websoso.WSSServer.feed.repository.FeedRepository;
+
+@Service
+@RequiredArgsConstructor
+public class FeedServiceImpl {
+
+    private final FeedRepository feedRepository;
+
+    @Transactional(readOnly = true)
+    public Feed getFeedOrException(Long feedId) {
+        return feedRepository.findById(feedId)
+                .orElseThrow(() -> new CustomFeedException(FEED_NOT_FOUND, "feed with the given id was not found"));
+    }
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- refactor/#411 -> refactor/#409
- close #411

## Key Changes
<!-- 최대한 자세히 -->
1. CommentApplication 생성
* CommentFindApplication (댓글 조회), CommentManagementApplication (댓글 관리)로 비즈니스 로직를 분리하여 처리하도록 수정했습니다.
2. CommentServiceImpl 생성
* CommentServiceImpl을 통해 CRUD 작업을 수행하도록 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
* Notification관련 로직을 아에 NotificationService에 위임하면 어떨까 싶습니다.

## References
<!-- 참고한 자료-->
