### PR TITLE
[FIX] 소설 오늘의 발견 조회시 비공개, 스포일러 피드 제외하고 조회

### DIFF
--- a/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
@@ -45,7 +45,11 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                 .map(novelId -> jpaQueryFactory
                         .selectFrom(feed)
                         .leftJoin(feed.likes, like)
-                        .where(feed.novelId.eq(novelId))
+                        .where(
+                                feed.novelId.eq(novelId),
+                                feed.isPublic.isTrue(),
+                                feed.isSpoiler.isFalse()
+                        )
                         .groupBy(feed.feedId)
                         .orderBy(like.count().desc())
                         .fetchFirst())


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#486 -> dev
- close #486

## Key Changes
<!-- 최대한 자세히 -->
1. 소설 오늘의 발견 조회시 피드 내역을 같이 조회 하는데 이때 비공개, 스포일러 피드는 조회 하지 않도록 수정함.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
