### PR TITLE
[FEAT] 상위 키워드 조회 기능 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/KeywordFindApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/KeywordFindApplication.java
@@ -1,0 +1,51 @@
+package org.websoso.WSSServer.application;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.domain.common.KeywordCategoryName;
+import org.websoso.WSSServer.dto.keyword.CategoryGetResponse;
+import org.websoso.WSSServer.dto.keyword.KeywordByCategoryGetResponse;
+import org.websoso.WSSServer.dto.keyword.KeywordGetResponse;
+import org.websoso.WSSServer.dto.keyword.KeywordPopularGetResponse;
+import org.websoso.WSSServer.library.domain.Keyword;
+import org.websoso.WSSServer.library.service.KeywordService;
+
+@Service
+@RequiredArgsConstructor
+public class KeywordFindApplication {
+
+    private final KeywordService keywordService;
+
+    @Transactional(readOnly = true)
+    public KeywordByCategoryGetResponse searchKeywordByCategory(String query) {
+        List<Keyword> searchedKeywords = keywordService.searchKeyword(query);
+        List<CategoryGetResponse> categories = Arrays.stream(KeywordCategoryName.values())
+                .map(category -> CategoryGetResponse.of(
+                        keywordService.getKeywordCategory(category.getLabel()),
+                        sortByCategoryAndOrder(category, searchedKeywords)
+                ))
+                .toList();
+        return KeywordByCategoryGetResponse.of(categories);
+    }
+
+    @Transactional(readOnly = true)
+    public KeywordPopularGetResponse searchPopularKeyword(int size) {
+        List<KeywordGetResponse> keywords = keywordService.getPopularKeywords(size).stream()
+                .map(KeywordGetResponse::of)
+                .toList();
+        return KeywordPopularGetResponse.of(keywords);
+    }
+
+    private List<KeywordGetResponse> sortByCategoryAndOrder(KeywordCategoryName categoryName,
+                                                            List<Keyword> searchedKeywords) {
+        return searchedKeywords.stream()
+                .filter(k -> k.getKeywordCategory().getKeywordCategoryName().equals(categoryName.getLabel()))
+                .sorted(Comparator.comparing(Keyword::getSortOrder))
+                .map(KeywordGetResponse::of)
+                .toList();
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/controller/KeywordController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/KeywordController.java
@@ -8,21 +8,30 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.websoso.WSSServer.application.KeywordFindApplication;
 import org.websoso.WSSServer.dto.keyword.KeywordByCategoryGetResponse;
-import org.websoso.WSSServer.library.service.KeywordService;
+import org.websoso.WSSServer.dto.keyword.KeywordPopularGetResponse;
 
 @RestController
 @RequestMapping("/keywords")
 @RequiredArgsConstructor
 public class KeywordController {
 
-    private final KeywordService keywordService;
+    private final KeywordFindApplication keywordFindApplication;
 
     @GetMapping
     public ResponseEntity<KeywordByCategoryGetResponse> searchKeywordByCategory(
             @RequestParam(required = false) String query) {
         return ResponseEntity
                 .status(OK)
-                .body(keywordService.searchKeywordByCategory(query));
+                .body(keywordFindApplication.searchKeywordByCategory(query));
+    }
+
+    @GetMapping("/popular")
+    public ResponseEntity<KeywordPopularGetResponse> searchPopularKeyword(
+            @RequestParam(required = false, defaultValue = "7") int size) {
+        return ResponseEntity
+                .status(OK)
+                .body(keywordFindApplication.searchPopularKeyword(size));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/keyword/KeywordPopularGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/keyword/KeywordPopularGetResponse.java
@@ -1,0 +1,15 @@
+package org.websoso.WSSServer.dto.keyword;
+
+import org.websoso.WSSServer.library.domain.KeywordCategory;
+
+import java.util.List;
+
+public record KeywordPopularGetResponse(
+        List<KeywordGetResponse> keywords
+) {
+    public static KeywordPopularGetResponse of(List<KeywordGetResponse> keywords) {
+        return new KeywordPopularGetResponse(
+                keywords
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/library/repository/UserNovelKeywordRepository.java
+++ b/src/main/java/org/websoso/WSSServer/library/repository/UserNovelKeywordRepository.java
@@ -2,6 +2,7 @@ package org.websoso.WSSServer.library.repository;
 
 import java.util.List;
 import java.util.Set;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +17,9 @@ import org.websoso.WSSServer.library.domain.UserNovelKeyword;
 public interface UserNovelKeywordRepository extends JpaRepository<UserNovelKeyword, Long> {
 
     List<UserNovelKeyword> findAllByUserNovel_Novel(Novel novel);
+
+    @Query("SELECT unk.keyword FROM UserNovelKeyword unk GROUP BY unk.keyword ORDER BY COUNT(unk) DESC")
+    List<Keyword> findTopKeywordsByCount(Pageable pageable);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Transactional

--- a/src/main/java/org/websoso/WSSServer/library/service/KeywordService.java
+++ b/src/main/java/org/websoso/WSSServer/library/service/KeywordService.java
@@ -3,22 +3,17 @@ package org.websoso.WSSServer.library.service;
 import static org.websoso.WSSServer.exception.error.CustomKeywordCategoryError.KEYWORD_CATEGORY_NOT_FOUND;
 import static org.websoso.WSSServer.exception.error.CustomKeywordError.KEYWORD_NOT_FOUND;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.PageRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.dto.keyword.KeywordCountGetResponse;
 import org.websoso.WSSServer.library.domain.Keyword;
 import org.websoso.WSSServer.library.domain.KeywordCategory;
-import org.websoso.WSSServer.domain.common.KeywordCategoryName;
-import org.websoso.WSSServer.dto.keyword.CategoryGetResponse;
-import org.websoso.WSSServer.dto.keyword.KeywordByCategoryGetResponse;
-import org.websoso.WSSServer.dto.keyword.KeywordGetResponse;
 import org.websoso.WSSServer.exception.exception.CustomKeywordCategoryException;
 import org.websoso.WSSServer.exception.exception.CustomKeywordException;
 import org.websoso.WSSServer.library.domain.UserNovel;
@@ -46,18 +41,6 @@ public class KeywordService {
                         "keyword with the given id is not found"));
     }
 
-    @Transactional(readOnly = true)
-    public KeywordByCategoryGetResponse searchKeywordByCategory(String query) {
-        List<Keyword> searchedKeywords = searchKeyword(query);
-        List<CategoryGetResponse> categories = Arrays.stream(KeywordCategoryName.values())
-                .map(category -> CategoryGetResponse.of(
-                        getKeywordCategory(category.getLabel()),
-                        sortByCategoryAndOrder(category, searchedKeywords)
-                ))
-                .toList();
-        return KeywordByCategoryGetResponse.of(categories);
-    }
-
     public void createNovelKeyword(UserNovel userNovel, Keyword keyword) {
         userNovelKeywordRepository.save(UserNovelKeyword.create(userNovel, keyword));
     }
@@ -73,22 +56,18 @@ public class KeywordService {
         userNovelKeywordRepository.deleteAll(userNovelKeywords);
     }
 
-    private KeywordCategory getKeywordCategory(String keywordCategoryName) {
+    public KeywordCategory getKeywordCategory(String keywordCategoryName) {
         return keywordCategoryRepository.findByKeywordCategoryName(keywordCategoryName).orElseThrow(
                 () -> new CustomKeywordCategoryException(KEYWORD_CATEGORY_NOT_FOUND,
                         "keyword category with the given name is not found"));
     }
 
-    private List<KeywordGetResponse> sortByCategoryAndOrder(KeywordCategoryName categoryName,
-                                                            List<Keyword> searchedKeywords) {
-        return searchedKeywords.stream()
-                .filter(k -> k.getKeywordCategory().getKeywordCategoryName().equals(categoryName.getLabel()))
-                .sorted(Comparator.comparing(Keyword::getSortOrder))
-                .map(KeywordGetResponse::of)
-                .toList();
+    @Transactional(readOnly = true)
+    public List<Keyword> getPopularKeywords(int size) {
+        return userNovelKeywordRepository.findTopKeywordsByCount(PageRequest.of(0, size));
     }
 
-    private List<Keyword> searchKeyword(String query) {
+    public List<Keyword> searchKeyword(String query) {
         List<Keyword> allKeywords = keywordRepository.findAllByOrderBySortOrderAsc();
 
         if (query == null || query.isBlank()) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#504 -> dev
- close #504

## Key Changes
<!-- 최대한 자세히 -->
1. 키워드 컨트롤러에서 키워드 서비스를 바로 호출 하던 것을 키워드 애플리케이션 호출로 변경
2. 인기 키워드 리스트 조회 api 추가

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
