### PR TITLE
[FIX] 피드에서 피드 카테고리 제거

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/FeedFindApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/FeedFindApplication.java
@@ -90,19 +90,19 @@ public class FeedFindApplication {
     }
 
     @Transactional(readOnly = true)
-    public FeedsGetResponse getFeeds(User user, String category, Long lastFeedId, int size,
+    public FeedsGetResponse getFeeds(User user, Long lastFeedId, int size,
                                      FeedGetOption feedGetOption) {
         Long userIdOrNull = Optional.ofNullable(user).map(User::getUserId).orElse(null);
 
         List<Genre> genres = getPreferenceGenres(user);
 
-        Slice<Feed> feeds = findFeedsByCategoryLabel(getChosenCategoryOrDefault(category), lastFeedId, userIdOrNull,
+        Slice<Feed> feeds = findFeedsByCategoryLabel(lastFeedId, userIdOrNull,
                 PageRequest.of(DEFAULT_PAGE_NUMBER, size), feedGetOption, genres);
 
         List<FeedInfo> feedGetResponses = feeds.getContent().stream().filter(feed -> feed.isVisibleTo(userIdOrNull))
                 .map(feed -> createFeedInfo(feed, user)).toList();
 
-        return FeedsGetResponse.of(getChosenCategoryOrDefault(category), feeds.hasNext(), feedGetResponses);
+        return FeedsGetResponse.of(feeds.hasNext(), feedGetResponses);
     }
 
     private List<Genre> getPreferenceGenres(User user) {
@@ -116,9 +116,9 @@ public class FeedFindApplication {
         return Optional.ofNullable(category).orElse(DEFAULT_CATEGORY);
     }
 
-    private Slice<Feed> findFeedsByCategoryLabel(String category, Long lastFeedId, Long userId, PageRequest pageRequest,
+    private Slice<Feed> findFeedsByCategoryLabel(Long lastFeedId, Long userId, PageRequest pageRequest,
                                                  FeedGetOption feedGetOption, List<Genre> genres) {
-        return feedServiceImpl.findFeedsByCategoryLabel(category, lastFeedId, userId, pageRequest, feedGetOption,
+        return feedServiceImpl.findFeedsByCategoryLabel(lastFeedId, userId, pageRequest, feedGetOption,
                 genres);
     }
 

--- a/src/main/java/org/websoso/WSSServer/application/FeedFindApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/FeedFindApplication.java
@@ -62,12 +62,9 @@ public class FeedFindApplication {
         UserBasicInfo feedUserBasicInfo = getUserBasicInfo(feed.getUser());
         Novel novel = getLinkedNovelOrNull(feed.getNovelId());
         Boolean isLiked = isUserLikedFeed(user, feed);
-        List<String> relevantCategories = feed.getFeedCategories().stream()
-                .map(feedCategory -> feedCategory.getCategory().getCategoryName().getLabel())
-                .collect(Collectors.toList());
         Boolean isMyFeed = isUserFeedOwner(feed.getUser(), user);
 
-        return FeedGetResponse.of(feed, feedUserBasicInfo, novel, isLiked, relevantCategories, isMyFeed);
+        return FeedGetResponse.of(feed, feedUserBasicInfo, novel, isLiked, isMyFeed);
     }
 
     private UserBasicInfo getUserBasicInfo(User user) {
@@ -129,16 +126,12 @@ public class FeedFindApplication {
         UserBasicInfo userBasicInfo = getUserBasicInfo(feed.getUser());
         Novel novel = getLinkedNovelOrNull(feed.getNovelId());
         Boolean isLiked = user != null && isUserLikedFeed(user, feed);
-        List<String> relevantCategories = feed.getFeedCategories().stream()
-                .map(feedCategory -> feedCategory.getCategory().getCategoryName().getLabel())
-                .collect(Collectors.toList());
         Boolean isMyFeed = user != null && isUserFeedOwner(feed.getUser(), user);
         Integer imageCount = feedServiceImpl.countByFeedId(feed.getFeedId());
         Optional<FeedImage> thumbnailImage = feedServiceImpl.findThumbnailFeedImageByFeedId(feed.getFeedId());
         String thumbnailUrl = thumbnailImage.map(FeedImage::getUrl).orElse(null);
 
-        return FeedInfo.of(feed, userBasicInfo, novel, isLiked, relevantCategories, isMyFeed, thumbnailUrl, imageCount,
-                user);
+        return FeedInfo.of(feed, userBasicInfo, novel, isLiked, isMyFeed, thumbnailUrl, imageCount, user);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedCreateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedCreateRequest.java
@@ -1,16 +1,10 @@
 package org.websoso.WSSServer.dto.feed;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.util.List;
 
 public record FeedCreateRequest(
-        @NotNull(message = "카테고리는 null일 수 없습니다.")
-        @NotEmpty(message = "카테고리는 1개 이상 선택해야 합니다.")
-        List<String> relevantCategories,
-
         @NotBlank(message = "피드 내용은 비어 있거나, 공백일 수 없습니다.")
         @Size(max = 2000, message = "피드 내용은 2000자를 초과할 수 없습니다.")
         String feedContent,

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -22,7 +22,6 @@ public record FeedGetResponse(
         String title,
         Integer novelRatingCount,
         Float novelRating,
-        List<String> relevantCategories,
         Boolean isSpoiler,
         Boolean isModified,
         Boolean isMyFeed,
@@ -35,7 +34,7 @@ public record FeedGetResponse(
         String novelDescription
 ) {
     public static FeedGetResponse of(Feed feed, UserBasicInfo feedUserBasicInfo, Novel novel, Boolean isLiked,
-                                     List<String> relevantCategories, Boolean isMyFeed) {
+                                     Boolean isMyFeed) {
         String title = null;
         Integer novelRatingCount = null;
         Float novelRating = null;
@@ -81,7 +80,6 @@ public record FeedGetResponse(
                 title,
                 novelRatingCount,
                 novelRating,
-                relevantCategories,
                 feed.getIsSpoiler(),
                 !feed.getCreatedDate().equals(feed.getModifiedDate()),
                 isMyFeed,

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedInfo.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedInfo.java
@@ -22,7 +22,6 @@ public record FeedInfo(
         String title,
         Integer novelRatingCount,
         Float novelRating,
-        List<String> relevantCategories,
         Boolean isSpoiler,
         Boolean isModified,
         Boolean isMyFeed,
@@ -34,8 +33,7 @@ public record FeedInfo(
         Float feedWriterNovelRating
 ) {
     public static FeedInfo of(Feed feed, UserBasicInfo userBasicInfo, Novel novel, Boolean isLiked,
-                              List<String> relevantCategories, Boolean isMyFeed, String thumbnailUrl,
-                              Integer imageCount, User user) {
+                              Boolean isMyFeed, String thumbnailUrl, Integer imageCount, User user) {
         String title = null;
         Integer novelRatingCount = null;
         Float novelRating = null;
@@ -70,7 +68,6 @@ public record FeedInfo(
                 title,
                 novelRatingCount,
                 novelRating,
-                relevantCategories,
                 feed.getIsSpoiler(),
                 !feed.getCreatedDate().equals(feed.getModifiedDate()),
                 isMyFeed,

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedUpdateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedUpdateRequest.java
@@ -1,16 +1,10 @@
 package org.websoso.WSSServer.dto.feed;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.util.List;
 
 public record FeedUpdateRequest(
-        @NotNull(message = "카테고리는 null일 수 없습니다.")
-        @NotEmpty(message = "카테고리는 1개 이상 선택해야 합니다.")
-        List<String> relevantCategories,
-
         @NotBlank(message = "피드 내용은 비어 있거나, 공백일 수 없습니다.")
         @Size(max = 2000, message = "피드 내용은 2000자를 초과할 수 없습니다.")
         String feedContent,

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedsGetResponse.java
@@ -3,13 +3,11 @@ package org.websoso.WSSServer.dto.feed;
 import java.util.List;
 
 public record FeedsGetResponse(
-        String category,
         Boolean isLoadable,
         List<FeedInfo> feeds
 ) {
-    static public FeedsGetResponse of(String category, Boolean isLoadable, List<FeedInfo> feeds) {
+    static public FeedsGetResponse of( Boolean isLoadable, List<FeedInfo> feeds) {
         return new FeedsGetResponse(
-                category,
                 isLoadable,
                 feeds
         );

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -1,9 +1,7 @@
 package org.websoso.WSSServer.dto.feed;
 
 import java.util.List;
-import org.websoso.WSSServer.feed.domain.Category;
 import org.websoso.WSSServer.feed.domain.Feed;
-import org.websoso.WSSServer.feed.domain.FeedCategory;
 import org.websoso.WSSServer.feed.domain.Like;
 import org.websoso.WSSServer.novel.domain.Novel;
 import org.websoso.WSSServer.library.domain.UserNovel;
@@ -23,7 +21,6 @@ public record UserFeedGetResponse(
         String title,
         Float novelRating,
         Long novelRatingCount,
-        List<String> relevantCategories,
         Boolean isPublic,
         String genre,
         Float userNovelRating,
@@ -39,7 +36,6 @@ public record UserFeedGetResponse(
         Float novelRating = getNovelRating(novel, novelRatingCount);
         List<Long> likeUsers = getLikeUsers(feed);
         boolean isLiked = likeUsers.contains(visitorId);
-        List<String> relevantCategories = getFeedCategories(feed);
         String genreName = getNovelGenreName(novel);
         Float userNovelRating = getUserNovelRating(novel, visitorId);
         Float feedWriterNovelRating = getFeedWriterNovelRating(novel, feed.getUser().getUserId());
@@ -60,7 +56,6 @@ public record UserFeedGetResponse(
                         null : novel.getTitle(),
                 novelRating,
                 novelRatingCount,
-                relevantCategories,
                 feed.getIsPublic(),
                 genreName,
                 userNovelRating,
@@ -68,15 +63,6 @@ public record UserFeedGetResponse(
                 imageCount,
                 feedWriterNovelRating
         );
-    }
-
-    private static List<String> getFeedCategories(Feed feed) {
-        return feed.getFeedCategories()
-                .stream()
-                .map(FeedCategory::getCategory)
-                .map(Category::getCategoryName)
-                .map(Enum::name)
-                .toList();
     }
 
     private static List<Long> getLikeUsers(Feed feed) {

--- a/src/main/java/org/websoso/WSSServer/feed/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/feed/controller/FeedController.java
@@ -62,13 +62,12 @@ public class FeedController {
 
     @GetMapping
     public ResponseEntity<FeedsGetResponse> getFeeds(@AuthenticationPrincipal User user,
-                                                     @RequestParam(value = "category", required = false) String category,
                                                      @RequestParam("lastFeedId") Long lastFeedId,
                                                      @RequestParam("size") int size,
                                                      @RequestParam(value = "feedsOption", required = false) FeedGetOption feedGetOption) {
         return ResponseEntity
                 .status(OK)
-                .body(feedFindApplication.getFeeds(user, category, lastFeedId, size, feedGetOption));
+                .body(feedFindApplication.getFeeds(user, lastFeedId, size, feedGetOption));
     }
 
     @PutMapping("/{feedId}")

--- a/src/main/java/org/websoso/WSSServer/feed/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/feed/domain/Feed.java
@@ -60,9 +60,6 @@ public class Feed {
     private User user;
 
     @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY)
-    private List<FeedCategory> feedCategories = new ArrayList<>();
-
-    @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY)
     private List<Like> likes = new ArrayList<>();
 
     @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY)

--- a/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepository.java
@@ -14,11 +14,14 @@ public interface FeedCustomRepository {
 
     List<Feed> findFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size, Boolean isVisible,
                                              Boolean isUnVisible, SortCriteria sortCriteria, List<Genre> genres,
-                                             Long visitorId);
+                                             Long visitorId, boolean includeEtc);
 
     Slice<Feed> findRecommendedFeeds(Long lastFeedId, Long userId, PageRequest pageRequest, List<Genre> genres);
 
+    Slice<Feed> findFeedsByGenres(List<Genre> genres, boolean includeEtc, Long lastFeedId, Long userId,
+                                  PageRequest pageRequest);
+
     Long countVisibleFeeds(User owner, Long lastFeedId, Boolean isVisible,
                            Boolean isUnVisible, List<Genre> genres,
-                           Long visitorId);
+                           Long visitorId, boolean includeEtc);
 }

--- a/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
@@ -56,7 +56,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
     @Override
     public List<Feed> findFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size, Boolean isVisible,
                                                     Boolean isUnVisible, SortCriteria sortCriteria,
-                                                    List<Genre> genres, Long visitorId) {
+                                                    List<Genre> genres, Long visitorId, boolean includeEtc) {
         return jpaQueryFactory
                 .selectFrom(feed)
                 .distinct()
@@ -68,7 +68,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                         ltFeedId(lastFeedId),
                         checkVisible(visitorId),
                         checkPublic(isVisible, isUnVisible),
-                        checkGenres(genres)
+                        checkGenres(genres, includeEtc)
                 )
                 .orderBy(
                         checkSortCriteria(sortCriteria),
@@ -93,7 +93,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
     @Override
     public Long countVisibleFeeds(User owner, Long lastFeedId, Boolean isVisible,
                                   Boolean isUnVisible, List<Genre> genres,
-                                  Long visitorId) {
+                                  Long visitorId, boolean includeEtc) {
         return jpaQueryFactory
                 .select(feed.feedId.countDistinct())
                 .from(feed)
@@ -104,7 +104,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                         feed.user.eq(owner),
                         checkVisible(visitorId),
                         checkPublic(isVisible, isUnVisible),
-                        checkGenres(genres)
+                        checkGenres(genres, includeEtc)
                 )
                 .fetchOne();
     }
@@ -149,7 +149,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                 .where(
                         ltFeedId(lastFeedId),
                         checkPopularFeed(),
-                        checkGenres(genres),
+                        checkGenres(genres, false),
                         checkBlocking(userId),
                         checkHidden()
                 )
@@ -174,11 +174,39 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                 .goe(POPULAR_FEED_LIKE_COUNT);
     }
 
-    private BooleanExpression checkGenres(List<Genre> genres) {
+    private BooleanExpression checkGenres(List<Genre> genres, boolean includeEtc) {
+        BooleanExpression etcCondition = includeEtc ? feed.novelId.isNull() : null;
         if (genres != null && !genres.isEmpty()) {
-            return genre.in(genres).or(feed.novelId.isNull());
+            BooleanExpression genreCondition = genre.in(genres);
+            return etcCondition != null ? genreCondition.or(etcCondition) : genreCondition;
         }
-        return null;
+        return etcCondition;
+    }
+
+    @Override
+    public Slice<Feed> findFeedsByGenres(List<Genre> genres, boolean includeEtc, Long lastFeedId, Long userId,
+                                         PageRequest pageRequest) {
+        List<Feed> feeds = jpaQueryFactory
+                .selectFrom(feed)
+                .distinct()
+                .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
+                .leftJoin(novelGenre).on(novel.eq(novelGenre.novel))
+                .leftJoin(genre).on(novelGenre.genre.eq(genre))
+                .where(
+                        ltFeedId(lastFeedId),
+                        checkGenres(genres, includeEtc),
+                        checkBlocking(userId),
+                        checkHidden()
+                )
+                .orderBy(feed.feedId.desc())
+                .limit(pageRequest.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = feeds.size() > pageRequest.getPageSize();
+        if (hasNext) {
+            feeds.remove(feeds.size() - 1);
+        }
+        return new SliceImpl<>(feeds, pageRequest, hasNext);
     }
 
     private BooleanExpression checkBlocking(Long userId) {

--- a/src/main/java/org/websoso/WSSServer/feed/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/feed/service/FeedService.java
@@ -2,8 +2,6 @@ package org.websoso.WSSServer.feed.service;
 
 import static java.lang.Boolean.TRUE;
 import static org.websoso.WSSServer.exception.error.CustomAvatarError.AVATAR_NOT_FOUND;
-import static org.websoso.WSSServer.exception.error.CustomCategoryError.CATEGORY_NOT_FOUND;
-import static org.websoso.WSSServer.exception.error.CustomCategoryError.INVALID_CATEGORY_FORMAT;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.ALREADY_LIKED;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.NOT_LIKED;
@@ -35,7 +33,6 @@ import org.websoso.WSSServer.notification.domain.NotificationType;
 import org.websoso.WSSServer.user.repository.AvatarProfileRepository;
 import org.websoso.WSSServer.user.domain.User;
 import org.websoso.WSSServer.notification.domain.UserDevice;
-import org.websoso.WSSServer.domain.common.CategoryName;
 import org.websoso.WSSServer.domain.common.FeedGetOption;
 import org.websoso.WSSServer.domain.common.SortCriteria;
 import org.websoso.WSSServer.dto.feed.FeedCreateRequest;
@@ -54,21 +51,16 @@ import org.websoso.WSSServer.dto.feed.UserFeedsGetResponse;
 import org.websoso.WSSServer.dto.novel.NovelGetResponseFeedTab;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.exception.exception.CustomAvatarException;
-import org.websoso.WSSServer.exception.exception.CustomCategoryException;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
 import org.websoso.WSSServer.exception.exception.CustomGenreException;
 import org.websoso.WSSServer.exception.exception.CustomNovelException;
 import org.websoso.WSSServer.exception.exception.CustomUserException;
-import org.websoso.WSSServer.feed.domain.Category;
 import org.websoso.WSSServer.feed.domain.Comment;
 import org.websoso.WSSServer.feed.domain.Feed;
-import org.websoso.WSSServer.feed.domain.FeedCategory;
 import org.websoso.WSSServer.feed.domain.FeedImage;
 import org.websoso.WSSServer.feed.domain.Like;
 import org.websoso.WSSServer.feed.domain.PopularFeed;
-import org.websoso.WSSServer.feed.repository.CategoryRepository;
 import org.websoso.WSSServer.feed.repository.CommentRepository;
-import org.websoso.WSSServer.feed.repository.FeedCategoryRepository;
 import org.websoso.WSSServer.feed.repository.FeedImageCustomRepository;
 import org.websoso.WSSServer.feed.repository.FeedImageRepository;
 import org.websoso.WSSServer.feed.repository.FeedRepository;
@@ -101,8 +93,6 @@ public class FeedService {
 
     private final NovelRepository novelRepository;
     private final FeedRepository feedRepository;
-    private final CategoryRepository categoryRepository;
-    private final FeedCategoryRepository feedCategoryRepository;
     private final CommentRepository commentRepository;
     private final ReportedCommentRepository reportedCommentRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -131,10 +121,6 @@ public class FeedService {
                 feedImages);
 
         feedRepository.save(feed);
-        for (String relevantCategory : request.relevantCategories()) {
-            Category category = findCategoryByName(relevantCategory);
-            feedCategoryRepository.save(FeedCategory.create(feed, category));
-        }
 
         return FeedCreateResponse.of(feedImages);
     }
@@ -154,28 +140,6 @@ public class FeedService {
         List<FeedImage> feedImages = processFeedImages(imagesRequest.images());
 
         feed.updateFeed(request.feedContent(), request.isSpoiler(), request.isPublic(), request.novelId(), feedImages);
-        List<FeedCategory> feedCategories = feedCategoryRepository.findByFeed(feed);
-
-        if (feedCategories.isEmpty()) {
-            throw new CustomCategoryException(CATEGORY_NOT_FOUND, "Category for the given feed was not found");
-        }
-
-        Set<Category> categories = feedCategories.stream().map(FeedCategory::getCategory).collect(Collectors.toSet());
-
-        Set<Category> newCategories = request.relevantCategories().stream().map(this::findCategoryByName)
-                .collect(Collectors.toSet());
-
-        for (Category newCategory : newCategories) {
-            if (categories.contains(newCategory)) {
-                categories.remove(newCategory);
-            } else {
-                feedCategoryRepository.save(FeedCategory.create(feed, newCategory));
-            }
-        }
-
-        for (Category category : categories) {
-            feedCategoryRepository.deleteByCategoryAndFeed(category, feed);
-        }
 
         List<String> oldImageUrls = oldImages.stream().map(FeedImage::getUrl).toList();
         eventPublisher.publishEvent(new FeedImageDeleteEvent(oldImageUrls));
@@ -299,12 +263,9 @@ public class FeedService {
         UserBasicInfo feedUserBasicInfo = getUserBasicInfo(feed.getUser());
         Novel novel = getLinkedNovelOrNull(feed.getNovelId());
         Boolean isLiked = isUserLikedFeed(user, feed);
-        List<String> relevantCategories = feed.getFeedCategories().stream()
-                .map(feedCategory -> feedCategory.getCategory().getCategoryName().getLabel())
-                .collect(Collectors.toList());
         Boolean isMyFeed = isUserFeedOwner(feed.getUser(), user);
 
-        return FeedGetResponse.of(feed, feedUserBasicInfo, novel, isLiked, relevantCategories, isMyFeed);
+        return FeedGetResponse.of(feed, feedUserBasicInfo, novel, isLiked, isMyFeed);
     }
 
     @Transactional(readOnly = true)
@@ -367,36 +328,38 @@ public class FeedService {
         UserBasicInfo userBasicInfo = getUserBasicInfo(feed.getUser());
         Novel novel = getLinkedNovelOrNull(feed.getNovelId());
         Boolean isLiked = user != null && isUserLikedFeed(user, feed);
-        List<String> relevantCategories = feed.getFeedCategories().stream()
-                .map(feedCategory -> feedCategory.getCategory().getCategoryName().getLabel())
-                .collect(Collectors.toList());
         Boolean isMyFeed = user != null && isUserFeedOwner(feed.getUser(), user);
         Integer imageCount = feedImageRepository.countByFeedId(feed.getFeedId());
         Optional<FeedImage> thumbnailImage = feedImageCustomRepository.findThumbnailFeedImageByFeedId(feed.getFeedId());
         String thumbnailUrl = thumbnailImage.map(FeedImage::getUrl).orElse(null);
 
-        return FeedInfo.of(feed, userBasicInfo, novel, isLiked, relevantCategories, isMyFeed, thumbnailUrl, imageCount,
-                user);
+        return FeedInfo.of(feed, userBasicInfo, novel, isLiked, isMyFeed, thumbnailUrl, imageCount, user);
     }
 
     private Slice<Feed> findFeedsByCategoryLabel(String category, Long lastFeedId, Long userId, PageRequest pageRequest,
-                                                 FeedGetOption feedGetOption, List<Genre> genres) {
+                                                 FeedGetOption feedGetOption, List<Genre> preferenceGenres) {
         if (DEFAULT_CATEGORY.equals(category)) {
             if (FeedGetOption.isAll(feedGetOption)) {
                 return feedRepository.findFeeds(lastFeedId, userId, pageRequest);
             } else {
-                return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, genres);
-            }
-        } else {
-            if (FeedGetOption.isAll(feedGetOption)) {
-                return feedCategoryRepository.findFeedsByCategory(findCategoryByName(category), lastFeedId, userId,
-                        pageRequest);
-            } else {
-                return feedCategoryRepository.findRecommendedFeedsByCategoryLabel(findCategoryByName(category),
-                        lastFeedId,
-                        userId, pageRequest, genres);
+                return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, preferenceGenres);
             }
         }
+
+        boolean includeEtc = "etc".equals(category);
+        List<Genre> filterGenres = includeEtc ? null : List.of(findGenreByName(category));
+
+        if (FeedGetOption.isAll(feedGetOption)) {
+            return feedRepository.findFeedsByGenres(filterGenres, includeEtc, lastFeedId, userId, pageRequest);
+        } else {
+            return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, filterGenres);
+        }
+    }
+
+    private Genre findGenreByName(String genreName) {
+        return genreRepository.findByGenreName(genreName)
+                .orElseThrow(() -> new CustomGenreException(GENRE_NOT_FOUND,
+                        "genre with the given name is not found"));
     }
 
     @Transactional(readOnly = true)
@@ -452,10 +415,13 @@ public class FeedService {
         Long visitorId = Optional.ofNullable(visitor).map(User::getUserId).orElse(null);
 
         if (owner.getIsProfilePublic() || isOwner(visitor, ownerId)) {
-            List<Genre> genres = getGenres(genreNames);
+            boolean includeEtc = genreNames != null && genreNames.contains("etc");
+            List<String> filteredGenreNames = genreNames == null ? null :
+                    genreNames.stream().filter(name -> !name.equals("etc")).collect(Collectors.toList());
+            List<Genre> genres = getGenres(filteredGenreNames);
 
             List<Feed> visibleFeeds = feedRepository.findFeedsByNoOffsetPagination(owner, lastFeedId, size, isVisible,
-                    isUnVisible, sortCriteria, genres, visitorId);
+                    isUnVisible, sortCriteria, genres, visitorId, includeEtc);
 
             List<Long> novelIds = visibleFeeds.stream().map(Feed::getNovelId).filter(Objects::nonNull)
                     .collect(Collectors.toList());
@@ -469,7 +435,7 @@ public class FeedService {
             // TODO Slice의 hasNext()로 판단하도록 수정
             Boolean isLoadable = visibleFeeds.size() == size;
             long feedsCount = feedRepository.countVisibleFeeds(owner, lastFeedId, isVisible, isUnVisible, genres,
-                    visitorId);
+                    visitorId, includeEtc);
 
             return UserFeedsGetResponse.of(isLoadable, feedsCount, userFeedGetResponseList);
         }
@@ -484,11 +450,12 @@ public class FeedService {
 
     private List<Genre> getGenres(List<String> genreNames) {
         if (genreNames != null && !genreNames.isEmpty()) {
-            return genreNames.stream()
+            List<Genre> genres = genreNames.stream()
                     .map(genreName -> genreRepository.findByGenreName(genreName)
                             .orElseThrow(() -> new CustomGenreException(GENRE_NOT_FOUND,
                                     "genre with the given name is not found"))
                     ).toList();
+            return genres.isEmpty() ? null : genres;
         }
         return null;
     }
@@ -500,12 +467,6 @@ public class FeedService {
 
     private Integer getImageCount(Feed feed) {
         return feedImageRepository.countByFeedId(feed.getFeedId());
-    }
-
-    private Category findCategoryByName(String categoryName) {
-        return categoryRepository.findByCategoryName(CategoryName.valueOf(categoryName)).orElseThrow(
-                () -> new CustomCategoryException(INVALID_CATEGORY_FORMAT,
-                        "Category for the given feed was not found"));
     }
 
     private void sendPopularFeedPushMessage(Feed feed) {

--- a/src/main/java/org/websoso/WSSServer/feed/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/feed/service/FeedService.java
@@ -275,13 +275,13 @@ public class FeedService {
 
         List<Genre> genres = getPreferenceGenres(user);
 
-        Slice<Feed> feeds = findFeedsByCategoryLabel(getChosenCategoryOrDefault(category), lastFeedId, userIdOrNull,
+        Slice<Feed> feeds = findFeedsByCategoryLabel(lastFeedId, userIdOrNull,
                 PageRequest.of(DEFAULT_PAGE_NUMBER, size), feedGetOption, genres);
 
         List<FeedInfo> feedGetResponses = feeds.getContent().stream().filter(feed -> feed.isVisibleTo(userIdOrNull))
                 .map(feed -> createFeedInfo(feed, user)).toList();
 
-        return FeedsGetResponse.of(getChosenCategoryOrDefault(category), feeds.hasNext(), feedGetResponses);
+        return FeedsGetResponse.of(feeds.hasNext(), feedGetResponses);
     }
 
     private List<Genre> getPreferenceGenres(User user) {
@@ -336,24 +336,13 @@ public class FeedService {
         return FeedInfo.of(feed, userBasicInfo, novel, isLiked, isMyFeed, thumbnailUrl, imageCount, user);
     }
 
-    private Slice<Feed> findFeedsByCategoryLabel(String category, Long lastFeedId, Long userId, PageRequest pageRequest,
+    private Slice<Feed> findFeedsByCategoryLabel(Long lastFeedId, Long userId, PageRequest pageRequest,
                                                  FeedGetOption feedGetOption, List<Genre> preferenceGenres) {
-        if (DEFAULT_CATEGORY.equals(category)) {
             if (FeedGetOption.isAll(feedGetOption)) {
                 return feedRepository.findFeeds(lastFeedId, userId, pageRequest);
-            } else {
-                return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, preferenceGenres);
             }
-        }
+            return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, preferenceGenres);
 
-        boolean includeEtc = "etc".equals(category);
-        List<Genre> filterGenres = includeEtc ? null : List.of(findGenreByName(category));
-
-        if (FeedGetOption.isAll(feedGetOption)) {
-            return feedRepository.findFeedsByGenres(filterGenres, includeEtc, lastFeedId, userId, pageRequest);
-        } else {
-            return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, filterGenres);
-        }
     }
 
     private Genre findGenreByName(String genreName) {

--- a/src/main/java/org/websoso/WSSServer/feed/service/FeedServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/service/FeedServiceImpl.java
@@ -1,7 +1,7 @@
 package org.websoso.WSSServer.feed.service;
 
-import static org.websoso.WSSServer.exception.error.CustomCategoryError.INVALID_CATEGORY_FORMAT;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOUND;
+import static org.websoso.WSSServer.exception.error.CustomGenreError.GENRE_NOT_FOUND;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,31 +11,27 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Genre;
-import org.websoso.WSSServer.domain.common.CategoryName;
 import org.websoso.WSSServer.domain.common.FeedGetOption;
-import org.websoso.WSSServer.exception.exception.CustomCategoryException;
 import org.websoso.WSSServer.exception.exception.CustomFeedException;
-import org.websoso.WSSServer.feed.domain.Category;
+import org.websoso.WSSServer.exception.exception.CustomGenreException;
 import org.websoso.WSSServer.feed.domain.Feed;
 import org.websoso.WSSServer.feed.domain.FeedImage;
 import org.websoso.WSSServer.feed.domain.PopularFeed;
-import org.websoso.WSSServer.feed.repository.CategoryRepository;
-import org.websoso.WSSServer.feed.repository.FeedCategoryRepository;
 import org.websoso.WSSServer.feed.repository.FeedImageCustomRepository;
 import org.websoso.WSSServer.feed.repository.FeedImageRepository;
 import org.websoso.WSSServer.feed.repository.FeedRepository;
 import org.websoso.WSSServer.feed.repository.PopularFeedRepository;
+import org.websoso.WSSServer.repository.GenreRepository;
 
 @Service
 @RequiredArgsConstructor
 public class FeedServiceImpl {
 
     private final FeedRepository feedRepository;
-    private final FeedCategoryRepository feedCategoryRepository;
-    private final CategoryRepository categoryRepository;
     private final FeedImageRepository feedImageRepository;
     private final FeedImageCustomRepository feedImageCustomRepository;
     private final PopularFeedRepository popularFeedRepository;
+    private final GenreRepository genreRepository;
 
     private static final String DEFAULT_CATEGORY = "all";
 
@@ -47,29 +43,29 @@ public class FeedServiceImpl {
 
     @Transactional(readOnly = true)
     public Slice<Feed> findFeedsByCategoryLabel(String category, Long lastFeedId, Long userId, PageRequest pageRequest,
-                                                FeedGetOption feedGetOption, List<Genre> genres) {
+                                                FeedGetOption feedGetOption, List<Genre> preferenceGenres) {
         if (DEFAULT_CATEGORY.equals(category)) {
             if (FeedGetOption.isAll(feedGetOption)) {
                 return feedRepository.findFeeds(lastFeedId, userId, pageRequest);
             } else {
-                return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, genres);
+                return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, preferenceGenres);
             }
+        }
+
+        boolean includeEtc = "etc".equals(category);
+        List<Genre> filterGenres = includeEtc ? null : List.of(findGenreByName(category));
+
+        if (FeedGetOption.isAll(feedGetOption)) {
+            return feedRepository.findFeedsByGenres(filterGenres, includeEtc, lastFeedId, userId, pageRequest);
         } else {
-            if (FeedGetOption.isAll(feedGetOption)) {
-                return feedCategoryRepository.findFeedsByCategory(findCategoryByName(category), lastFeedId, userId,
-                        pageRequest);
-            } else {
-                return feedCategoryRepository.findRecommendedFeedsByCategoryLabel(findCategoryByName(category),
-                        lastFeedId, userId, pageRequest, genres);
-            }
+            return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, filterGenres);
         }
     }
 
-    // 이 부분 private으로 두는 게 맞을지 아니면 public으로 두는 게 나을지 고민
-    private Category findCategoryByName(String categoryName) {
-        return categoryRepository.findByCategoryName(CategoryName.valueOf(categoryName)).orElseThrow(
-                () -> new CustomCategoryException(INVALID_CATEGORY_FORMAT,
-                        "Category for the given feed was not found"));
+    private Genre findGenreByName(String genreName) {
+        return genreRepository.findByGenreName(genreName)
+                .orElseThrow(() -> new CustomGenreException(GENRE_NOT_FOUND,
+                        "genre with the given name is not found"));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/websoso/WSSServer/feed/service/FeedServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/service/FeedServiceImpl.java
@@ -42,24 +42,15 @@ public class FeedServiceImpl {
     }
 
     @Transactional(readOnly = true)
-    public Slice<Feed> findFeedsByCategoryLabel(String category, Long lastFeedId, Long userId, PageRequest pageRequest,
+    public Slice<Feed> findFeedsByCategoryLabel(Long lastFeedId, Long userId, PageRequest pageRequest,
                                                 FeedGetOption feedGetOption, List<Genre> preferenceGenres) {
-        if (DEFAULT_CATEGORY.equals(category)) {
+
             if (FeedGetOption.isAll(feedGetOption)) {
                 return feedRepository.findFeeds(lastFeedId, userId, pageRequest);
             } else {
                 return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, preferenceGenres);
             }
-        }
 
-        boolean includeEtc = "etc".equals(category);
-        List<Genre> filterGenres = includeEtc ? null : List.of(findGenreByName(category));
-
-        if (FeedGetOption.isAll(feedGetOption)) {
-            return feedRepository.findFeedsByGenres(filterGenres, includeEtc, lastFeedId, userId, pageRequest);
-        } else {
-            return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, filterGenres);
-        }
     }
 
     private Genre findGenreByName(String genreName) {

--- a/src/test/java/org/websoso/WSSServer/feed/FeedApiIntegrationTest.java
+++ b/src/test/java/org/websoso/WSSServer/feed/FeedApiIntegrationTest.java
@@ -1,0 +1,367 @@
+package org.websoso.WSSServer.feed;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.websoso.WSSServer.oauth2.repository.RefreshTokenRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+@Transactional
+class FeedApiIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    TransactionTemplate transactionTemplate;
+
+    @Autowired
+    EntityManager em;
+
+
+    private static final Long USER_ID = 10034L;
+    private static final Long NOVEL_ID = 3147L;
+    private static final String TEST_GENRE_NAME = "romance";
+
+    private Long genreId = 1L;
+    private final List<Long> insertedFeedIds = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        transactionTemplate.execute(status -> {
+            // 피드1: 소설 연결 피드
+            em.createNativeQuery("""
+                    INSERT INTO feed (feed_content, novel_id, is_spoiler, is_public, is_hidden, user_id, created_date, modified_date)
+                    VALUES ('테스트_소설연결피드', ?, FALSE, TRUE, FALSE, ?, NOW(), NOW())
+                    """)
+                    .setParameter(1, NOVEL_ID)
+                    .setParameter(2, USER_ID)
+                    .executeUpdate();
+            insertedFeedIds.add(((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue());
+
+            // 피드2: etc 피드 (novelId = null)
+            em.createNativeQuery("""
+                    INSERT INTO feed (feed_content, novel_id, is_spoiler, is_public, is_hidden, user_id, created_date, modified_date)
+                    VALUES ('테스트_소설없는피드1', NULL, FALSE, TRUE, FALSE, ?, NOW(), NOW())
+                    """)
+                    .setParameter(1, USER_ID)
+                    .executeUpdate();
+            insertedFeedIds.add(((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue());
+
+            // 피드3: etc 피드 (novelId = null)
+            em.createNativeQuery("""
+                    INSERT INTO feed (feed_content, novel_id, is_spoiler, is_public, is_hidden, user_id, created_date, modified_date)
+                    VALUES ('테스트_소설없는피드2', NULL, FALSE, TRUE, FALSE, ?, NOW(), NOW())
+                    """)
+                    .setParameter(1, USER_ID)
+                    .executeUpdate();
+            insertedFeedIds.add(((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue());
+
+            return null;
+        });
+    }
+
+    private String getAccessToken() throws Exception {
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.post("/users/login")
+                                .contentType(APPLICATION_JSON)
+                                .content(String.valueOf(USER_ID)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        return objectMapper.readTree(body).get("Authorization").asText();
+    }
+
+    // ============================================================
+    // GET /feeds - category=all
+    // ============================================================
+
+    @Test
+    void category_all_요청시_200_응답과_피드_목록이_반환된다() throws Exception {
+        String token = getAccessToken();
+
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/feeds")
+                                .header("Authorization", "Bearer " + token)
+                                .param("category", "all")
+                                .param("lastFeedId", "0")
+                                .param("size", "100"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        System.out.println(body);
+        int feedCount = objectMapper.readTree(body).get("feeds").size();
+        assertThat(feedCount).isGreaterThanOrEqualTo(3);
+    }
+
+    // ============================================================
+    // GET /feeds - category=etc
+    // ============================================================
+
+    @Test
+    void category_etc_요청시_novelId가_null인_피드만_반환된다() throws Exception {
+        String token = getAccessToken();
+
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/feeds")
+                                .header("Authorization", "Bearer " + token)
+                                .param("category", "etc")
+                                .param("lastFeedId", "0")
+                                .param("size", "10"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        System.out.println(body);
+        var feeds = objectMapper.readTree(body).get("feeds");
+        feeds.forEach(feed -> assertThat(feed.get("novelId").isNull()).isTrue());
+    }
+
+    // ============================================================
+    // GET /feeds - category=장르명
+    // ============================================================
+
+    @Test
+    void category_장르명_요청시_해당_장르의_소설이_연결된_피드만_반환된다() throws Exception {
+        String token = getAccessToken();
+
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/feeds")
+                                .header("Authorization", "Bearer " + token)
+                                .param("category", TEST_GENRE_NAME)
+                                .param("lastFeedId", "0")
+                                .param("size", "10"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        var feeds = objectMapper.readTree(body).get("feeds");
+        assertThat(feeds.size()).isGreaterThanOrEqualTo(1);
+        feeds.forEach(feed -> assertThat(feed.get("novelId").isNull()).isFalse());
+    }
+
+    // ============================================================
+    // GET /feeds - 존재하지 않는 장르명
+    // ============================================================
+
+    @Test
+    void 존재하지_않는_장르명으로_요청시_에러가_반환된다() throws Exception {
+        String token = getAccessToken();
+
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/feeds")
+                                .header("Authorization", "Bearer " + token)
+                                .param("category", "없는장르xyz")
+                                .param("lastFeedId", "0")
+                                .param("size", "10"))
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError());
+    }
+
+    // ============================================================
+    // GET /feeds - 비로그인(anonymous)
+    // ============================================================
+
+    @Test
+    void 비로그인_상태로_category_all_요청시_200_응답이_반환된다() throws Exception {
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/feeds")
+                                .param("category", "all")
+                                .param("lastFeedId", "0")
+                                .param("size", "10"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(objectMapper.readTree(body).get("feeds")).isNotNull();
+    }
+
+    @Test
+    void 비로그인_상태로_category_etc_요청시_200_응답이_반환된다() throws Exception {
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/feeds")
+                                .param("category", "etc")
+                                .param("lastFeedId", "0")
+                                .param("size", "10"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        var feeds = objectMapper.readTree(body).get("feeds");
+        feeds.forEach(feed -> assertThat(feed.get("novelId").isNull()).isTrue());
+    }
+
+    // ============================================================
+    // POST /feeds - FeedCreateRequest (relevantCategories 없이 정상 동작)
+    // ============================================================
+
+    private MockMultipartFile feedPart(String json) {
+        return new MockMultipartFile("feed", null, "application/json",
+                json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    private static final String CREATE_FEED_CONTENT = "API생성_테스트피드내용";
+    private static final String CREATE_FEED_CONTENT_COMPAT = "API생성_하위호환테스트피드";
+
+    @Test
+    void 피드_생성시_relevantCategories_없이_201이_반환된다() throws Exception {
+        String token = getAccessToken();
+        String feedJson = String.format(
+                "{\"feedContent\":\"%s\",\"novelId\":null,\"isSpoiler\":false,\"isPublic\":true}",
+                CREATE_FEED_CONTENT);
+
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.multipart("/feeds")
+                                .file(feedPart(feedJson))
+                                .header("Authorization", "Bearer " + token))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andReturn();
+
+        var responseNode = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(responseNode.has("imagesCount")).isTrue();
+    }
+
+    @Test
+    void 피드_생성시_relevantCategories_포함해도_201이_반환된다() throws Exception {
+        String token = getAccessToken();
+        // 기존 클라이언트가 relevantCategories를 포함해서 요청해도 에러가 나지 않는지 검증 (하위호환)
+        String feedJsonWithOldField = String.format(
+                "{\"feedContent\":\"%s\",\"novelId\":null,\"isSpoiler\":false,\"isPublic\":true,\"relevantCategories\":[\"로맨스\",\"판타지\"]}",
+                CREATE_FEED_CONTENT_COMPAT);
+
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.multipart("/feeds")
+                                .file(feedPart(feedJsonWithOldField))
+                                .header("Authorization", "Bearer " + token))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andReturn();
+
+        var responseNode = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(responseNode.has("imagesCount")).isTrue();
+    }
+
+    // ============================================================
+    // GET /feeds/{feedId} - FeedGetResponse에 relevantCategories 없음
+    // ============================================================
+
+    @Test
+    void 단건_피드_조회시_응답에_relevantCategories_필드가_없다() throws Exception {
+        Long feedId = insertedFeedIds.get(0);
+        String token = getAccessToken();
+
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/feeds/{feedId}", feedId)
+                                .header("Authorization", "Bearer " + token))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        var responseNode = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(responseNode.has("relevantCategories")).isFalse();
+    }
+
+    // ============================================================
+    // GET /users/{userId}/feeds - UserFeedGetResponse에 relevantCategories 없음
+    // ============================================================
+
+    @Test
+    void 유저_피드_목록_조회시_응답에_relevantCategories_필드가_없다() throws Exception {
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/users/{userId}/feeds", USER_ID)
+                                .param("lastFeedId", "0")
+                                .param("size", "10"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        var feeds = objectMapper.readTree(result.getResponse().getContentAsString()).get("feeds");
+        assertThat(feeds.size()).isGreaterThanOrEqualTo(1);
+        feeds.forEach(feed -> assertThat(feed.has("relevantCategories")).isFalse());
+    }
+
+    @Test
+    void 유저_피드_목록_조회시_genreNames에_etc_포함하면_novelId_null_피드만_반환된다() throws Exception {
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/users/{userId}/feeds", USER_ID)
+                                .param("lastFeedId", "0")
+                                .param("size", "10")
+                                .param("genreNames", "etc"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        var feeds = objectMapper.readTree(result.getResponse().getContentAsString()).get("feeds");
+        assertThat(feeds.size()).isGreaterThanOrEqualTo(1);
+        feeds.forEach(feed -> assertThat(feed.get("novelId").isNull()).isTrue());
+    }
+
+    // ============================================================
+    // GET /users/{userId}/feeds - genreNames에 선호 장르만 포함 시 etc 피드 미포함
+    // ============================================================
+
+    @Test
+    void 유저_피드_목록_조회시_선호_장르로만_검색하면_etc_피드가_포함되지_않는다() throws Exception {
+        // etc 피드(novelId=null)는 소설과 연결이 없으므로 장르 기반 검색 대상이 아님
+        // 선호 장르(소설 연결 필요)로만 검색하면 etc 피드는 결과에 나오지 않아야 함
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/users/{userId}/feeds", USER_ID)
+                                .param("lastFeedId", "0")
+                                .param("size", "100")
+                                .param("genreNames", TEST_GENRE_NAME))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        var feeds = objectMapper.readTree(result.getResponse().getContentAsString()).get("feeds");
+        // 모든 결과 피드는 소설이 연결된 피드여야 함 (etc 피드 제외)
+        feeds.forEach(feed -> {assertThat(feed.get("novelId").isNull()).isFalse();
+        });
+    }
+
+    @Test
+    void 유저_피드_목록_조회시_etc_피드만_있는_상태에서_선호_장르로_검색하면_빈_목록이_반환된다() throws Exception {
+        // etc 전용 유저 피드 셋업: 소설 연결 피드(피드1)를 제외하고 etc 피드(피드2, 피드3)만 남긴다
+        Long novelFeedId = insertedFeedIds.get(0);
+        transactionTemplate.execute(status -> {
+            em.createNativeQuery("DELETE FROM feed WHERE feed_id = ?")
+                    .setParameter(1, novelFeedId)
+                    .executeUpdate();
+            return null;
+        });
+        insertedFeedIds.remove(novelFeedId);
+
+        // 이 시점에서 USER_ID의 피드는 novelId=null인 etc 피드 2개만 남음
+        // TEST_GENRE_NAME(선호 장르)으로 검색하면 소설이 연결된 피드가 없으므로 빈 목록 반환
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/users/{userId}/feeds", USER_ID)
+                                .param("lastFeedId", "0")
+                                .param("size", "100")
+                                .param("genreNames", TEST_GENRE_NAME))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        var feeds = objectMapper.readTree(result.getResponse().getContentAsString()).get("feeds");
+        assertThat(feeds.size()).isZero();
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/feed/FeedApiIntegrationTest.java
+++ b/src/test/java/org/websoso/WSSServer/feed/FeedApiIntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
+import org.websoso.WSSServer.domain.common.FeedGetOption;
 import org.websoso.WSSServer.oauth2.repository.RefreshTokenRepository;
 
 @SpringBootTest
@@ -108,7 +109,6 @@ class FeedApiIntegrationTest {
         MvcResult result = mockMvc.perform(
                         MockMvcRequestBuilders.get("/feeds")
                                 .header("Authorization", "Bearer " + token)
-                                .param("category", "all")
                                 .param("lastFeedId", "0")
                                 .param("size", "100"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -120,68 +120,8 @@ class FeedApiIntegrationTest {
         assertThat(feedCount).isGreaterThanOrEqualTo(3);
     }
 
-    // ============================================================
-    // GET /feeds - category=etc
-    // ============================================================
 
-    @Test
-    void category_etc_요청시_novelId가_null인_피드만_반환된다() throws Exception {
-        String token = getAccessToken();
 
-        MvcResult result = mockMvc.perform(
-                        MockMvcRequestBuilders.get("/feeds")
-                                .header("Authorization", "Bearer " + token)
-                                .param("category", "etc")
-                                .param("lastFeedId", "0")
-                                .param("size", "10"))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andReturn();
-
-        String body = result.getResponse().getContentAsString();
-        System.out.println(body);
-        var feeds = objectMapper.readTree(body).get("feeds");
-        feeds.forEach(feed -> assertThat(feed.get("novelId").isNull()).isTrue());
-    }
-
-    // ============================================================
-    // GET /feeds - category=장르명
-    // ============================================================
-
-    @Test
-    void category_장르명_요청시_해당_장르의_소설이_연결된_피드만_반환된다() throws Exception {
-        String token = getAccessToken();
-
-        MvcResult result = mockMvc.perform(
-                        MockMvcRequestBuilders.get("/feeds")
-                                .header("Authorization", "Bearer " + token)
-                                .param("category", TEST_GENRE_NAME)
-                                .param("lastFeedId", "0")
-                                .param("size", "10"))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andReturn();
-
-        String body = result.getResponse().getContentAsString();
-        var feeds = objectMapper.readTree(body).get("feeds");
-        assertThat(feeds.size()).isGreaterThanOrEqualTo(1);
-        feeds.forEach(feed -> assertThat(feed.get("novelId").isNull()).isFalse());
-    }
-
-    // ============================================================
-    // GET /feeds - 존재하지 않는 장르명
-    // ============================================================
-
-    @Test
-    void 존재하지_않는_장르명으로_요청시_에러가_반환된다() throws Exception {
-        String token = getAccessToken();
-
-        mockMvc.perform(
-                        MockMvcRequestBuilders.get("/feeds")
-                                .header("Authorization", "Bearer " + token)
-                                .param("category", "없는장르xyz")
-                                .param("lastFeedId", "0")
-                                .param("size", "10"))
-                .andExpect(MockMvcResultMatchers.status().is4xxClientError());
-    }
 
     // ============================================================
     // GET /feeds - 비로그인(anonymous)
@@ -191,7 +131,6 @@ class FeedApiIntegrationTest {
     void 비로그인_상태로_category_all_요청시_200_응답이_반환된다() throws Exception {
         MvcResult result = mockMvc.perform(
                         MockMvcRequestBuilders.get("/feeds")
-                                .param("category", "all")
                                 .param("lastFeedId", "0")
                                 .param("size", "10"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -201,24 +140,7 @@ class FeedApiIntegrationTest {
         assertThat(objectMapper.readTree(body).get("feeds")).isNotNull();
     }
 
-    @Test
-    void 비로그인_상태로_category_etc_요청시_200_응답이_반환된다() throws Exception {
-        MvcResult result = mockMvc.perform(
-                        MockMvcRequestBuilders.get("/feeds")
-                                .param("category", "etc")
-                                .param("lastFeedId", "0")
-                                .param("size", "10"))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andReturn();
 
-        String body = result.getResponse().getContentAsString();
-        var feeds = objectMapper.readTree(body).get("feeds");
-        feeds.forEach(feed -> assertThat(feed.get("novelId").isNull()).isTrue());
-    }
-
-    // ============================================================
-    // POST /feeds - FeedCreateRequest (relevantCategories 없이 정상 동작)
-    // ============================================================
 
     private MockMultipartFile feedPart(String json) {
         return new MockMultipartFile("feed", null, "application/json",
@@ -284,10 +206,6 @@ class FeedApiIntegrationTest {
         assertThat(responseNode.has("relevantCategories")).isFalse();
     }
 
-    // ============================================================
-    // GET /users/{userId}/feeds - UserFeedGetResponse에 relevantCategories 없음
-    // ============================================================
-
     @Test
     void 유저_피드_목록_조회시_응답에_relevantCategories_필드가_없다() throws Exception {
         MvcResult result = mockMvc.perform(
@@ -317,51 +235,84 @@ class FeedApiIntegrationTest {
         feeds.forEach(feed -> assertThat(feed.get("novelId").isNull()).isTrue());
     }
 
-    // ============================================================
-    // GET /users/{userId}/feeds - genreNames에 선호 장르만 포함 시 etc 피드 미포함
-    // ============================================================
-
     @Test
-    void 유저_피드_목록_조회시_선호_장르로만_검색하면_etc_피드가_포함되지_않는다() throws Exception {
-        // etc 피드(novelId=null)는 소설과 연결이 없으므로 장르 기반 검색 대상이 아님
-        // 선호 장르(소설 연결 필요)로만 검색하면 etc 피드는 결과에 나오지 않아야 함
+    void 피드_목록_조회시_선호_장르로만_검색하면_etc_피드가_포함되지_않는다() throws Exception {
+        String token = getAccessToken();
         MvcResult result = mockMvc.perform(
-                        MockMvcRequestBuilders.get("/users/{userId}/feeds", USER_ID)
+                        MockMvcRequestBuilders.get("/feeds")
+                                .header("Authorization", "Bearer " + token)
                                 .param("lastFeedId", "0")
                                 .param("size", "100")
-                                .param("genreNames", TEST_GENRE_NAME))
+                                .param("feedsOption", "RECOMMENDED"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn();
 
         var feeds = objectMapper.readTree(result.getResponse().getContentAsString()).get("feeds");
-        // 모든 결과 피드는 소설이 연결된 피드여야 함 (etc 피드 제외)
+
         feeds.forEach(feed -> {assertThat(feed.get("novelId").isNull()).isFalse();
         });
     }
 
     @Test
-    void 유저_피드_목록_조회시_etc_피드만_있는_상태에서_선호_장르로_검색하면_빈_목록이_반환된다() throws Exception {
-        // etc 전용 유저 피드 셋업: 소설 연결 피드(피드1)를 제외하고 etc 피드(피드2, 피드3)만 남긴다
-        Long novelFeedId = insertedFeedIds.get(0);
-        transactionTemplate.execute(status -> {
-            em.createNativeQuery("DELETE FROM feed WHERE feed_id = ?")
-                    .setParameter(1, novelFeedId)
-                    .executeUpdate();
-            return null;
-        });
-        insertedFeedIds.remove(novelFeedId);
-
-        // 이 시점에서 USER_ID의 피드는 novelId=null인 etc 피드 2개만 남음
-        // TEST_GENRE_NAME(선호 장르)으로 검색하면 소설이 연결된 피드가 없으므로 빈 목록 반환
+    void 유저_피드_목록_조회시_장르가_etc이면_작품_없는_피드만_조회되야_한다() throws Exception {
+        String token = getAccessToken();
         MvcResult result = mockMvc.perform(
                         MockMvcRequestBuilders.get("/users/{userId}/feeds", USER_ID)
+                                .header("Authorization", "Bearer " + token)
                                 .param("lastFeedId", "0")
-                                .param("size", "100")
-                                .param("genreNames", TEST_GENRE_NAME))
+                                .param("size", "10")
+                                .param("genreNames", "etc"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn();
 
         var feeds = objectMapper.readTree(result.getResponse().getContentAsString()).get("feeds");
-        assertThat(feeds.size()).isZero();
+        assertThat(feeds.size()).isGreaterThanOrEqualTo(1);
+        feeds.forEach(feed -> assertThat(feed.get("genre").isNull()).isTrue());
+    }
+
+    @Test
+    void 유저_피드_목록_조회시_장르가_여러개일때_여러_장르의_작품이_조회되야_한다() throws Exception {
+        String token = getAccessToken();
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/users/{userId}/feeds", USER_ID)
+                                .header("Authorization", "Bearer " + token)
+                                .param("lastFeedId", "0")
+                                .param("size", "10")
+                                .param("genreNames", "etc")
+                                .param("genreNames", "romance"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        var feeds = objectMapper.readTree(result.getResponse().getContentAsString()).get("feeds");
+        assertThat(feeds.size()).isGreaterThanOrEqualTo(2);
+        feeds.forEach(feed -> {
+            var genreNode = feed.get("genre");
+            boolean isNullOrRomance = genreNode.isNull() || "romance".equals(genreNode.asText());
+
+            assertThat(isNullOrRomance).isTrue();
+        });
+    }
+
+    @Test
+    void 유저_피드_목록_조회시_장르에_etc_없으면_작품이_조회되야_한다() throws Exception {
+        String token = getAccessToken();
+        MvcResult result = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/users/{userId}/feeds", USER_ID)
+                                .header("Authorization", "Bearer " + token)
+                                .param("lastFeedId", "0")
+                                .param("size", "10")
+                                .param("genreNames", "etc")
+                                .param("genreNames", "romance"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        var feeds = objectMapper.readTree(result.getResponse().getContentAsString()).get("feeds");
+        assertThat(feeds.size()).isGreaterThanOrEqualTo(2);
+        feeds.forEach(feed -> {
+            var genreNode = feed.get("genre");
+            boolean isNullOrRomance = genreNode.isNull() || "romance".equals(genreNode.asText());
+
+            assertThat(isNullOrRomance).isTrue();
+        });
     }
 }

--- a/src/test/java/org/websoso/WSSServer/feed/service/FeedServiceImplTest.java
+++ b/src/test/java/org/websoso/WSSServer/feed/service/FeedServiceImplTest.java
@@ -1,0 +1,136 @@
+package org.websoso.WSSServer.feed.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.websoso.WSSServer.domain.Genre;
+import org.websoso.WSSServer.domain.common.FeedGetOption;
+import org.websoso.WSSServer.exception.exception.CustomGenreException;
+import org.websoso.WSSServer.feed.repository.FeedImageCustomRepository;
+import org.websoso.WSSServer.feed.repository.FeedImageRepository;
+import org.websoso.WSSServer.feed.repository.FeedRepository;
+import org.websoso.WSSServer.feed.repository.PopularFeedRepository;
+import org.websoso.WSSServer.repository.GenreRepository;
+
+@ExtendWith(MockitoExtension.class)
+class FeedServiceImplTest {
+
+    @Mock
+    FeedRepository feedRepository;
+    @Mock
+    FeedImageRepository feedImageRepository;
+    @Mock
+    FeedImageCustomRepository feedImageCustomRepository;
+    @Mock
+    PopularFeedRepository popularFeedRepository;
+    @Mock
+    GenreRepository genreRepository;
+
+    @InjectMocks
+    FeedServiceImpl feedServiceImpl;
+
+    private PageRequest pageRequest;
+    private static final Long LAST_FEED_ID = 0L;
+    private static final Long USER_ID = 1L;
+    private static final int SIZE = 10;
+
+    @BeforeEach
+    void setUp() {
+        pageRequest = PageRequest.of(0, SIZE);
+    }
+
+    @Test
+    void category가_all이고_ALL_옵션이면_findFeeds를_호출한다() {
+        feedServiceImpl.findFeedsByCategoryLabel("all", LAST_FEED_ID, USER_ID, pageRequest, FeedGetOption.ALL, null);
+
+        verify(feedRepository).findFeeds(LAST_FEED_ID, USER_ID, pageRequest);
+        verify(feedRepository, never()).findRecommendedFeeds(any(), any(), any(), any());
+        verify(feedRepository, never()).findFeedsByGenres(any(), anyBoolean(), any(), any(), any());
+    }
+
+    @Test
+    void category가_all이고_RECOMMENDED_옵션이면_findRecommendedFeeds를_유저_선호장르로_호출한다() {
+        Genre prefGenre = mock(Genre.class);
+        List<Genre> preferenceGenres = List.of(prefGenre);
+
+        feedServiceImpl.findFeedsByCategoryLabel("all", LAST_FEED_ID, USER_ID, pageRequest,
+                FeedGetOption.RECOMMENDED, preferenceGenres);
+
+        verify(feedRepository).findRecommendedFeeds(LAST_FEED_ID, USER_ID, pageRequest, preferenceGenres);
+        verify(feedRepository, never()).findFeeds(any(), any(), any());
+    }
+
+    @Test
+    void category가_etc이고_ALL_옵션이면_novelId_null_피드만_조회한다() {
+        feedServiceImpl.findFeedsByCategoryLabel("etc", LAST_FEED_ID, USER_ID, pageRequest, FeedGetOption.ALL, null);
+
+        verify(feedRepository).findFeedsByGenres(isNull(), eq(true), eq(LAST_FEED_ID), eq(USER_ID), eq(pageRequest));
+        verify(feedRepository, never()).findFeeds(any(), any(), any());
+    }
+
+    @Test
+    void category가_etc이고_RECOMMENDED_옵션이면_findRecommendedFeeds를_null_genres로_호출한다() {
+        feedServiceImpl.findFeedsByCategoryLabel("etc", LAST_FEED_ID, USER_ID, pageRequest,
+                FeedGetOption.RECOMMENDED, null);
+
+        verify(feedRepository).findRecommendedFeeds(eq(LAST_FEED_ID), eq(USER_ID), eq(pageRequest), isNull());
+        verify(feedRepository, never()).findFeedsByGenres(any(), anyBoolean(), any(), any(), any());
+    }
+
+    @Test
+    void category가_특정_장르명이고_ALL_옵션이면_해당_장르로_findFeedsByGenres를_호출한다() {
+        Genre romance = mock(Genre.class);
+        when(genreRepository.findByGenreName("로맨스")).thenReturn(Optional.of(romance));
+
+        feedServiceImpl.findFeedsByCategoryLabel("로맨스", LAST_FEED_ID, USER_ID, pageRequest, FeedGetOption.ALL, null);
+
+        verify(feedRepository).findFeedsByGenres(eq(List.of(romance)), eq(false), eq(LAST_FEED_ID), eq(USER_ID),
+                eq(pageRequest));
+    }
+
+    @Test
+    void category가_특정_장르명이고_RECOMMENDED_옵션이면_해당_장르로_findRecommendedFeeds를_호출한다() {
+        Genre romance = mock(Genre.class);
+        when(genreRepository.findByGenreName("로맨스")).thenReturn(Optional.of(romance));
+
+        feedServiceImpl.findFeedsByCategoryLabel("로맨스", LAST_FEED_ID, USER_ID, pageRequest,
+                FeedGetOption.RECOMMENDED, null);
+
+        verify(feedRepository).findRecommendedFeeds(eq(LAST_FEED_ID), eq(USER_ID), eq(pageRequest),
+                eq(List.of(romance)));
+        verify(feedRepository, never()).findFeedsByGenres(any(), anyBoolean(), any(), any(), any());
+    }
+
+    @Test
+    void 존재하지_않는_장르명이면_GENRE_NOT_FOUND_예외가_발생한다() {
+        when(genreRepository.findByGenreName("없는장르")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                feedServiceImpl.findFeedsByCategoryLabel("없는장르", LAST_FEED_ID, USER_ID, pageRequest,
+                        FeedGetOption.ALL, null))
+                .isInstanceOf(CustomGenreException.class);
+    }
+
+    @Test
+    void feedGetOption이_null이면_ALL로_동작한다() {
+        feedServiceImpl.findFeedsByCategoryLabel("all", LAST_FEED_ID, USER_ID, pageRequest, null, null);
+
+        verify(feedRepository).findFeeds(LAST_FEED_ID, USER_ID, pageRequest);
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/feed/service/FeedServiceImplTest.java
+++ b/src/test/java/org/websoso/WSSServer/feed/service/FeedServiceImplTest.java
@@ -56,8 +56,8 @@ class FeedServiceImplTest {
     }
 
     @Test
-    void category가_all이고_ALL_옵션이면_findFeeds를_호출한다() {
-        feedServiceImpl.findFeedsByCategoryLabel("all", LAST_FEED_ID, USER_ID, pageRequest, FeedGetOption.ALL, null);
+    void ALL_옵션이면_findFeeds를_호출한다() {
+        feedServiceImpl.findFeedsByCategoryLabel(LAST_FEED_ID, USER_ID, pageRequest, FeedGetOption.ALL, null);
 
         verify(feedRepository).findFeeds(LAST_FEED_ID, USER_ID, pageRequest);
         verify(feedRepository, never()).findRecommendedFeeds(any(), any(), any(), any());
@@ -65,11 +65,11 @@ class FeedServiceImplTest {
     }
 
     @Test
-    void category가_all이고_RECOMMENDED_옵션이면_findRecommendedFeeds를_유저_선호장르로_호출한다() {
+    void RECOMMENDED_옵션이면_findRecommendedFeeds를_유저_선호장르로_호출한다() {
         Genre prefGenre = mock(Genre.class);
         List<Genre> preferenceGenres = List.of(prefGenre);
 
-        feedServiceImpl.findFeedsByCategoryLabel("all", LAST_FEED_ID, USER_ID, pageRequest,
+        feedServiceImpl.findFeedsByCategoryLabel(LAST_FEED_ID, USER_ID, pageRequest,
                 FeedGetOption.RECOMMENDED, preferenceGenres);
 
         verify(feedRepository).findRecommendedFeeds(LAST_FEED_ID, USER_ID, pageRequest, preferenceGenres);
@@ -77,59 +77,8 @@ class FeedServiceImplTest {
     }
 
     @Test
-    void category가_etc이고_ALL_옵션이면_novelId_null_피드만_조회한다() {
-        feedServiceImpl.findFeedsByCategoryLabel("etc", LAST_FEED_ID, USER_ID, pageRequest, FeedGetOption.ALL, null);
-
-        verify(feedRepository).findFeedsByGenres(isNull(), eq(true), eq(LAST_FEED_ID), eq(USER_ID), eq(pageRequest));
-        verify(feedRepository, never()).findFeeds(any(), any(), any());
-    }
-
-    @Test
-    void category가_etc이고_RECOMMENDED_옵션이면_findRecommendedFeeds를_null_genres로_호출한다() {
-        feedServiceImpl.findFeedsByCategoryLabel("etc", LAST_FEED_ID, USER_ID, pageRequest,
-                FeedGetOption.RECOMMENDED, null);
-
-        verify(feedRepository).findRecommendedFeeds(eq(LAST_FEED_ID), eq(USER_ID), eq(pageRequest), isNull());
-        verify(feedRepository, never()).findFeedsByGenres(any(), anyBoolean(), any(), any(), any());
-    }
-
-    @Test
-    void category가_특정_장르명이고_ALL_옵션이면_해당_장르로_findFeedsByGenres를_호출한다() {
-        Genre romance = mock(Genre.class);
-        when(genreRepository.findByGenreName("로맨스")).thenReturn(Optional.of(romance));
-
-        feedServiceImpl.findFeedsByCategoryLabel("로맨스", LAST_FEED_ID, USER_ID, pageRequest, FeedGetOption.ALL, null);
-
-        verify(feedRepository).findFeedsByGenres(eq(List.of(romance)), eq(false), eq(LAST_FEED_ID), eq(USER_ID),
-                eq(pageRequest));
-    }
-
-    @Test
-    void category가_특정_장르명이고_RECOMMENDED_옵션이면_해당_장르로_findRecommendedFeeds를_호출한다() {
-        Genre romance = mock(Genre.class);
-        when(genreRepository.findByGenreName("로맨스")).thenReturn(Optional.of(romance));
-
-        feedServiceImpl.findFeedsByCategoryLabel("로맨스", LAST_FEED_ID, USER_ID, pageRequest,
-                FeedGetOption.RECOMMENDED, null);
-
-        verify(feedRepository).findRecommendedFeeds(eq(LAST_FEED_ID), eq(USER_ID), eq(pageRequest),
-                eq(List.of(romance)));
-        verify(feedRepository, never()).findFeedsByGenres(any(), anyBoolean(), any(), any(), any());
-    }
-
-    @Test
-    void 존재하지_않는_장르명이면_GENRE_NOT_FOUND_예외가_발생한다() {
-        when(genreRepository.findByGenreName("없는장르")).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() ->
-                feedServiceImpl.findFeedsByCategoryLabel("없는장르", LAST_FEED_ID, USER_ID, pageRequest,
-                        FeedGetOption.ALL, null))
-                .isInstanceOf(CustomGenreException.class);
-    }
-
-    @Test
     void feedGetOption이_null이면_ALL로_동작한다() {
-        feedServiceImpl.findFeedsByCategoryLabel("all", LAST_FEED_ID, USER_ID, pageRequest, null, null);
+        feedServiceImpl.findFeedsByCategoryLabel(LAST_FEED_ID, USER_ID, pageRequest, null, null);
 
         verify(feedRepository).findFeeds(LAST_FEED_ID, USER_ID, pageRequest);
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#484 -> dev
- close #484 

## Key Changes
<!-- 최대한 자세히 -->
1. feed 조회시 피드 카테고리 어레이리스트 제거
2. feed 생성시 피드 카테고리 입력 제거
3. 전체 feed 조회시 category 제거
4. 유저 피드 조회시 etc 추가 - etc는 작품 연결 없는 피드들

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
