### PR TITLE
[CHORE] 운영 서버 CI/CD시, Secrets가 아닌 서브 모듈을 사용하도록 워크플로우 수정

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -11,41 +11,26 @@ jobs:
     steps: 
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.ACTION_TOKEN }}
+        submodules: true
+        fetch-depth: 0
+
+    - name: Update Submodule
+      run: git submodule update --init --recursive --remote
 
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         distribution: 'corretto'
         java-version: '17'
-        
-    - name: Create application.yml and application-prod.yml
-      run: | 
-          mkdir src/main/resources
-          cd src/main/resources
-          echo "${{ secrets.APPLICATION }}" > ./application.yml
-          echo "${{ secrets.APPLICATION_PROD }}" > ./application-prod.yml
-
-    - name: create-json
-      id: create-json
-      uses: jsdaniell/create-json@1.1.2
-      with:
-        name: "websoso-fcm.json"
-        json: ${{ secrets.WEBSOSOFCM_JSON }}
-        dir: 'src/main/resources/'
-
-    - name: Create apple login key file
-      env:
-        API_KEY: ${{ secrets.APPSTORE_API_KEY_ID }}
-      run: |
-        mkdir -p src/main/resources/static/apple
-        echo "${{ secrets.APPLE_AUTH_KEY }}" > src/main/resources/static/apple/AuthKey_$API_KEY.p8
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       shell: bash
 
     - name: Build with Gradle
-      run: ./gradlew build -x test
+      run: ./gradlew build -x test -Dspring.profiles.active=prod
       shell: bash
 
     - name: Docker build Setting

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,34 +14,16 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.ACTION_TOKEN }}
+        submodules: true
+        fetch-depth: 0
 
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         distribution: 'corretto'
         java-version: '17'
-
-    - name: Create application.yml and application-prod.yml
-      run: | 
-          mkdir src/main/resources
-          cd src/main/resources
-          echo "${{ secrets.APPLICATION }}" > ./application.yml
-          echo "${{ secrets.APPLICATION_PROD }}" > ./application-prod.yml
-
-    - name: create-json
-      id: create-json
-      uses: jsdaniell/create-json@1.1.2
-      with:
-        name: "websoso-fcm.json"
-        json: ${{ secrets.WEBSOSOFCM_JSON }}
-        dir: 'src/main/resources/'
-
-    - name: Create apple login key file
-      env:
-        API_KEY: ${{ secrets.APPSTORE_API_KEY_ID }}
-      run: |
-        mkdir -p src/main/resources/static/apple
-        echo "${{ secrets.APPLE_AUTH_KEY }}" > src/main/resources/static/apple/AuthKey_$API_KEY.p8
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- chore/#453 -> refactor/#409
- close #453 

## Key Changes
<!-- 최대한 자세히 -->
운영 서버의 CI/CD 워크플로우를 서브 모듈을 사용하도록 수정

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
