### PR TITLE
[FEAT] 키워드, 매력포인트 및 정렬 기능 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/common/AttractivePointName.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/AttractivePointName.java
@@ -10,7 +10,8 @@ public enum AttractivePointName {
     MATERIAL("material"),
     CHARACTER("character"),
     RELATIONSHIP("relationship"),
-    VIBE("vibe");
+    VIBE("vibe"),
+    WRITINGSKILL("writingskill");
 
     private final String label;
 }

--- a/src/main/java/org/websoso/WSSServer/library/domain/Keyword.java
+++ b/src/main/java/org/websoso/WSSServer/library/domain/Keyword.java
@@ -28,6 +28,9 @@ public class Keyword implements Serializable {
     @Column(columnDefinition = "varchar(10)", nullable = false)
     private String keywordName;
 
+    @Column(nullable = false)
+    private Integer sortOrder;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "keyword_category_id", nullable = false)
     private KeywordCategory keywordCategory;

--- a/src/main/java/org/websoso/WSSServer/library/repository/KeywordRepository.java
+++ b/src/main/java/org/websoso/WSSServer/library/repository/KeywordRepository.java
@@ -10,4 +10,6 @@ public interface KeywordRepository extends JpaRepository<Keyword, Integer> {
 
     List<Keyword> findByKeywordIdIn(List<Integer> keywordIds);
 
+    List<Keyword> findAllByOrderBySortOrderAsc();
+
 }

--- a/src/main/java/org/websoso/WSSServer/library/service/KeywordService.java
+++ b/src/main/java/org/websoso/WSSServer/library/service/KeywordService.java
@@ -5,6 +5,7 @@ import static org.websoso.WSSServer.exception.error.CustomKeywordError.KEYWORD_N
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -49,8 +50,10 @@ public class KeywordService {
     public KeywordByCategoryGetResponse searchKeywordByCategory(String query) {
         List<Keyword> searchedKeywords = searchKeyword(query);
         List<CategoryGetResponse> categories = Arrays.stream(KeywordCategoryName.values())
-                .map(category -> CategoryGetResponse.of(getKeywordCategory(category.getLabel()),
-                        sortByCategory(category, searchedKeywords)))
+                .map(category -> CategoryGetResponse.of(
+                        getKeywordCategory(category.getLabel()),
+                        sortByCategoryAndOrder(category, searchedKeywords)
+                ))
                 .toList();
         return KeywordByCategoryGetResponse.of(categories);
     }
@@ -67,7 +70,7 @@ public class KeywordService {
     }
 
     public void deleteUserNovelKeywords(List<UserNovelKeyword> userNovelKeywords) {
-            userNovelKeywordRepository.deleteAll(userNovelKeywords);
+        userNovelKeywordRepository.deleteAll(userNovelKeywords);
     }
 
     private KeywordCategory getKeywordCategory(String keywordCategoryName) {
@@ -76,21 +79,26 @@ public class KeywordService {
                         "keyword category with the given name is not found"));
     }
 
-    private List<KeywordGetResponse> sortByCategory(KeywordCategoryName keywordCategoryName,
-                                                    List<Keyword> searchedKeyword) {
-        return searchedKeyword.stream()
-                .filter(keyword -> keyword.getKeywordCategory().getKeywordCategoryName()
-                        .equals(keywordCategoryName.getLabel()))
-                .map(KeywordGetResponse::of).toList();
+    private List<KeywordGetResponse> sortByCategoryAndOrder(KeywordCategoryName categoryName,
+                                                            List<Keyword> searchedKeywords) {
+        return searchedKeywords.stream()
+                .filter(k -> k.getKeywordCategory().getKeywordCategoryName().equals(categoryName.getLabel()))
+                .sorted(Comparator.comparing(Keyword::getSortOrder))
+                .map(KeywordGetResponse::of)
+                .toList();
     }
 
     private List<Keyword> searchKeyword(String query) {
+        List<Keyword> allKeywords = keywordRepository.findAllByOrderBySortOrderAsc();
+
         if (query == null || query.isBlank()) {
-            return keywordRepository.findAll().stream().toList();
+            return allKeywords;
         }
+
         String[] words = query.split(" ");
-        return keywordRepository.findAll().stream()
-                .filter(keyword -> keyword.containsAllWords(words)).toList();
+        return allKeywords.stream()
+                .filter(keyword -> keyword.containsAllWords(words))
+                .toList();
     }
 
     public List<KeywordCountGetResponse> getKeywordNameAndCount(Novel novel) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#472 -> dev
- close #472 

## Key Changes
<!-- 최대한 자세히 -->
### Keyword
1. Keyword 테이블에 sort_order 컬럼이 추가되었습니다.
  - 키워드의 경우, 서버에서 리스트를 조회하여 화면에 출력하는 형식이기 때문에 정렬을 위해 해당 컬럼이 추가되었습니다.
  - 또한, Repository에 해당 컬럼을 기준으로 조회하는 JPA 메서드가 작성되었습니다.

2. AttractivePointName Enum 클래스에 필력이 추가되었습니다.
  - 작품 상세 조회시, 사용자들의 Top3 매력포인트를 불러오는 기능이 있습니다.
  - 해당 기능에서, AttractivePointName Enum 클래스를 사용중이라, 필력 매력포인트가 조회되지 않는 문제가 발생했습니다.
  - 이를 해결하기 위해 해당 클래스에 필력(writingskill)을 추가하였습니다. 

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
데이터베이스 컬럼 추가 개설 및 신규 코드성 데이터 Insert이 대부분인 작업이다 보니 코드 수정은 거의 없습니다.

## References
<!-- 참고한 자료-->
