### PR TITLE
[FIX] 홈 화면 인기 소설 조회 정보 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.dto.novel.AutocompleteKeywordsResponse;
+import org.websoso.WSSServer.library.domain.UserNovelKeyword;
 import org.websoso.WSSServer.recentsearch.event.NovelSearchedEvent;
 import org.websoso.WSSServer.user.domain.AvatarProfile;
 import org.websoso.WSSServer.domain.Genre;
@@ -176,17 +178,30 @@ public class SearchNovelApplication {
     }
 
     @Transactional(readOnly = true)
-    public PopularNovelsGetResponse getTodayPopularNovels() {
+    public PopularNovelsGetResponse getTodayPopularNovels(Integer keywordSize) {
         List<Long> novelIdsFromPopularNovel = popularNovelService.getNovelIdsFromPopularNovel();
         List<Long> selectedNovelIdsFromPopularNovel = getSelectedNovelIdsFromPopularNovel(novelIdsFromPopularNovel);
         List<Novel> popularNovels = novelService.getSelectedPopularNovels(selectedNovelIdsFromPopularNovel);
         List<Feed> popularFeedsFromPopularNovels = feedRepository.findPopularFeedsByNovelIds(
                 selectedNovelIdsFromPopularNovel);
 
+        Map<Long, List<Keyword>> keywordMap = popularNovels.stream()
+                .collect(Collectors.toMap(
+                    Novel::getNovelId,
+                    novel -> libraryKeywordService.getKeywords(novel).stream()
+                            .map(UserNovelKeyword::getKeyword)
+                            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
+                            .entrySet().stream()
+                            .sorted(Map.Entry.<Keyword, Long>comparingByValue().reversed())
+                            .limit(keywordSize)
+                            .map(Map.Entry::getKey)
+                            .collect(Collectors.toList())
+                ));
+
         Map<Long, Feed> feedMap = createFeedMap(popularFeedsFromPopularNovels);
         Map<Long, AvatarProfile> avatarMap = createAvatarMap(feedMap);
 
-        return PopularNovelsGetResponse.create(popularNovels, feedMap, avatarMap);
+        return PopularNovelsGetResponse.create(popularNovels, feedMap, avatarMap, keywordMap);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -127,11 +127,12 @@ public class NovelController {
      * @return PopularNovelsGetResponse
      */
     @GetMapping("/popular")
-    public ResponseEntity<PopularNovelsGetResponse> getTodayPopularNovels(@AuthenticationPrincipal User user) {
+    public ResponseEntity<PopularNovelsGetResponse> getTodayPopularNovels(@AuthenticationPrincipal User user,
+                                                                          @RequestParam(required = false, defaultValue = "2") Integer keywordSize) {
         //TODO 차단 관계에 있는 유저의 피드글 처리
         return ResponseEntity
                 .status(OK)
-                .body(searchNovelApplication.getTodayPopularNovels());
+                .body(searchNovelApplication.getTodayPopularNovels(keywordSize));
     }
 
     /**

--- a/src/main/java/org/websoso/WSSServer/dto/popularNovel/PopularNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/popularNovel/PopularNovelGetResponse.java
@@ -1,8 +1,14 @@
 package org.websoso.WSSServer.dto.popularNovel;
 
+import org.websoso.WSSServer.dto.keyword.KeywordGetResponse;
+import org.websoso.WSSServer.library.domain.Keyword;
+import org.websoso.WSSServer.novel.domain.NovelGenre;
 import org.websoso.WSSServer.user.domain.AvatarProfile;
 import org.websoso.WSSServer.feed.domain.Feed;
 import org.websoso.WSSServer.novel.domain.Novel;
+
+import java.util.List;
+import java.util.Optional;
 
 public record PopularNovelGetResponse(
         Long novelId,
@@ -10,10 +16,17 @@ public record PopularNovelGetResponse(
         String novelImage,
         String avatarImage,
         String nickname,
-        String feedContent
+        String feedContent,
+        List<String> keywords,
+        String author,
+        Optional<String> novelGenreImage,
+        String novelDescription,
+        boolean isNovelCompleted,
+        List<String> novelGenres
+
 ) {
 
-    public static PopularNovelGetResponse of(Novel novel, AvatarProfile avatarProfile, Feed feed) {
+    public static PopularNovelGetResponse of(Novel novel, AvatarProfile avatarProfile, Feed feed, List<String> keywords, List<String> genres) {
         if (avatarProfile == null && feed == null) {
             return new PopularNovelGetResponse(
                     novel.getNovelId(),
@@ -21,7 +34,14 @@ public record PopularNovelGetResponse(
                     novel.getNovelImage(),
                     null,
                     null,
-                    novel.getNovelDescription()
+                    null,
+                    keywords,
+                    novel.getAuthor(),
+                    novel.getFirstGenreImage(),
+                    novel.getNovelDescription(),
+                    novel.getIsCompleted(),
+                    genres
+
             );
         }
         return new PopularNovelGetResponse(
@@ -30,7 +50,13 @@ public record PopularNovelGetResponse(
                 novel.getNovelImage(),
                 avatarProfile.getAvatarProfileImage(),
                 feed.getUser().getNickname(),
-                feed.getFeedContent()
+                feed.getFeedContent(),
+                keywords,
+                novel.getAuthor(),
+                novel.getFirstGenreImage(),
+                novel.getNovelDescription(),
+                novel.getIsCompleted(),
+                genres
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/popularNovel/PopularNovelsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/popularNovel/PopularNovelsGetResponse.java
@@ -2,6 +2,9 @@ package org.websoso.WSSServer.dto.popularNovel;
 
 import java.util.List;
 import java.util.Map;
+
+import org.websoso.WSSServer.dto.keyword.KeywordGetResponse;
+import org.websoso.WSSServer.library.domain.Keyword;
 import org.websoso.WSSServer.user.domain.AvatarProfile;
 import org.websoso.WSSServer.feed.domain.Feed;
 import org.websoso.WSSServer.novel.domain.Novel;
@@ -11,15 +14,23 @@ public record PopularNovelsGetResponse(
 ) {
     public static PopularNovelsGetResponse create(List<Novel> popularNovels,
                                                                            Map<Long, Feed> feedMap,
-                                                                           Map<Long, AvatarProfile> avatarMap) {
+                                                                           Map<Long, AvatarProfile> avatarMap,
+                                                                           Map<Long, List<Keyword>> keywords) {
         List<PopularNovelGetResponse> popularNovelResponses = popularNovels.stream()
                 .map(novel -> {
                     Feed feed = feedMap.get(novel.getNovelId());
+
+                    List<String> keywordGetResponsesList = keywords.get(novel.getNovelId()).stream()
+                            .map(keyword -> keyword.getKeywordName())
+                            .toList();
+                    List<String> genres = novel.getNovelGenres().stream()
+                            .map(novelGenre -> novelGenre.getGenre().getGenreName())
+                            .toList();
                     if (feed == null) {
-                        return PopularNovelGetResponse.of(novel, null, null);
+                        return PopularNovelGetResponse.of(novel, null, null, keywordGetResponsesList, genres);
                     }
                     AvatarProfile avatar = avatarMap.get(feed.getUser().getAvatarProfileId());
-                    return PopularNovelGetResponse.of(novel, avatar, feed);
+                    return PopularNovelGetResponse.of(novel, avatar, feed, keywordGetResponsesList, genres);
                 })
                 .toList();
         return new PopularNovelsGetResponse(popularNovelResponses);

--- a/src/main/java/org/websoso/WSSServer/feed/domain/Feed.java
+++ b/src/main/java/org/websoso/WSSServer/feed/domain/Feed.java
@@ -73,9 +73,6 @@ public class Feed {
     @OneToMany(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<ReportedFeed> reportedFeeds = new ArrayList<>();
 
-    @OneToOne(mappedBy = "feed", cascade = ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private PopularFeed popularFeed;
-
     private Feed(String feedContent, Long novelId, Boolean isSpoiler, Boolean isPublic, User user, List<FeedImage> images) {
         this.feedContent = feedContent;
         this.novelId = novelId;

--- a/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
@@ -10,6 +10,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -44,5 +46,11 @@ public class Novel {
 
     @OneToMany(mappedBy = "novel", fetch = FetchType.LAZY)
     private List<NovelGenre> novelGenres = new ArrayList<>();
+
+    public Optional<String> getFirstGenreImage(){
+        return novelGenres.stream()
+                .findFirst()
+                .map(novelGenre -> novelGenre.getGenre().getGenreImage());
+    }
 
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#514 -> dev
- close #514

## Key Changes
<!-- 최대한 자세히 -->
get /novels/popular 조회시 필드 추가
author: 작가명
isNovelCompleted: 연재/완결 여부
novelGenres: 장르명
novelGenreImage: 작품 상세에서 사용 중인 장르 아이콘 이미지
keywords: 상위 연관 키워드 최대 2개
novelDescription: feedContent가 null일 때 대체로 보여줄 작품 소개

Feed 도메인에서 안쓰는 popularFedds 필드 제거

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
