### PR TITLE
[REFACTOR] 프로필 API 엔드포인트 개편(/profile) 및 아바타 ID 하위 호환성 로직 적용

### DIFF
--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -106,6 +106,7 @@ public class UserController {
                 .body(userService.getProfileInfo(user, userId));
     }
 
+    @Deprecated
     @GetMapping("/my-profile")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<MyProfileResponse> getMyProfileInfo(@AuthenticationPrincipal User user) {
@@ -113,6 +114,15 @@ public class UserController {
                 .status(OK)
                 .body(userService.getMyProfileInfo(user));
     }
+
+    @GetMapping("/profile")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<MyProfileResponse> getProfileInfo(@AuthenticationPrincipal User user) {
+        return ResponseEntity
+                .status(OK)
+                .body(userService.getMyProfileInfo(user));
+    }
+
 
     @Deprecated
     @PatchMapping("/my-profile")

--- a/src/main/java/org/websoso/WSSServer/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/UserController.java
@@ -114,11 +114,23 @@ public class UserController {
                 .body(userService.getMyProfileInfo(user));
     }
 
+    @Deprecated
     @PatchMapping("/my-profile")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Void> updateMyProfileInfo(@AuthenticationPrincipal User user,
                                                     @RequestBody @Valid UpdateMyProfileRequest updateMyProfileRequest) {
         userService.updateMyProfileInfo(user, updateMyProfileRequest);
+        return ResponseEntity
+                .status(NO_CONTENT)
+                .build();
+    }
+
+    @PatchMapping("/profile")
+    @PreAuthorize("isAuthenticated()")
+    @Deprecated
+    public ResponseEntity<Void> updateProfileInfo(@AuthenticationPrincipal User user,
+                                                    @RequestBody @Valid UpdateMyProfileRequest updateMyProfileRequest) {
+        userService.updateProfileInfo(user, updateMyProfileRequest);
         return ResponseEntity
                 .status(NO_CONTENT)
                 .build();

--- a/src/main/java/org/websoso/WSSServer/dto/user/UpdateMyProfileRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/UpdateMyProfileRequest.java
@@ -17,4 +17,18 @@ public record UpdateMyProfileRequest(
         @NotNull(message = "선호 장르는 null일 수 없습니다.")
         List<String> genrePreferences
 ) {
+    @Deprecated
+    public Long getMappedAvatarId() {
+        if (this.avatarId == null) {
+            return null;
+        }
+
+        return switch (this.avatarId.intValue()) {
+            case 1 -> 1L;
+            case 2 -> 4L;
+            case 3 -> 5L;
+
+            default -> null;
+        };
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/service/AvatarService.java
+++ b/src/main/java/org/websoso/WSSServer/service/AvatarService.java
@@ -50,7 +50,7 @@ public class AvatarService {
         Byte representativeAvatarId = user.getAvatarId();
         List<Avatar> avatars = avatarRepository.findAll();
         List<AvatarGetResponse> avatarGetResponses = avatars.stream()
-                .filter(avatar -> avatar.getAvatarId() >= 0)
+                .filter(avatar -> 0 <= avatar.getAvatarId() && avatar.getAvatarId() <= 3)
                 .map(avatar -> {
                     List<AvatarLine> avatarLines = avatar.getAvatarLines();
                     return AvatarGetResponse.of(avatar, getRandomAvatarLine(avatarLines), representativeAvatarId);

--- a/src/main/java/org/websoso/WSSServer/user/domain/User.java
+++ b/src/main/java/org/websoso/WSSServer/user/domain/User.java
@@ -122,15 +122,30 @@ public class User extends BaseEntity {
         this.isProfilePublic = profileStatus;
     }
 
+    // TODO: DTO에 의존적인 DDD 로직 (기중)
+    @Deprecated
     public void updateUserProfile(UpdateMyProfileRequest updateMyProfileRequest) {
         if (updateMyProfileRequest.avatarId() != null) {
-            this.avatarProfileId = updateMyProfileRequest.avatarId();
+            this.avatarId = updateMyProfileRequest.avatarId().byteValue();
+            this.avatarProfileId = updateMyProfileRequest.getMappedAvatarId();
         }
         if (updateMyProfileRequest.nickname() != null) {
             this.nickname = updateMyProfileRequest.nickname();
         }
         if (updateMyProfileRequest.intro() != null) {
             this.intro = updateMyProfileRequest.intro();
+        }
+    }
+
+    public void updateUserProfile(Long avatarProfileId, String nickname, String intro) {
+        if (avatarProfileId != null) {
+            this.avatarProfileId = avatarProfileId;
+        }
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+        if (intro != null) {
+            this.intro = intro;
         }
     }
 

--- a/src/main/java/org/websoso/WSSServer/user/service/UserService.java
+++ b/src/main/java/org/websoso/WSSServer/user/service/UserService.java
@@ -109,8 +109,9 @@ public class UserService {
     }
 
     // TODO: 멱등성을 보장하는데, Exception이 발생하는게 맞나? (기중)
+    @Deprecated
     public void updateMyProfileInfo(User user, UpdateMyProfileRequest updateMyProfileRequest) {
-        checkIfAlreadySetOrThrow(user.getAvatarProfileId(), updateMyProfileRequest.avatarId(),
+        checkIfAlreadySetOrThrow(user.getAvatarId(), updateMyProfileRequest.avatarId(),
                 ALREADY_SET_AVATAR, "avatarId with given is already set");
 
         checkIfAlreadySetOrThrow(user.getNickname(), updateMyProfileRequest.nickname(),
@@ -127,6 +128,26 @@ public class UserService {
         genrePreferenceRepository.saveAll(newPreferGenres);
 
         user.updateUserProfile(updateMyProfileRequest);
+    }
+
+    public void updateProfileInfo(User user, UpdateMyProfileRequest updateMyProfileRequest) {
+        checkIfAlreadySetOrThrow(user.getAvatarProfileId(), updateMyProfileRequest.avatarId(),
+                ALREADY_SET_AVATAR, "avatarId with given is already set");
+
+        checkIfAlreadySetOrThrow(user.getNickname(), updateMyProfileRequest.nickname(),
+                ALREADY_SET_NICKNAME, "nickname with given is already set");
+        checkNicknameIfAlreadyExist(updateMyProfileRequest.nickname());
+
+        checkIfAlreadySetOrThrow(user.getIntro(), updateMyProfileRequest.intro(),
+                ALREADY_SET_INTRO, "intro with given is already set");
+
+        genrePreferenceRepository.deleteAllByUser(user);
+
+        List<GenrePreference> newPreferGenres = createGenrePreferences(user, updateMyProfileRequest.genrePreferences());
+        genrePreferenceRepository.saveAll(newPreferGenres);
+
+        user.updateUserProfile(updateMyProfileRequest.avatarId(), updateMyProfileRequest.nickname(),
+                updateMyProfileRequest.intro());
     }
 
     public void registerUserInfo(User user, RegisterUserInfoRequest registerUserInfoRequest) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- refactor/#434 -> dev
- close #434 

## Key Changes
<!-- 최대한 자세히 -->
**1. 프로필 업데이트 (`PATCH /users/profile`)**
- 신규 엔드포인트 `/profile`을 추가했습니다.
- **하위 호환성 매핑 로직:** 기존 클라이언트에서 넘어오는 `avatarId`를 신규 ID 체계로 변환하여 저장합니다.
    - `1` → `1`
    - `2` → `4`
    - `3` → `5`
    - 그 외 값: 변환 없이 그대로 저장

**2. 프로필 조회 (`GET /users/profile`)**
- 기존 `/my-profile`과 동일한 응답을 반환하는 `/profile` 엔드포인트를 추가하여 URL 명칭을 통일했습니다.

**3. 아바타 목록 조회 수정**
- 기존 아바타 목록 조회 시, 신규 추가된 아바타는 노출되지 않도록 필터링(Limit)을 적용했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
