### PR TITLE
[FIX] 피드 조회 결과가 빈 리스트로 나오는 문제

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/FeedFindApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/FeedFindApplication.java
@@ -95,6 +95,7 @@ public class FeedFindApplication {
         Slice<Feed> feeds = findFeedsByCategoryLabel(lastFeedId, userIdOrNull,
                 PageRequest.of(DEFAULT_PAGE_NUMBER, size), feedGetOption, genres);
 
+        // TODO: feed -> feed.isVisibleTo(userIdOrNull) 해당 필터링 로직은 필요 없음
         List<FeedInfo> feedGetResponses = feeds.getContent().stream().filter(feed -> feed.isVisibleTo(userIdOrNull))
                 .map(feed -> createFeedInfo(feed, user)).toList();
 

--- a/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/repository/FeedCustomRepositoryImpl.java
@@ -156,7 +156,8 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                         checkPopularFeed(),
                         checkGenresAndNovels(genres, true),
                         checkBlocking(userId),
-                        checkHidden()
+                        checkHidden(),
+                        checkVisible(userId)
                 )
                 .limit(pageRequest.getPageSize() + 1)
                 .orderBy(feed.feedId.desc())
@@ -181,7 +182,8 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository, FeedImage
                         ltFeedId(lastFeedId),
                         checkBlocking(userId),
                         checkHidden(),
-                        checkInterestedNovels(userId)
+                        checkInterestedNovels(userId),
+                        checkVisible(userId)
                 )
                 .limit(pageRequest.getPageSize() + 1)
                 .orderBy(feed.feedId.desc())

--- a/src/main/java/org/websoso/WSSServer/feed/repository/FeedRepository.java
+++ b/src/main/java/org/websoso/WSSServer/feed/repository/FeedRepository.java
@@ -18,6 +18,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedCustomRep
     @Query(value = "SELECT f FROM Feed f WHERE "
             + "(:lastFeedId = 0 OR f.feedId < :lastFeedId) "
             + "AND f.isHidden = false "
+            + "AND (f.isPublic = true OR f.user.userId = :userId)"
             + "AND (:userId IS NULL "
             + "OR f.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = :userId)) "
             + "ORDER BY f.feedId DESC")
@@ -29,6 +30,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedCustomRep
             + "(:lastFeedId = 0 OR f.feedId < :lastFeedId) "
             + "AND f.novelId = :novelId "
             + "AND f.isHidden = false "
+            + "AND (f.isPublic = true OR f.user.userId = :userId)"
             + "AND (:userId IS NULL "
             + "OR f.user.userId NOT IN (SELECT b.blockedId FROM Block b WHERE b.blockingId = :userId)) "
             + "ORDER BY f.feedId DESC")


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#511 -> dev
- close #511

## Key Changes
<!-- 최대한 자세히 -->
비 공개 글을 애플리케이션에서 필터링을 진행하고 있고 있었습니다.
이로 인해서 최근 글이 전부 비공개 글인 경우, 리스트를 빈 값으로 반환하게 되는 문제가 발생했습니다.

여태 문제가 없었던 이유는 최근 글 20개 중 한건이라도 공개 글이면 무한스크롤에 의해서 피드를 계속 조회해오기 때문입니다.

따라서, 해당 필터링을 쿼리에서 수행하도록 긴급 수정하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
