### PR TITLE
[FEAT] 제목 기반 검색어 자동완성 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.dto.novel.AutocompleteKeywordsResponse;
 import org.websoso.WSSServer.recentsearch.event.NovelSearchedEvent;
 import org.websoso.WSSServer.user.domain.AvatarProfile;
 import org.websoso.WSSServer.domain.Genre;
@@ -186,6 +187,16 @@ public class SearchNovelApplication {
         Map<Long, AvatarProfile> avatarMap = createAvatarMap(feedMap);
 
         return PopularNovelsGetResponse.create(popularNovels, feedMap, avatarMap);
+    }
+
+    @Transactional(readOnly = true)
+    public AutocompleteKeywordsResponse autocompleteKeywords(String searchQuery, int size) {
+        List<String> autocompleteKeywords = novelService.getAutocompleteNovels(searchQuery, size)
+                .stream()
+                .map(Novel::getTitle)
+                .toList();
+
+        return new AutocompleteKeywordsResponse(autocompleteKeywords);
     }
 
     /**

--- a/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
             "/users/login",
             "/actuator/health",
             "/novels",
+            "/novels/autocomplete",
             "/novels/{novelId}",
             "/novels/{novelId}/info",
             "/novels/{novelId}/feeds",

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.websoso.WSSServer.application.SearchNovelApplication;
+import org.websoso.WSSServer.dto.novel.AutocompleteKeywordsResponse;
 import org.websoso.WSSServer.dto.novel.FilteredNovelsResponse;
 import org.websoso.WSSServer.dto.novel.SearchedNovelsResponse;
 import org.websoso.WSSServer.user.domain.User;
@@ -47,6 +48,20 @@ public class NovelController {
         return ResponseEntity
                 .status(OK)
                 .body(searchNovelApplication.searchNovels(user, query, page, size));
+    }
+
+    /**
+     * 검색어를 사용해서 소설을 찾는다.
+     *
+     * @param query 검색할 작품명
+     * @return SearchedNovelsResponse
+     */
+    @GetMapping("/autocomplete")
+    public ResponseEntity<AutocompleteKeywordsResponse> autocomplete(@RequestParam String query,
+                                                                     @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity
+                .status(OK)
+                .body(searchNovelApplication.autocompleteKeywords(query, size));
     }
 
     /**

--- a/src/main/java/org/websoso/WSSServer/dto/novel/AutocompleteKeywordsResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/AutocompleteKeywordsResponse.java
@@ -1,0 +1,8 @@
+package org.websoso.WSSServer.dto.novel;
+
+import java.util.List;
+
+public record AutocompleteKeywordsResponse(
+        List<String> keywords
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepository.java
@@ -13,4 +13,5 @@ public interface NovelCustomRepository {
 
     Page<Novel> findFilteredNovels(Pageable pageable, List<Genre> genres, Boolean isCompleted, Float novelRatingStart, Float novelRatingEnd, List<Keyword> keywords);
 
+    List<Novel> findAutocompleteNovels(String searchQuery, int limitSize);
 }

--- a/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
@@ -102,6 +102,21 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
         return applyPagination(pageable, query);
     }
 
+    @Override
+    public List<Novel> findAutocompleteNovels(String searchQuery, int limitSize) {
+
+        BooleanExpression titleContainsQuery = getCleanedString(novel.title).containsIgnoreCase(searchQuery);
+
+        return jpaQueryFactory
+                .selectFrom(novel)
+                .leftJoin(novel.userNovels, userNovel)
+                .where(titleContainsQuery)
+                .groupBy(novel.novelId)
+                .orderBy(getPopularity(novel).desc())
+                .limit(limitSize)
+                .fetch();
+    }
+
     private NumberExpression<Double> getAverageRating(QNovel novel) {
         return Expressions.numberTemplate(Double.class,
                 "(SELECT AVG(un.userNovelRating) FROM UserNovel un WHERE un.novel = {0} AND un.userNovelRating <> 0)",

--- a/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
@@ -36,13 +36,12 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
     @Override
     public Page<Novel> findSearchedNovels(Pageable pageable, String searchQuery) {
 
-        BooleanExpression titleContainsQuery = getCleanedString(novel.title).containsIgnoreCase(searchQuery);
         BooleanExpression authorContainsQuery = getCleanedString(novel.author).containsIgnoreCase(searchQuery);
 
         List<Novel> novelsByTitle = jpaQueryFactory
                 .selectFrom(novel)
                 .leftJoin(novel.userNovels, userNovel)
-                .where(titleContainsQuery)
+                .where(titleContainsQuery(searchQuery))
                 .groupBy(novel.novelId)
                 .orderBy(getPopularity(novel).desc())
                 .fetch();
@@ -50,7 +49,7 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
         List<Novel> novelsByAuthor = jpaQueryFactory
                 .selectFrom(novel)
                 .leftJoin(novel.userNovels, userNovel)
-                .where(authorContainsQuery.and(titleContainsQuery.not()))
+                .where(authorContainsQuery.and(titleContainsQuery(searchQuery).not()))
                 .groupBy(novel.novelId)
                 .orderBy(getPopularity(novel).desc())
                 .fetch();
@@ -105,17 +104,21 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
     @Override
     public List<Novel> findAutocompleteNovels(String searchQuery, int limitSize) {
 
-        BooleanExpression titleContainsQuery = getCleanedString(novel.title).containsIgnoreCase(searchQuery);
 
         return jpaQueryFactory
                 .selectFrom(novel)
                 .leftJoin(novel.userNovels, userNovel)
-                .where(titleContainsQuery)
+                .where(titleContainsQuery(searchQuery))
                 .groupBy(novel.novelId)
                 .orderBy(getPopularity(novel).desc())
                 .limit(limitSize)
                 .fetch();
     }
+
+    private BooleanExpression titleContainsQuery(String searchQuery) {
+        return getCleanedString(novel.title).containsIgnoreCase(searchQuery);
+    }
+
 
     private NumberExpression<Double> getAverageRating(QNovel novel) {
         return Expressions.numberTemplate(Double.class,

--- a/src/main/java/org/websoso/WSSServer/novel/service/NovelServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/service/NovelServiceImpl.java
@@ -41,6 +41,10 @@ public class NovelServiceImpl {
         return novelRepository.findSearchedNovels(pageRequest, searchQuery);
     }
 
+    public List<Novel> getAutocompleteNovels(String searchQuery, int getSize) {
+        return novelRepository.findAutocompleteNovels(searchQuery, getSize);
+    }
+
     public Page<Novel> findFilteredNovels(PageRequest pageRequest, List<Genre> genres, List<Keyword> keywords,
                                           Boolean isCompleted, Float novelRatingStart, Float novelRatingEnd) {
         return novelRepository.findFilteredNovels(pageRequest, genres, isCompleted, novelRatingStart, novelRatingEnd, keywords);


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#493 -> dev
- close #493

## Key Changes
<!-- 최대한 자세히 -->

소설 제목 contains 기반의 검색어 자동 완성 기능


## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
현재 contains와 order의 쿼리의 비용이 매우 큰 편입니다.
추후 해당 비용을 해소할 방안을 고려해보고 적용해야 합니다.

## References
<!-- 참고한 자료-->
