### PR TITLE
[FIX] 소설 탐색시 별점 조건을 범위 조건으로 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
@@ -87,15 +87,24 @@ public class SearchNovelApplication {
         return SearchedNovelsResponse.of(novelGetResponsePreviews, novels.getTotalElements(), novels.hasNext());
     }
 
+    //TODO: 추후 novelRating 제거
     @Transactional(readOnly = true)
-    public FilteredNovelsResponse getFilteredNovels(List<String> genreNames, List<Integer> keywordIds, Boolean isCompleted, Float novelRating, int page, int size) {
+    public FilteredNovelsResponse getFilteredNovels(List<String> genreNames, List<Integer> keywordIds, Boolean isCompleted, Float novelRating, Float novelRatingStart, Float novelRatingEnd, int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size);
 
         List<Genre> genres = genreService.getGenresOrException(genreNames);
 
         List<Keyword> keywords = keywordService.getKeywordsOrException(keywordIds);
 
-        Page<Novel> novels = novelService.findFilteredNovels(pageRequest, genres, keywords, isCompleted, novelRating);
+        Page<Novel> novels;
+
+        if (novelRating == null) {
+            novels = novelService.findFilteredNovels(pageRequest, genres, keywords, isCompleted, novelRatingStart, novelRatingEnd);
+        } else {
+            novels = novelService.findFilteredNovels(pageRequest, genres, keywords, isCompleted, novelRating, novelRatingEnd);
+        }
+
+
 
         List<NovelSummaryResponse> novelGetResponsePreviews = novels.stream()
                 .map(this::convertToDTO2)

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -64,8 +64,7 @@ public class NovelController {
     public ResponseEntity<FilteredNovelsResponse> getFilteredNovels(
             @RequestParam(required = false) List<String> genres,
             @RequestParam(required = false) Boolean isCompleted,
-            @Deprecated
-            @RequestParam(required = false) Float novelRating,
+            @Deprecated @RequestParam(required = false) Float novelRating,
             @RequestParam(required = false, defaultValue = "0.0") Float novelRatingStart,
             @RequestParam(required = false, defaultValue = "5.0") Float novelRatingEnd,
             @RequestParam(required = false) List<Integer> keywordIds,

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -66,7 +66,7 @@ public class NovelController {
             @RequestParam(required = false) Boolean isCompleted,
             @Deprecated
             @RequestParam(required = false) Float novelRating,
-            @RequestParam(required = false, defaultValue = "0.0") Float novelRatingStart,
+            @RequestParam(required = false) Float novelRatingStart,
             @RequestParam(required = false, defaultValue = "5.0") Float novelRatingEnd,
             @RequestParam(required = false) List<Integer> keywordIds,
             @RequestParam int page,

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -64,13 +64,16 @@ public class NovelController {
     public ResponseEntity<FilteredNovelsResponse> getFilteredNovels(
             @RequestParam(required = false) List<String> genres,
             @RequestParam(required = false) Boolean isCompleted,
+            @Deprecated
             @RequestParam(required = false) Float novelRating,
+            @RequestParam(required = false, defaultValue = "0.0") Float novelRatingStart,
+            @RequestParam(required = false, defaultValue = "5.0") Float novelRatingEnd,
             @RequestParam(required = false) List<Integer> keywordIds,
             @RequestParam int page,
             @RequestParam int size) {
         return ResponseEntity
                 .status(OK)
-                .body(searchNovelApplication.getFilteredNovels(genres, keywordIds, isCompleted, novelRating, page, size));
+                .body(searchNovelApplication.getFilteredNovels(genres, keywordIds, isCompleted, novelRating, novelRatingStart, novelRatingEnd, page, size));
     }
 
     /**

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -66,7 +66,7 @@ public class NovelController {
             @RequestParam(required = false) Boolean isCompleted,
             @Deprecated
             @RequestParam(required = false) Float novelRating,
-            @RequestParam(required = false) Float novelRatingStart,
+            @RequestParam(required = false, defaultValue = "0.0") Float novelRatingStart,
             @RequestParam(required = false, defaultValue = "5.0") Float novelRatingEnd,
             @RequestParam(required = false) List<Integer> keywordIds,
             @RequestParam int page,

--- a/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepository.java
@@ -11,6 +11,6 @@ public interface NovelCustomRepository {
 
     Page<Novel> findSearchedNovels(Pageable pageable, String query);
 
-    Page<Novel> findFilteredNovels(Pageable pageable, List<Genre> genres, Boolean isCompleted, Float novelRating, List<Keyword> keywords);
+    Page<Novel> findFilteredNovels(Pageable pageable, List<Genre> genres, Boolean isCompleted, Float novelRatingStart, Float novelRatingEnd, List<Keyword> keywords);
 
 }

--- a/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
@@ -74,8 +74,8 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
     }
 
     @Override
-    public Page<Novel> findFilteredNovels(Pageable pageable, List<Genre> genres, Boolean isCompleted, Float novelRating,
-                                          List<Keyword> keywords) {
+    public Page<Novel> findFilteredNovels(Pageable pageable, List<Genre> genres, Boolean isCompleted, Float novelRatingStart,
+                                          Float novelRatingEnd, List<Keyword> keywords) {
 
         NumberTemplate<Long> popularity = Expressions.numberTemplate(Long.class,
                 "(SELECT COUNT(un) FROM UserNovel un WHERE un.novel = {0} AND (un.isInterest = true OR un.status <> 'QUIT'))",
@@ -92,9 +92,7 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
                         isCompleted == null
                                 ? null
                                 : novel.isCompleted.eq(isCompleted),
-                        novelRating == null
-                                ? null
-                                : getAverageRating(novel).goe(novelRating),
+                        getAverageRating(novel).between(novelRatingStart, novelRatingEnd),
                         keywords.isEmpty()
                                 ? null
                                 : getKeywordCount(novel, keywords).eq(keywords.size())

--- a/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
@@ -92,7 +92,9 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
                         isCompleted == null
                                 ? null
                                 : novel.isCompleted.eq(isCompleted),
-                        getAverageRating(novel).between(novelRatingStart, novelRatingEnd),
+                        novelRatingStart == null
+                                ? null
+                                : getAverageRating(novel).between(novelRatingStart, novelRatingEnd),
                         keywords.isEmpty()
                                 ? null
                                 : getKeywordCount(novel, keywords).eq(keywords.size())

--- a/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
@@ -92,9 +92,7 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
                         isCompleted == null
                                 ? null
                                 : novel.isCompleted.eq(isCompleted),
-                        novelRatingStart == null
-                                ? null
-                                : getAverageRating(novel).between(novelRatingStart, novelRatingEnd),
+                        getAverageRatingCondition(novel, novelRatingStart, novelRatingEnd),
                         keywords.isEmpty()
                                 ? null
                                 : getKeywordCount(novel, keywords).eq(keywords.size())
@@ -108,6 +106,21 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
         return Expressions.numberTemplate(Double.class,
                 "(SELECT AVG(un.userNovelRating) FROM UserNovel un WHERE un.novel = {0} AND un.userNovelRating <> 0)",
                 novel);
+    }
+
+    private BooleanExpression getAverageRatingCondition(QNovel novel, Float novelRatingStart, Float novelRatingEnd) {
+        if (novelRatingStart == null) {
+            return null;
+        }
+
+        NumberExpression<Double> averageRating = getAverageRating(novel);
+        BooleanExpression averageRatingBetween = averageRating.between(novelRatingStart, novelRatingEnd);
+
+        if (Float.compare(novelRatingStart, 0.0f) == 0) {
+            return averageRating.isNull().or(averageRatingBetween);
+        }
+
+        return averageRatingBetween;
     }
 
     private NumberExpression<Integer> getKeywordCount(QNovel novel, List<Keyword> keywords) {

--- a/src/main/java/org/websoso/WSSServer/novel/service/NovelServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/service/NovelServiceImpl.java
@@ -42,8 +42,8 @@ public class NovelServiceImpl {
     }
 
     public Page<Novel> findFilteredNovels(PageRequest pageRequest, List<Genre> genres, List<Keyword> keywords,
-                                          Boolean isCompleted, Float novelRating) {
-        return novelRepository.findFilteredNovels(pageRequest, genres, isCompleted, novelRating, keywords);
+                                          Boolean isCompleted, Float novelRatingStart, Float novelRatingEnd) {
+        return novelRepository.findFilteredNovels(pageRequest, genres, isCompleted, novelRatingStart, novelRatingEnd, keywords);
     }
 
     public List<NovelGenre> getGenresByNovel(Novel novel) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#498 -> dev
- close #498

## Key Changes
<!-- 최대한 자세히 -->
1. /novels/filters api에 novelRatingStart, novelRatingEnd 파라미터 추가.
2. novelRatingStart가 null일 경우, 별점 없는 작품도 조회.
3. 기존 api와의 호환성을 위해 novelRating파라미터가 들어올 경우 분기 처리

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
