### PR TITLE
[FIX] 인기글 조회시 사용자 선호 장르 필터 제거

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/FeedFindApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/FeedFindApplication.java
@@ -94,10 +94,8 @@ public class FeedFindApplication {
                                      FeedGetOption feedGetOption) {
         Long userIdOrNull = Optional.ofNullable(user).map(User::getUserId).orElse(null);
 
-        List<Genre> genres = getPreferenceGenres(user);
-
         Slice<Feed> feeds = findFeedsByCategoryLabel(lastFeedId, userIdOrNull,
-                PageRequest.of(DEFAULT_PAGE_NUMBER, size), feedGetOption, genres);
+                PageRequest.of(DEFAULT_PAGE_NUMBER, size), feedGetOption);
 
         List<FeedInfo> feedGetResponses = feeds.getContent().stream().filter(feed -> feed.isVisibleTo(userIdOrNull))
                 .map(feed -> createFeedInfo(feed, user)).toList();
@@ -117,9 +115,8 @@ public class FeedFindApplication {
     }
 
     private Slice<Feed> findFeedsByCategoryLabel(Long lastFeedId, Long userId, PageRequest pageRequest,
-                                                 FeedGetOption feedGetOption, List<Genre> genres) {
-        return feedServiceImpl.findFeedsByCategoryLabel(lastFeedId, userId, pageRequest, feedGetOption,
-                genres);
+                                                 FeedGetOption feedGetOption) {
+        return feedServiceImpl.findFeedsByCategoryLabel(lastFeedId, userId, pageRequest, feedGetOption);
     }
 
     private FeedInfo createFeedInfo(Feed feed, User user) {

--- a/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepository.java
@@ -16,7 +16,7 @@ public interface FeedCustomRepository {
                                              Boolean isUnVisible, SortCriteria sortCriteria, List<Genre> genres,
                                              Long visitorId, boolean includeEtc);
 
-    Slice<Feed> findRecommendedFeeds(Long lastFeedId, Long userId, PageRequest pageRequest, List<Genre> genres);
+    Slice<Feed> findRecommendedFeeds(Long lastFeedId, Long userId, PageRequest pageRequest);
 
     Slice<Feed> findFeedsByGenres(List<Genre> genres, boolean includeEtc, Long lastFeedId, Long userId,
                                   PageRequest pageRequest);

--- a/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
@@ -144,16 +144,12 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
     }
 
     @Override
-    public Slice<Feed> findRecommendedFeeds(Long lastFeedId, Long userId, PageRequest pageRequest, List<Genre> genres) {
+    public Slice<Feed> findRecommendedFeeds(Long lastFeedId, Long userId, PageRequest pageRequest) {
         List<Feed> feeds = jpaQueryFactory
                 .selectFrom(feed)
-                .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
-                .leftJoin(novelGenre).on(novel.eq(novelGenre.novel))
-                .leftJoin(genre).on(novelGenre.genre.eq(genre))
                 .where(
                         ltFeedId(lastFeedId),
                         checkPopularFeed(),
-                        checkGenres(genres, false),
                         checkBlocking(userId),
                         checkHidden()
                 )

--- a/src/main/java/org/websoso/WSSServer/feed/service/FeedService.java
+++ b/src/main/java/org/websoso/WSSServer/feed/service/FeedService.java
@@ -341,7 +341,7 @@ public class FeedService {
             if (FeedGetOption.isAll(feedGetOption)) {
                 return feedRepository.findFeeds(lastFeedId, userId, pageRequest);
             }
-            return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, preferenceGenres);
+            return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest);
 
     }
 

--- a/src/main/java/org/websoso/WSSServer/feed/service/FeedServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/service/FeedServiceImpl.java
@@ -43,12 +43,12 @@ public class FeedServiceImpl {
 
     @Transactional(readOnly = true)
     public Slice<Feed> findFeedsByCategoryLabel(Long lastFeedId, Long userId, PageRequest pageRequest,
-                                                FeedGetOption feedGetOption, List<Genre> preferenceGenres) {
+                                                FeedGetOption feedGetOption) {
 
             if (FeedGetOption.isAll(feedGetOption)) {
                 return feedRepository.findFeeds(lastFeedId, userId, pageRequest);
             } else {
-                return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, preferenceGenres);
+                return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest);
             }
 
     }

--- a/src/test/java/org/websoso/WSSServer/feed/service/FeedServiceImplTest.java
+++ b/src/test/java/org/websoso/WSSServer/feed/service/FeedServiceImplTest.java
@@ -60,20 +60,8 @@ class FeedServiceImplTest {
         feedServiceImpl.findFeedsByCategoryLabel(LAST_FEED_ID, USER_ID, pageRequest, FeedGetOption.ALL, null);
 
         verify(feedRepository).findFeeds(LAST_FEED_ID, USER_ID, pageRequest);
-        verify(feedRepository, never()).findRecommendedFeeds(any(), any(), any(), any());
+        verify(feedRepository, never()).findRecommendedFeeds(any(), any(), any());
         verify(feedRepository, never()).findFeedsByGenres(any(), anyBoolean(), any(), any(), any());
-    }
-
-    @Test
-    void RECOMMENDED_옵션이면_findRecommendedFeeds를_유저_선호장르로_호출한다() {
-        Genre prefGenre = mock(Genre.class);
-        List<Genre> preferenceGenres = List.of(prefGenre);
-
-        feedServiceImpl.findFeedsByCategoryLabel(LAST_FEED_ID, USER_ID, pageRequest,
-                FeedGetOption.RECOMMENDED, preferenceGenres);
-
-        verify(feedRepository).findRecommendedFeeds(LAST_FEED_ID, USER_ID, pageRequest, preferenceGenres);
-        verify(feedRepository, never()).findFeeds(any(), any(), any());
     }
 
     @Test

--- a/src/test/java/org/websoso/WSSServer/feed/service/FeedServiceImplTest.java
+++ b/src/test/java/org/websoso/WSSServer/feed/service/FeedServiceImplTest.java
@@ -57,7 +57,7 @@ class FeedServiceImplTest {
 
     @Test
     void ALL_옵션이면_findFeeds를_호출한다() {
-        feedServiceImpl.findFeedsByCategoryLabel(LAST_FEED_ID, USER_ID, pageRequest, FeedGetOption.ALL, null);
+        feedServiceImpl.findFeedsByCategoryLabel(LAST_FEED_ID, USER_ID, pageRequest, FeedGetOption.ALL);
 
         verify(feedRepository).findFeeds(LAST_FEED_ID, USER_ID, pageRequest);
         verify(feedRepository, never()).findRecommendedFeeds(any(), any(), any());
@@ -66,7 +66,7 @@ class FeedServiceImplTest {
 
     @Test
     void feedGetOption이_null이면_ALL로_동작한다() {
-        feedServiceImpl.findFeedsByCategoryLabel(LAST_FEED_ID, USER_ID, pageRequest, null, null);
+        feedServiceImpl.findFeedsByCategoryLabel(LAST_FEED_ID, USER_ID, pageRequest, null);
 
         verify(feedRepository).findFeeds(LAST_FEED_ID, USER_ID, pageRequest);
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#488 -> dev
- close #488

## Key Changes
<!-- 최대한 자세히 -->
인기글 조회시 사용자 선호 장르 필터 제거

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
