### PR TITLE
[FEAT] 인기글 로직 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepository.java
@@ -18,6 +18,8 @@ public interface FeedCustomRepository {
 
     Slice<Feed> findRecommendedFeeds(Long lastFeedId, Long userId, PageRequest pageRequest, List<Genre> genres);
 
+    Slice<Feed> findInterestedNovelFeeds(Long lastFeedId, Long userId, PageRequest pageRequest);
+
     Slice<Feed> findFeedsByGenres(List<Genre> genres, boolean includeEtc, Long lastFeedId, Long userId,
                                   PageRequest pageRequest);
 

--- a/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
@@ -61,7 +61,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
     @Override
     public List<Feed> findFeedsByNoOffsetPagination(User owner, Long lastFeedId, int size, Boolean isVisible,
                                                     Boolean isUnVisible, SortCriteria sortCriteria,
-                                                    List<Genre> genres, Long visitorId, boolean includeEtc) {
+                                                    List<Genre> genres, Long visitorId, boolean isNotNovelConnect) {
         return jpaQueryFactory
                 .selectFrom(feed)
                 .distinct()
@@ -73,7 +73,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                         ltFeedId(lastFeedId),
                         checkVisible(visitorId),
                         checkPublic(isVisible, isUnVisible),
-                        checkGenres(genres, includeEtc)
+                        checkGenresAndNovels(genres, isNotNovelConnect)
                 )
                 .orderBy(
                         checkSortCriteria(sortCriteria),
@@ -98,7 +98,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
     @Override
     public Long countVisibleFeeds(User owner, Long lastFeedId, Boolean isVisible,
                                   Boolean isUnVisible, List<Genre> genres,
-                                  Long visitorId, boolean includeEtc) {
+                                  Long visitorId, boolean isNotNovelConnect) {
         return jpaQueryFactory
                 .select(feed.feedId.countDistinct())
                 .from(feed)
@@ -109,7 +109,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                         feed.user.eq(owner),
                         checkVisible(visitorId),
                         checkPublic(isVisible, isUnVisible),
-                        checkGenres(genres, includeEtc)
+                        checkGenresAndNovels(genres, isNotNovelConnect)
                 )
                 .fetchOne();
     }
@@ -154,7 +154,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                 .where(
                         ltFeedId(lastFeedId),
                         checkPopularFeed(),
-                        checkGenres(genres, true),
+                        checkGenresAndNovels(genres, true),
                         checkBlocking(userId),
                         checkHidden()
                 )
@@ -204,17 +204,17 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                 .goe(POPULAR_FEED_LIKE_COUNT);
     }
 
