### PR TITLE
[FIX] 만료된 토큰으로 애플 소셜 연동 불가 이슈 해결

### DIFF
--- a/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
             "/login/apple",
             "/auth/login/kakao",
             "/auth/login/apple",
+            "/auth/apple/sync",
             "/minimum-version"
     };
 

--- a/src/main/java/org/websoso/WSSServer/config/jwt/JwtProvider.java
+++ b/src/main/java/org/websoso/WSSServer/config/jwt/JwtProvider.java
@@ -51,6 +51,35 @@ public class JwtProvider {
                 .compact();
     }
 
+    public Long getUserIdFromToken(String token) {
+        if (token != null && token.startsWith("Bearer ")) {
+            token = token.substring(7);
+        }
+
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            return extractUserId(claims);
+
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            return extractUserId(e.getClaims());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Long extractUserId(Claims claims) {
+        Object userId = claims.get(CLAIM_USER_ID);
+        if (userId instanceof Integer) {
+            return ((Integer) userId).longValue();
+        }
+        return (Long) userId;
+    }
+
     private Claims generateClaims(Authentication authentication, Long expirationTime, String tokenType) {
         long now = System.currentTimeMillis();
         final Claims claims = Jwts.claims()


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#443 -> main
- close #443

## Key Changes
<!-- 최대한 자세히 -->
### 1. 문제 현상 (AS-IS)
- 기존 #440 작업 이후, 애플 소셜 연동(`PATCH /auth/apple/sync`) 시 **Access Token이 만료된 상태**라면 Security Filter Chain에서 `401 Unauthorized`가 발생
- 이로 인해 클라이언트(프론트)에서 연동 로직을 처리하지 못하고 로그인 페이지나 로딩 상태에 갇히는 버그 발생

### 2. 해결 방안 (TO-BE)
만료된 토큰이라도 **사용자 식별(User ID)** 만 가능하다면 연동 로직을 수행할 수 있도록 변경했습니다.

- **`SecurityConfig.java`**:
  - `/auth/apple/sync` 경로를 `permitAll()`로 설정하여 Security Filter의 토큰 만료 검증을 우회하도록 수정

- **`JwtProvider.java`**:
  - `getUserIdFromExpiredToken()` 메서드 추가
  - `Jwts.parserBuilder()` 실행 시 `ExpiredJwtException`이 발생하더라도, 예외 객체 내의 `Claims`를 조회하여 `userId`를 추출하도록 구현

- **`AuthController.java`**:
  - 기존 `@AuthenticationPrincipal`은 유효한 토큰일 때만 동작하므로 제거
  - 대신 `@RequestHeader("Authorization")`을 통해 토큰 문자열을 직접 받아, 위에서 구현한 파싱 메서드로 유저를 식별하도록 변경

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
