### PR TITLE
[FEAT] 피드 작성 시간 표기 정책 변경 (Relative Time 포맷 적용)

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -1,12 +1,12 @@
 package org.websoso.WSSServer.dto.feed;
 
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.websoso.WSSServer.feed.domain.Feed;
 import org.websoso.WSSServer.feed.domain.FeedImage;
 import org.websoso.WSSServer.novel.domain.Novel;
 import org.websoso.WSSServer.library.domain.UserNovel;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
+import org.websoso.WSSServer.util.TimeFormatUtil;
 
 public record FeedGetResponse(
         Long userId,
@@ -72,7 +72,7 @@ public record FeedGetResponse(
                 feedUserBasicInfo.nickname(),
                 feedUserBasicInfo.avatarImage(),
                 feed.getFeedId(),
-                feed.getCreatedDate().format(DateTimeFormatter.ofPattern("M월 d일")),
+                TimeFormatUtil.formatRelativeTime(feed.getCreatedDate()),
                 feed.getFeedContent(),
                 feed.getLikes().size(),
                 isLiked,

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedInfo.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedInfo.java
@@ -1,12 +1,12 @@
 package org.websoso.WSSServer.dto.feed;
 
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.websoso.WSSServer.feed.domain.Feed;
 import org.websoso.WSSServer.novel.domain.Novel;
 import org.websoso.WSSServer.user.domain.User;
 import org.websoso.WSSServer.library.domain.UserNovel;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
+import org.websoso.WSSServer.util.TimeFormatUtil;
 
 public record FeedInfo(
         Long feedId,
@@ -61,7 +61,7 @@ public record FeedInfo(
                 userBasicInfo.userId(),
                 userBasicInfo.nickname(),
                 userBasicInfo.avatarImage(),
-                feed.getCreatedDate().format(DateTimeFormatter.ofPattern("M월 d일")),
+                TimeFormatUtil.formatRelativeTime(feed.getCreatedDate()),
                 feed.getFeedContent(),
                 feed.getLikes().size(),
                 isLiked,

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -1,6 +1,5 @@
 package org.websoso.WSSServer.dto.feed;
 
-import java.time.LocalDate;
 import java.util.List;
 import org.websoso.WSSServer.feed.domain.Category;
 import org.websoso.WSSServer.feed.domain.Feed;
@@ -8,11 +7,12 @@ import org.websoso.WSSServer.feed.domain.FeedCategory;
 import org.websoso.WSSServer.feed.domain.Like;
 import org.websoso.WSSServer.novel.domain.Novel;
 import org.websoso.WSSServer.library.domain.UserNovel;
+import org.websoso.WSSServer.util.TimeFormatUtil;
 
 public record UserFeedGetResponse(
         Long feedId,
         String feedContent,
-        LocalDate createdDate,
+        String createdDate,
         Boolean isSpoiler,
         Boolean isModified,
         List<Long> likerUsers,
@@ -47,7 +47,7 @@ public record UserFeedGetResponse(
         return new UserFeedGetResponse(
                 feed.getFeedId(),
                 feed.getFeedContent(),
-                feed.getCreatedDate().toLocalDate(),
+                TimeFormatUtil.formatRelativeTime(feed.getCreatedDate()),
                 feed.getIsSpoiler(),
                 isModified,
                 likeUsers,

--- a/src/main/java/org/websoso/WSSServer/util/TimeFormatUtil.java
+++ b/src/main/java/org/websoso/WSSServer/util/TimeFormatUtil.java
@@ -1,0 +1,52 @@
+package org.websoso.WSSServer.util;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TimeFormatUtil {
+
+    private static final long SECONDS_PER_MINUTE = 60;
+    private static final long MINUTES_PER_HOUR = 60;
+    private static final long HOURS_PER_DAY = 24;
+    private static final long DAYS_PER_WEEK = 7;
+
+    private static final DateTimeFormatter SAME_YEAR_FMT = DateTimeFormatter.ofPattern("M월 d일");
+    private static final DateTimeFormatter DIFF_YEAR_FMT = DateTimeFormatter.ofPattern("yyyy년 M월 d일");
+
+    public static String formatRelativeTime(LocalDateTime createdDate) {
+        return formatRelativeTime(createdDate, Clock.systemDefaultZone());
+    }
+
+    public static String formatRelativeTime(LocalDateTime createdDate, Clock clock) {
+        LocalDateTime now = LocalDateTime.now(clock);
+        Duration duration = Duration.between(createdDate, now);
+
+        long seconds = duration.getSeconds();
+        if (seconds < SECONDS_PER_MINUTE) {
+            return "방금 전";
+        }
+
+        long minutes = duration.toMinutes();
+        if (minutes < MINUTES_PER_HOUR) {
+            return minutes + "분 전";
+        }
+
+        long hours = duration.toHours();
+        if (hours < HOURS_PER_DAY) {
+            return hours + "시간 전";
+        }
+
+        long days = duration.toDays();
+        if (days < DAYS_PER_WEEK) {
+            return days + "일 전";
+        }
+
+        if (createdDate.getYear() == now.getYear()) {
+            return createdDate.format(SAME_YEAR_FMT);
+        }
+
+        return createdDate.format(DIFF_YEAR_FMT);
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/util/TimeFormatUtilTest.java
+++ b/src/test/java/org/websoso/WSSServer/util/TimeFormatUtilTest.java
@@ -1,0 +1,97 @@
+package org.websoso.WSSServer.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+
+class TimeFormatUtilTest {
+
+    private static final ZoneId ZONE = ZoneId.systemDefault();
+
+    @Test
+    void 방금_전() {
+        Clock clock = fixedClock("2024-01-15T12:00:00");
+        assertThat(format(clock, 30)).isEqualTo("방금 전");
+    }
+
+    @Test
+    void 방금_전_경계값_59초() {
+        Clock clock = fixedClock("2024-01-15T12:00:00");
+        assertThat(format(clock, 59)).isEqualTo("방금 전");
+    }
+
+    @Test
+    void 분_전() {
+        Clock clock = fixedClock("2024-01-15T12:00:00");
+        assertThat(format(clock, 60)).isEqualTo("1분 전");
+    }
+
+    @Test
+    void 분_전_경계값_59분() {
+        Clock clock = fixedClock("2024-01-15T12:00:00");
+        assertThat(format(clock, 59 * 60)).isEqualTo("59분 전");
+    }
+
+    @Test
+    void 시간_전() {
+        Clock clock = fixedClock("2024-01-15T12:00:00");
+        assertThat(format(clock, 3600)).isEqualTo("1시간 전");
+    }
+
+    @Test
+    void 시간_전_경계값_23시간() {
+        Clock clock = fixedClock("2024-01-15T12:00:00");
+        assertThat(format(clock, 23 * 3600)).isEqualTo("23시간 전");
+    }
+
+    @Test
+    void 일_전() {
+        Clock clock = fixedClock("2024-01-15T12:00:00");
+        assertThat(format(clock, 24 * 3600)).isEqualTo("1일 전");
+    }
+
+    @Test
+    void 일_전_경계값_6일() {
+        Clock clock = fixedClock("2024-01-15T12:00:00");
+        assertThat(format(clock, 6 * 24 * 3600)).isEqualTo("6일 전");
+    }
+
+    @Test
+    void 같은_해_날짜_포맷() {
+        Clock clock = fixedClock("2024-06-15T12:00:00");
+        LocalDateTime createdAt = LocalDateTime.parse("2024-01-01T00:00:00");
+        assertThat(TimeFormatUtil.formatRelativeTime(createdAt, clock)).isEqualTo("1월 1일");
+    }
+
+    @Test
+    void 다른_해_날짜_포맷() {
+        Clock clock = fixedClock("2024-01-15T12:00:00");
+        LocalDateTime createdAt = LocalDateTime.parse("2023-12-31T00:00:00");
+        assertThat(TimeFormatUtil.formatRelativeTime(createdAt, clock)).isEqualTo("2023년 12월 31일");
+    }
+
+    @Test
+    void 미래_시각은_방금_전() {
+        Clock clock = fixedClock("2024-01-15T12:00:00");
+        LocalDateTime future = LocalDateTime.now(clock).plusHours(1);
+        assertThat(TimeFormatUtil.formatRelativeTime(future, clock)).isEqualTo("방금 전");
+    }
+
+    private Clock fixedClock(String isoDateTime) {
+        return Clock.fixed(
+                LocalDateTime.parse(isoDateTime)
+                        .atZone(ZONE)
+                        .toInstant(),
+                ZONE
+        );
+    }
+
+    private String format(Clock clock, long secondsBefore) {
+        LocalDateTime createdAt = LocalDateTime.now(clock).minusSeconds(secondsBefore);
+        return TimeFormatUtil.formatRelativeTime(createdAt, clock);
+    }
+
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#477 -> dev
- close #477 

## Key Changes
<!-- 최대한 자세히 -->
- `TimeFormatUtil` 상대 시간 포맷 유틸 클래스 추가
  - 60초 미만 → "방금 전"
  - 60분 미만 → "N분 전"
  - 24시간 미만 → "N시간 전"
  - 7일 미만 → "N일 전"
  - 7일 이상, 같은 해 → "M월 d일"
  - 7일 이상, 다른 해 → "yyyy년 M월 d일"
- 테스트 가능한 구조를 위해 `Clock` 주입 오버로딩 추가
- `DateTimeFormatter` static final 선언으로 불필요한 객체 생성 제거
- 단위 테스트 작성 (경계값 중심)

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 운영 코드에서는 `Clock` 없는 메서드를 사용하고, `Clock` 주입 버전은 테스트 전용으로 의도했습니다.

## References
<!-- 참고한 자료-->
