### PR TITLE
[FEAT] 댓글 작성 시간 표기 정책 변경 (Relative Time 포맷 적용)

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/comment/CommentGetResponse.java
@@ -1,17 +1,15 @@
 package org.websoso.WSSServer.dto.comment;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import java.time.LocalDate;
 import org.websoso.WSSServer.feed.domain.Comment;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
+import org.websoso.WSSServer.util.TimeFormatUtil;
 
 public record CommentGetResponse(
         Long userId,
         String nickname,
         String avatarImage,
         Long commentId,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "M월 d일", timezone = "Asia/Seoul")
-        LocalDate createdDate,
+        String createdDate,
         String commentContent,
         Boolean isModified,
         Boolean isMyComment,
@@ -26,7 +24,7 @@ public record CommentGetResponse(
                 userBasicInfo.nickname(),
                 userBasicInfo.avatarImage(),
                 comment.getCommentId(),
-                comment.getCreatedDate().toLocalDate(),
+                TimeFormatUtil.formatRelativeDateTime(comment.getCreatedDate()),
                 comment.getCommentContent(),
                 !comment.getCreatedDate().equals(comment.getModifiedDate()),
                 isMyComment,

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedGetResponse.java
@@ -71,7 +71,7 @@ public record FeedGetResponse(
                 feedUserBasicInfo.nickname(),
                 feedUserBasicInfo.avatarImage(),
                 feed.getFeedId(),
-                TimeFormatUtil.formatFeedDate(feed.getCreatedDate()),
+                TimeFormatUtil.formatRelativeDateTime(feed.getCreatedDate()),
                 feed.getFeedContent(),
                 feed.getLikes().size(),
                 isLiked,

--- a/src/main/java/org/websoso/WSSServer/dto/feed/FeedInfo.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/FeedInfo.java
@@ -59,7 +59,7 @@ public record FeedInfo(
                 userBasicInfo.userId(),
                 userBasicInfo.nickname(),
                 userBasicInfo.avatarImage(),
-                TimeFormatUtil.formatFeedDate(feed.getCreatedDate()),
+                TimeFormatUtil.formatRelativeDateTime(feed.getCreatedDate()),
                 feed.getFeedContent(),
                 feed.getLikes().size(),
                 isLiked,

--- a/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/feed/UserFeedGetResponse.java
@@ -43,7 +43,7 @@ public record UserFeedGetResponse(
         return new UserFeedGetResponse(
                 feed.getFeedId(),
                 feed.getFeedContent(),
-                TimeFormatUtil.formatFeedDate(feed.getCreatedDate()),
+                TimeFormatUtil.formatRelativeDateTime(feed.getCreatedDate()),
                 feed.getIsSpoiler(),
                 isModified,
                 likeUsers,

--- a/src/main/java/org/websoso/WSSServer/util/TimeFormatUtil.java
+++ b/src/main/java/org/websoso/WSSServer/util/TimeFormatUtil.java
@@ -20,7 +20,7 @@ public class TimeFormatUtil {
     private static final DateTimeFormatter NOTIFICATION_FMT = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
     /**
-     * 피드 날짜 포맷
+     * 피드/댓글 날짜 포맷
      * 60초 미만: 방금 전
      * 1시간 미만: N분 전
      * 24시간 미만: N시간 전
@@ -28,11 +28,11 @@ public class TimeFormatUtil {
      * 동일 년도: M월 d일
      * 과거 년도: yyyy년 M월 d일
      */
-    public static String formatFeedDate(LocalDateTime createdDate) {
-        return formatFeedDate(createdDate, Clock.systemDefaultZone());
+    public static String formatRelativeDateTime(LocalDateTime createdDate) {
+        return formatRelativeDateTime(createdDate, Clock.systemDefaultZone());
     }
 
-    public static String formatFeedDate(LocalDateTime createdDate, Clock clock) {
+    public static String formatRelativeDateTime(LocalDateTime createdDate, Clock clock) {
         LocalDateTime now = LocalDateTime.now(clock);
         Duration duration = Duration.between(createdDate, now);
 

--- a/src/test/java/org/websoso/WSSServer/util/TimeFormatUtilTest.java
+++ b/src/test/java/org/websoso/WSSServer/util/TimeFormatUtilTest.java
@@ -15,63 +15,63 @@ class TimeFormatUtilTest {
     private static final ZoneId ZONE = ZoneId.systemDefault();
 
     @Nested
-    @DisplayName("피드 날짜 포맷팅 테스트")
+    @DisplayName("피드/댓글 날짜 포맷팅 테스트")
     class FormatFeedDate {
 
         @DisplayName("60초 미만이면 '방금 전'을 반환한다")
         @Test
         void returnsJustNowForUnder60Seconds() {
             Clock clock = fixedClock("2024-01-15T12:00:00");
-            assertThat(formatFeed(clock, 30)).isEqualTo("방금 전");
+            assertThat(formatFeedAndComment(clock, 30)).isEqualTo("방금 전");
         }
 
         @DisplayName("59초일 때 '방금 전'을 반환한다")
         @Test
         void returnsJustNowAt59Seconds() {
             Clock clock = fixedClock("2024-01-15T12:00:00");
-            assertThat(formatFeed(clock, 59)).isEqualTo("방금 전");
+            assertThat(formatFeedAndComment(clock, 59)).isEqualTo("방금 전");
         }
 
         @DisplayName("60초이면 '1분 전'을 반환한다")
         @Test
         void returns1MinuteAt60Seconds() {
             Clock clock = fixedClock("2024-01-15T12:00:00");
-            assertThat(formatFeed(clock, 60)).isEqualTo("1분 전");
+            assertThat(formatFeedAndComment(clock, 60)).isEqualTo("1분 전");
         }
 
         @DisplayName("59분이면 '59분 전'을 반환한다")
         @Test
         void returns59MinutesAt59Minutes() {
             Clock clock = fixedClock("2024-01-15T12:00:00");
-            assertThat(formatFeed(clock, 59 * 60)).isEqualTo("59분 전");
+            assertThat(formatFeedAndComment(clock, 59 * 60)).isEqualTo("59분 전");
         }
 
         @DisplayName("1시간이면 '1시간 전'을 반환한다")
         @Test
         void returns1HourAt3600Seconds() {
             Clock clock = fixedClock("2024-01-15T12:00:00");
-            assertThat(formatFeed(clock, 3600)).isEqualTo("1시간 전");
+            assertThat(formatFeedAndComment(clock, 3600)).isEqualTo("1시간 전");
         }
 
         @DisplayName("23시간이면 '23시간 전'을 반환한다")
         @Test
         void returns23HoursAt23Hours() {
             Clock clock = fixedClock("2024-01-15T12:00:00");
-            assertThat(formatFeed(clock, 23 * 3600)).isEqualTo("23시간 전");
+            assertThat(formatFeedAndComment(clock, 23 * 3600)).isEqualTo("23시간 전");
         }
 
         @DisplayName("24시간이면 '1일 전'을 반환한다")
         @Test
         void returns1DayAt24Hours() {
             Clock clock = fixedClock("2024-01-15T12:00:00");
-            assertThat(formatFeed(clock, 24 * 3600)).isEqualTo("1일 전");
+            assertThat(formatFeedAndComment(clock, 24 * 3600)).isEqualTo("1일 전");
         }
 
         @DisplayName("6일이면 '6일 전'을 반환한다")
         @Test
         void returns6DaysAt6Days() {
             Clock clock = fixedClock("2024-01-15T12:00:00");
-            assertThat(formatFeed(clock, 6 * 24 * 3600)).isEqualTo("6일 전");
+            assertThat(formatFeedAndComment(clock, 6 * 24 * 3600)).isEqualTo("6일 전");
         }
 
         @DisplayName("같은 해이면 '월 일' 형식을 반환한다")
@@ -79,7 +79,7 @@ class TimeFormatUtilTest {
         void returnsMonthDayForSameYear() {
             Clock clock = fixedClock("2024-06-15T12:00:00");
             LocalDateTime createdAt = LocalDateTime.parse("2024-01-01T00:00:00");
-            assertThat(TimeFormatUtil.formatFeedDate(createdAt, clock)).isEqualTo("1월 1일");
+            assertThat(TimeFormatUtil.formatRelativeDateTime(createdAt, clock)).isEqualTo("1월 1일");
         }
 
         @DisplayName("다른 해이면 '년 월 일' 형식을 반환한다")
@@ -87,7 +87,7 @@ class TimeFormatUtilTest {
         void returnsYearMonthDayForDifferentYear() {
             Clock clock = fixedClock("2024-01-15T12:00:00");
             LocalDateTime createdAt = LocalDateTime.parse("2023-12-31T00:00:00");
-            assertThat(TimeFormatUtil.formatFeedDate(createdAt, clock)).isEqualTo("2023년 12월 31일");
+            assertThat(TimeFormatUtil.formatRelativeDateTime(createdAt, clock)).isEqualTo("2023년 12월 31일");
         }
 
         @DisplayName("미래 시각이면 '방금 전'을 반환한다")
@@ -95,7 +95,7 @@ class TimeFormatUtilTest {
         void returnsJustNowForFutureTime() {
             Clock clock = fixedClock("2024-01-15T12:00:00");
             LocalDateTime future = LocalDateTime.now(clock).plusHours(1);
-            assertThat(TimeFormatUtil.formatFeedDate(future, clock)).isEqualTo("방금 전");
+            assertThat(TimeFormatUtil.formatRelativeDateTime(future, clock)).isEqualTo("방금 전");
         }
     }
 
@@ -178,9 +178,9 @@ class TimeFormatUtilTest {
         );
     }
 
-    private String formatFeed(Clock clock, long secondsBefore) {
+    private String formatFeedAndComment(Clock clock, long secondsBefore) {
         LocalDateTime createdAt = LocalDateTime.now(clock).minusSeconds(secondsBefore);
-        return TimeFormatUtil.formatFeedDate(createdAt, clock);
+        return TimeFormatUtil.formatRelativeDateTime(createdAt, clock);
     }
 
     private String formatNotification(Clock clock, long secondsBefore) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#504-> dev
- close #504

## Key Changes
<!-- 최대한 자세히 -->

피드와 날짜 정책을 수정하였습니다.

기존 피드 날짜 포맷팅 유틸 클래스를 사용하였으며, 메서드 명을 `formatFeedDateTime`에서 `formatRelativeDateTime`으로 일괄 수정하였습니다.


## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
