### PR TITLE
[FIX] 피드 별점 미등록 시 0.0 대신 null 반환 로직 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -111,7 +111,7 @@ public record FeedGetResponse(
                 .stream()
                 .filter(userNovel -> userNovel.getUser().getUserId().equals(feedWriterId))
                 .findFirst()
-                .map(UserNovel::getUserNovelRating)
+                .map(userNovel -> userNovel.isOnlyInterested() ? null : userNovel.getUserNovelRating())
                 .orElse(null);
     }
 }

--- a/src/main/java/org/websoso/WSSServer/library/domain/UserNovel.java
+++ b/src/main/java/org/websoso/WSSServer/library/domain/UserNovel.java
@@ -117,8 +117,8 @@ public class UserNovel extends BaseEntity {
     }
 
     public void deleteEvaluation() {
-        this.status = null;
-        this.userNovelRating = 0.0f;
+        this.status = DEFAULT_STATUS;
+        this.userNovelRating = DEFAULT_RATING;
         this.startDate = null;
         this.endDate = null;
     }

--- a/src/main/java/org/websoso/WSSServer/library/domain/UserNovel.java
+++ b/src/main/java/org/websoso/WSSServer/library/domain/UserNovel.java
@@ -123,4 +123,8 @@ public class UserNovel extends BaseEntity {
         this.endDate = null;
     }
 
+    public boolean isOnlyInterested() {
+        return this.status == DEFAULT_STATUS;
+    }
+
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#464 -> dev
- close #

## Key Changes
<!-- 최대한 자세히 -->
피드 조회 API에서 피드 작성자의 평가가 없는 경우, 평점이 0.0이 아닌 null을 반환하도록 수정하였습니다.

빠른 수정 및 배포를 위해 DTO 레이어에서 우선적으로 처리하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
추후 서재 리팩토링 시, 도메인 객체에서 평점을 불러올 때 관심 설정/평가 작성을 스스로 구분하여 해당 평점을 불러오도록 하면 좋을 것 같습니다.

## References
<!-- 참고한 자료-->