-    private BooleanExpression checkGenres(List<Genre> genres, boolean includeEtc) {
+    private BooleanExpression checkGenresAndNovels(List<Genre> genres, boolean isNotNovelConnect) {
         if (genres != null && !genres.isEmpty()) {
             BooleanExpression genreCondition = genre.in(genres);
-            BooleanExpression etcCondition = includeEtc ? feed.novelId.isNull() : null;
-            return etcCondition != null ? genreCondition.or(etcCondition) : genreCondition;
+            BooleanExpression novelConnectCondition = isNotNovelConnect ? feed.novelId.isNull() : null;
+            return novelConnectCondition != null ? genreCondition.or(novelConnectCondition) : genreCondition;
         }
         return null;
     }
 
     @Override
-    public Slice<Feed> findFeedsByGenres(List<Genre> genres, boolean includeEtc, Long lastFeedId, Long userId,
+    public Slice<Feed> findFeedsByGenres(List<Genre> genres, boolean isNotNovelConnect, Long lastFeedId, Long userId,
                                          PageRequest pageRequest) {
         List<Feed> feeds = jpaQueryFactory
                 .selectFrom(feed)
@@ -224,7 +224,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                 .leftJoin(genre).on(novelGenre.genre.eq(genre))
                 .where(
                         ltFeedId(lastFeedId),
-                        checkGenres(genres, includeEtc),
+                        checkGenresAndNovels(genres, isNotNovelConnect),
                         checkBlocking(userId),
                         checkHidden()
                 )

--- a/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ import static org.websoso.WSSServer.domain.QGenre.genre;
 import static org.websoso.WSSServer.feed.domain.QFeed.feed;
 import static org.websoso.WSSServer.feed.domain.QFeedImage.feedImage;
 import static org.websoso.WSSServer.feed.domain.QLike.like;
+import static org.websoso.WSSServer.library.domain.QUserNovel.userNovel;
 import static org.websoso.WSSServer.novel.domain.QNovel.novel;
 import static org.websoso.WSSServer.novel.domain.QNovelGenre.novelGenre;
 import static org.websoso.WSSServer.user.domain.QBlock.block;
@@ -170,6 +171,31 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
         return new SliceImpl<>(feeds, pageRequest, hasNext);
     }
 
+    @Override
+    public Slice<Feed> findInterestedNovelFeeds(Long lastFeedId, Long userId, PageRequest pageRequest) {
+        List<Feed> feeds = jpaQueryFactory
+                .selectFrom(feed)
+                .join(novel).on(feed.novelId.eq(novel.novelId))
+                .join(userNovel).on(novel.eq(userNovel.novel))
+                .where(
+                        ltFeedId(lastFeedId),
+                        checkBlocking(userId),
+                        checkHidden(),
+                        checkInterestedNovels(userId)
+                )
+                .limit(pageRequest.getPageSize() + 1)
+                .orderBy(feed.feedId.desc())
+                .fetch();
+
+        boolean hasNext = feeds.size() > pageRequest.getPageSize();
+
+        if (hasNext) {
+            feeds.remove(feeds.size() - 1);
+        }
+
+        return new SliceImpl<>(feeds, pageRequest, hasNext);
+    }
+
     private BooleanExpression checkPopularFeed() {
         return JPAExpressions
                 .select(like.count())
@@ -235,4 +261,12 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
         }
         return null;
     }
+
+    private BooleanExpression checkInterestedNovels(Long userId) {
+        if (userId != null) {
+            return userNovel.user.userId.eq(userId).and(userNovel.isInterest.isTrue());
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/feed/service/FeedServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/service/FeedServiceImpl.java
@@ -3,11 +3,16 @@ package org.websoso.WSSServer.feed.service;
 import static org.websoso.WSSServer.exception.error.CustomFeedError.FEED_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomGenreError.GENRE_NOT_FOUND;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Genre;
@@ -48,7 +53,22 @@ public class FeedServiceImpl {
             if (FeedGetOption.isAll(feedGetOption)) {
                 return feedRepository.findFeeds(lastFeedId, userId, pageRequest);
             } else {
-                return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, preferenceGenres);
+                // 인기 피드
+                Slice<Feed> recommendedFeeds = feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, preferenceGenres);
+                // 내가 관심 등록한 작품의 피드
+                Slice<Feed> interestedNovelFeeds = feedRepository.findInterestedNovelFeeds(lastFeedId, userId, pageRequest);
+                int pageSize = pageRequest.getPageSize();
+                List<Feed> combinedFeeds = Stream.concat(
+                    recommendedFeeds.getContent().stream(),
+                    interestedNovelFeeds.getContent().stream())
+                    .distinct()
+                    .sorted(Comparator.comparing(Feed::getFeedId).reversed()) // feedId 내림차순 정렬
+                    .collect(Collectors.toList());
+                boolean hasNext = combinedFeeds.size() > pageSize || recommendedFeeds.hasNext() || interestedNovelFeeds.hasNext();
+                List<Feed> resultFeeds = combinedFeeds.stream()
+                    .limit(pageSize)
+                    .collect(Collectors.toList());
+                return new SliceImpl<>(resultFeeds, pageRequest, hasNext);
             }
 
     }

--- a/src/main/java/org/websoso/WSSServer/feed/service/FeedServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/service/FeedServiceImpl.java
@@ -61,13 +61,13 @@ public class FeedServiceImpl {
                 List<Feed> combinedFeeds = Stream.concat(
                     recommendedFeeds.getContent().stream(),
                     interestedNovelFeeds.getContent().stream())
-                    .distinct()
-                    .sorted(Comparator.comparing(Feed::getFeedId).reversed()) // feedId 내림차순 정렬
-                    .collect(Collectors.toList());
-                boolean hasNext = combinedFeeds.size() > pageSize || recommendedFeeds.hasNext() || interestedNovelFeeds.hasNext();
+                        .distinct()
+                        .sorted(Comparator.comparing(Feed::getFeedId).reversed()) // feedId 내림차순 정렬
+                        .toList();
                 List<Feed> resultFeeds = combinedFeeds.stream()
-                    .limit(pageSize)
-                    .collect(Collectors.toList());
+                        .limit(pageSize)
+                        .toList();
+                boolean hasNext = combinedFeeds.size() > pageSize || recommendedFeeds.hasNext() || interestedNovelFeeds.hasNext();
                 return new SliceImpl<>(resultFeeds, pageRequest, hasNext);
             }
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#494 -> dev
- close #494

## Key Changes
<!-- 최대한 자세히 -->
1. 전체 피드 조회 시, 추천작 조회 옵션(RECOMMEND)일 경우 기존 인기 피드(좋아요 5개 이상) 외에 사용자가 관심 등록한 작품의 모든 피드를 함께 조회하도록 변경                                                                                                                                                  
    - FeedCustomRepository에 findInterestedNovelFeeds 메서드 추가
    - FeedCustomRepositoryImpl에 QueryDSL 쿼리 구현: userNovel 조인 후 isInterest = true 조건으로 관심 작품 피드 필터링, 차단 유저 및 숨김 피드 제외                                                                                                                                                          
    - FeedServiceImpl.findFeedsByCategoryLabel에서 인기 피드와 관심 작품 피드를 합산 후 feedId 기준 내림차순 정렬, 중복 제거하여 반환                                                                                                                                                                         
 2. 변수명 및 메서드명 명확화 리팩터링                                                                                                                                                                                                                                                                       
    - includeEtc → isNotNovelConnect (작품 미연결 피드 포함 여부를 보다 명확히 표현)                                                                                                                                                                                                                          
    - checkGenres → checkGenresAndNovels (장르 조건 외 작품 연결 여부도 함께 체크함을 명시) 

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 두 Slice를 메모리에서 합산하는 방식을 사용했습니다. 같은 트랜잭션 내에서 실행되므로 JPA 1차 캐시에 의해 동일 피드는 같은 객체 참조가 보장되어 distinct()가 정상 동작합니다.    
- 현재 인기글 조회로 좋아요 갯수를 찾을 때 where 절에 feedid로 like 테이블의 카운트를 세는 서브쿼리로 찾고 있습니다. 추후 피드 갯수가 많아질수록 성능이 박살날것 같아 이것을 해결하기 위해 역정규화를 거는것은 어떨까요

## References
<!-- 참고한 자료-->
