### PR TITLE
[FIX] NativeQuery 오작성으로 인한 SQL 호출시 오류가 발생하는 문제 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/notification/repository/ReadNotificationRepository.java
+++ b/src/main/java/org/websoso/WSSServer/notification/repository/ReadNotificationRepository.java
@@ -16,8 +16,8 @@ public interface ReadNotificationRepository extends JpaRepository<ReadNotificati
 
     @Modifying
     @Query(value = """
-            INSERT IGNORE INTO read_notification (notification_id, user_id, created_at, updated_at)
-            VALUES (:notificationId, :userId, NOW(), NOW())
+            INSERT IGNORE INTO read_notification (notification_id, user_id)
+            VALUES (:notificationId, :userId)
             """, nativeQuery = true)
     void insertIgnoreReadNotification(
             @Param("notificationId") Long notificationId,


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#481 -> dev
- close #481

## Key Changes
<!-- 최대한 자세히 -->
ReadNotification 테이블에는 CreatedAt과 UpdatedAt 필드가 존재하지 않습니다.
하지만 NativeQuery에서 해당 필드를 저장하는 쿼리가 존재하고 있습니다.
이로 인해서, 공지를 읽을 때 읽기 여부를 저장하는 쿼리에서 필드 불일치로 인해 예외가 발생하고 있는 문제였습니다.
따라서, 해당 NativeQuery를 정상적으로 수정하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
컴파일 단계에서 문제를 알 수 있는 QueryDSL 등으로의 전환도 고려해봐야 할 듯 싶습니다.

## References
<!-- 참고한 자료-->
