### PR TITLE
[REFACTOR] 서재 관심 등록 및 해제 API의 멱등성 보장 및 성능 개선

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/LibraryInterestApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/LibraryInterestApplication.java
@@ -1,11 +1,8 @@
 package org.websoso.WSSServer.application;
 
-import static org.websoso.WSSServer.exception.error.CustomUserNovelError.ALREADY_INTERESTED;
 import static org.websoso.WSSServer.exception.error.CustomUserNovelError.NOT_INTERESTED;
-import static org.websoso.WSSServer.exception.error.CustomUserNovelError.USER_NOVEL_ALREADY_EXISTS;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.user.domain.User;
@@ -32,21 +29,7 @@ public class LibraryInterestApplication {
     public void registerAsInterest(User user, Long novelId) {
         Novel novel = novelService.getNovelOrException(novelId);
 
-        UserNovel userNovel = user == null ? null : libraryService.getLibraryOrNull(user, novel);
-
-        if (userNovel != null && userNovel.getIsInterest()) {
-            throw new CustomUserNovelException(ALREADY_INTERESTED, "already registered as interested");
-        }
-
-        if (userNovel == null) {
-            try {
-                userNovel = createUserNovelByInterest(user, novel);
-            } catch (DataIntegrityViolationException e) {
-                userNovel = libraryService.getLibraryOrException(user, novelId);
-            }
-        }
-
-        userNovel.setIsInterest(true);
+        libraryService.registerInterest(user, novel);
     }
 
     /**
@@ -71,11 +54,4 @@ public class LibraryInterestApplication {
 
     }
 
-    private UserNovel createUserNovelByInterest(User user, Novel novel) {
-        if (libraryService.getLibraryOrNull(user, novel) != null) {
-            throw new CustomUserNovelException(USER_NOVEL_ALREADY_EXISTS, "this novel is already registered");
-        }
-
-        return libraryService.createLibrary(null, 0.0f, null, null, user, novel);
-    }
 }

--- a/src/main/java/org/websoso/WSSServer/application/LibraryInterestApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/LibraryInterestApplication.java
@@ -40,18 +40,13 @@ public class LibraryInterestApplication {
      */
     @Transactional
     public void unregisterAsInterest(User user, Long novelId) {
-        UserNovel userNovel = libraryService.getLibraryOrException(user, novelId);
+        UserNovel library = libraryService.getLibraryOrNull(user, novelId);
 
-        if (!userNovel.getIsInterest()) {
-            throw new CustomUserNovelException(NOT_INTERESTED, "not registered as interest");
+        if (library == null) {
+            return;
         }
 
-        userNovel.setIsInterest(false);
-
-        if (userNovel.getStatus() == null) {
-            libraryService.delete(userNovel);
-        }
-
+        libraryService.unregisterInterest(library);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/library/domain/UserNovel.java
+++ b/src/main/java/org/websoso/WSSServer/library/domain/UserNovel.java
@@ -90,10 +90,6 @@ public class UserNovel extends BaseEntity {
         return new UserNovel(status, userNovelRating, startDate, endDate, user, novel);
     }
 
-    public void setIsInterest(Boolean isInterest) {
-        this.isInterest = isInterest;
-    }
-
     /**
      * 관심 상태 지정
      */
@@ -106,6 +102,11 @@ public class UserNovel extends BaseEntity {
      */
     public void unmarkAsInterested() {
         this.isInterest = false;
+    }
+
+    public boolean isSafeToDelete() {
+        return !this.isInterest
+                && this.status == null;
     }
 
     public void updateUserNovel(Float userNovelRating, ReadStatus status, LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/org/websoso/WSSServer/library/domain/UserNovel.java
+++ b/src/main/java/org/websoso/WSSServer/library/domain/UserNovel.java
@@ -91,6 +91,20 @@ public class UserNovel extends BaseEntity {
         this.isInterest = isInterest;
     }
 
+    /**
+     * 관심 상태 지정
+     */
+    public void markAsInterested() {
+        this.isInterest = true;
+    }
+
+    /**
+     * 관심 상태 해제
+     */
+    public void unmarkAsInterested() {
+        this.isInterest = false;
+    }
+
     public void updateUserNovel(Float userNovelRating, ReadStatus status, LocalDate startDate, LocalDate endDate) {
         this.userNovelRating = userNovelRating;
         this.status = status;

--- a/src/main/java/org/websoso/WSSServer/library/domain/UserNovel.java
+++ b/src/main/java/org/websoso/WSSServer/library/domain/UserNovel.java
@@ -36,6 +36,9 @@ import org.websoso.WSSServer.domain.common.ReadStatus;
 })
 public class UserNovel extends BaseEntity {
 
+    public static final Float DEFAULT_RATING = 0.0f;
+    public static final ReadStatus DEFAULT_STATUS = null;
+
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(nullable = false)

--- a/src/main/java/org/websoso/WSSServer/library/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/library/repository/UserNovelRepository.java
@@ -1,8 +1,10 @@
 package org.websoso.WSSServer.library.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.novel.domain.Novel;
@@ -29,4 +31,28 @@ public interface UserNovelRepository extends JpaRepository<UserNovel, Long>, Use
     List<UserNovel> findUserNovelByUser(User user);
 
     Optional<UserNovel> findByNovel_NovelIdAndUser(Long novelId, User user);
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = """
+        INSERT INTO user_novel (
+            user_id, novel_id, is_interest, 
+            user_novel_rating, status, 
+            created_date, modified_date
+        ) VALUES (
+            :userId, :novelId, true, 
+            :defaultRating, 
+            :#{#defaultStatus?.name()},
+            NOW(), NOW()
+        )
+        ON DUPLICATE KEY UPDATE
+            is_interest = true,
+            modified_date = NOW()
+        """, nativeQuery = true)
+    void upsertInterest(
+            @Param("userId") Long userId,
+            @Param("novelId") Long novelId,
+            @Param("defaultRating") Float defaultRating,
+            @Param("defaultStatus") ReadStatus defaultStatus
+    );
+
 }

--- a/src/main/java/org/websoso/WSSServer/library/service/LibraryService.java
+++ b/src/main/java/org/websoso/WSSServer/library/service/LibraryService.java
@@ -56,6 +56,17 @@ public class LibraryService {
                 novel));
     }
 
+    @Transactional
+    public void registerInterest(User user, Novel novel) {
+        userNovelRepository.upsertInterest(
+                user.getUserId(),
+                novel.getNovelId(),
+                UserNovel.DEFAULT_RATING,
+                UserNovel.DEFAULT_STATUS
+        );
+    }
+
+    @Transactional
     public void delete(UserNovel library) {
         userNovelRepository.delete(library);
     }

--- a/src/main/java/org/websoso/WSSServer/novel/service/GenreServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/service/GenreServiceImpl.java
@@ -32,7 +32,7 @@ public class GenreServiceImpl {
 
         List<String> uniqueNames = names.stream().distinct().toList();
 
-        List<Genre> genres = genreRepository.findByNameIn(uniqueNames);
+        List<Genre> genres = genreRepository.findByGenreNameIn(uniqueNames);
 
         if (genres.size() != uniqueNames.size()) {
             throw new CustomGenreException(GENRE_NOT_FOUND,

--- a/src/main/java/org/websoso/WSSServer/repository/GenreRepository.java
+++ b/src/main/java/org/websoso/WSSServer/repository/GenreRepository.java
@@ -11,5 +11,5 @@ public interface GenreRepository extends JpaRepository<Genre, Byte> {
 
     Optional<Genre> findByGenreName(String name);
 
-    List<Genre> findByNameIn(List<String> names);
+    List<Genre> findByGenreNameIn(List<String> genreNames);
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- refactor/#410 -> #409
- close #

## Key Changes
<!-- 최대한 자세히 -->
- 서재 관심 등록 및 해제 API의 멱등성을 보장하도록 개선
  - Exception을 핸들링하여 비즈니스 로직이 동작되고 있는 부분을 개선하기 위함
- SELECT 후, INSERT / UPDATE 등 작업이 호출되는 부분을 UPSERT 로 한번에 처리되도록 개선

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
