### PR TITLE
[FIX] iOS 애플 로그인 유저 회원 탈퇴 실패 (Client Secret 생성 오류)

### DIFF
--- a/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/oauth2/service/AppleService.java
@@ -43,6 +43,7 @@ import org.bouncycastle.util.io.pem.PemReader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
@@ -108,6 +109,8 @@ public class AppleService {
 
     @Value("${apple.iss}")
     private String appleAuthUrl;
+
+    private final ResourceLoader resourceLoader;
 
     public void upsertRefreshToken(User user, String appleRefreshToken) {
         userAppleTokenRepository.findByUser(user)
@@ -267,10 +270,9 @@ public class AppleService {
     }
 
     private byte[] readPrivateKey(String keyPath) {
-        Resource resource = new ClassPathResource(keyPath);
+        Resource resource = resourceLoader.getResource("file:" + keyPath);
         try (PemReader pemReader = new PemReader(new InputStreamReader(resource.getInputStream()))) {
-            PemObject pemObject = pemReader.readPemObject();
-            return pemObject.getContent();
+            return pemReader.readPemObject().getContent();
         } catch (IOException e) {
             throw new CustomAppleLoginException(PRIVATE_KEY_READ_FAILED, "failed to read private key");
         }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#479 -> dev
- close #479 

## Key Changes
<!-- 최대한 자세히 -->
### 1. 애플 로그인 탈퇴 시 Client Secret(JWT) 생성 오류 수정

서브 모듈 구조로 전환되면서 리소스 참조 방식이 변경되었으나, 기존 탈퇴 로직이 ClassPathResource를 사용하는 구버전 상태로 남아있어 Private Key(.p8) 파일을 찾지 못하는 문제를 확인했습니다.

ResourceLoader를 주입받아 file: 프리픽스를 사용하는 방식으로 수정하여, 설정된 외부 경로의 키 파일을 정상적으로 로드하도록 개선했습니다.

### 2. 코드 수정 내역

기존: new ClassPathResource(keyPath)를 통해 클래스패스 내부 탐색

변경: resourceLoader.getResource("file:" + keyPath)를 통해 실제 파일 시스템 경로 탐색

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
