### PR TITLE
[FIX] 피드 조회시 distinct 적용

### DIFF
--- a/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
@@ -59,6 +59,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                                                     List<Genre> genres, Long visitorId) {
         return jpaQueryFactory
                 .selectFrom(feed)
+                .distinct()
                 .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
                 .leftJoin(novelGenre).on(novel.eq(novelGenre.novel))
                 .leftJoin(genre).on(novelGenre.genre.eq(genre))
@@ -94,7 +95,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                                   Boolean isUnVisible, List<Genre> genres,
                                   Long visitorId) {
         return jpaQueryFactory
-                .select(feed.count())
+                .select(feed.feedId.countDistinct())
                 .from(feed)
                 .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
                 .leftJoin(novelGenre).on(novel.eq(novelGenre.novel))


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#475 -> dev
- close #475 

## Key Changes
<!-- 최대한 자세히 -->
1. 사용자 피드 조회시 1:n 컬럼으로 인해 피드 갯수가 맞지 않는 문제 해결
2. 위 이슈로 인한 무한 스크롤이 중간에 막히는 현상 해결

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
