### PR TITLE
[FIX] 작품의 관심 수가 변경되지 않은 이슈 해결

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/LibraryEvaluationApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/LibraryEvaluationApplication.java
@@ -3,7 +3,6 @@ package org.websoso.WSSServer.application;
 import static org.websoso.WSSServer.exception.error.CustomUserNovelError.NOT_EVALUATED;
 import static org.websoso.WSSServer.exception.error.CustomUserNovelError.USER_NOVEL_ALREADY_EXISTS;
 
-import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -13,6 +12,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.user.domain.User;
 import org.websoso.WSSServer.dto.keyword.KeywordGetResponse;
 import org.websoso.WSSServer.dto.userNovel.UserNovelCreateRequest;
@@ -108,6 +108,7 @@ public class LibraryEvaluationApplication {
      * @param user    사용자 객체
      * @param novelId 소설 ID
      */
+    @Transactional
     public void deleteEvaluation(User user, Long novelId) {
         UserNovel userNovel = libraryService.getLibraryOrException(user, novelId);
 

--- a/src/main/java/org/websoso/WSSServer/application/LibraryInterestApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/LibraryInterestApplication.java
@@ -7,6 +7,7 @@ import static org.websoso.WSSServer.exception.error.CustomUserNovelError.USER_NO
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.user.domain.User;
 import org.websoso.WSSServer.exception.exception.CustomUserNovelException;
 import org.websoso.WSSServer.library.domain.UserNovel;
@@ -27,6 +28,7 @@ public class LibraryInterestApplication {
      * @param user    사용자 객체
      * @param novelId 소설 ID
      */
+    @Transactional
     public void registerAsInterest(User user, Long novelId) {
         Novel novel = novelService.getNovelOrException(novelId);
 
@@ -53,6 +55,7 @@ public class LibraryInterestApplication {
      * @param user    사용자 객체
      * @param novelId 소설 ID
      */
+    @Transactional
     public void unregisterAsInterest(User user, Long novelId) {
         UserNovel userNovel = libraryService.getLibraryOrException(user, novelId);
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#436 -> dev
- close #436

## Key Changes
<!-- 최대한 자세히 -->
### 문제 상황
하위 클래스 Service에서 @Transactional을 사용하여, @Transactional을 누락한 Application에서는 엔티티 수정시에도 반영되지 않는 문제
- 현재 구조는 Application 계층에서 각 기능별 Service를 조립하는 형태
- 서재 관련 Application에서는 @Transactional이 명시되어 있지 않고, 각 기능별 Service에서는 @Trasactional이 명시되어 있음
- 이로 인해, 엔티티 영속성 객체의 필드 값을 수정해도 데이터 베이스에 반영되지 않은 문제가 발생

### 해결
누락된 Transactional 애너테이션 추가
추후 리팩토링(#410) 때 Application에서 엔티티 객체를 직접 수정하는 코드를 제거할 예정 

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
