### PR TITLE
[REFACTOR] 장르 이미지 정책 변경으로 장르 이미지 url에서 장르 네임으로 반환값 변경

### DIFF
--- a/src/main/java/org/websoso/WSSServer/dto/popularNovel/PopularNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/popularNovel/PopularNovelGetResponse.java
@@ -1,14 +1,9 @@
 package org.websoso.WSSServer.dto.popularNovel;
 
-import org.websoso.WSSServer.dto.keyword.KeywordGetResponse;
-import org.websoso.WSSServer.library.domain.Keyword;
-import org.websoso.WSSServer.novel.domain.NovelGenre;
 import org.websoso.WSSServer.user.domain.AvatarProfile;
 import org.websoso.WSSServer.feed.domain.Feed;
 import org.websoso.WSSServer.novel.domain.Novel;
-
 import java.util.List;
-import java.util.Optional;
 
 public record PopularNovelGetResponse(
         Long novelId,
@@ -19,7 +14,7 @@ public record PopularNovelGetResponse(
         String feedContent,
         List<String> keywords,
         String author,
-        Optional<String> novelGenreImage,
+        String genreName,
         String novelDescription,
         boolean isNovelCompleted,
         List<String> novelGenres
@@ -37,7 +32,7 @@ public record PopularNovelGetResponse(
                     null,
                     keywords,
                     novel.getAuthor(),
-                    novel.getFirstGenreImage(),
+                    novel.getFirstGenreName(),
                     novel.getNovelDescription(),
                     novel.getIsCompleted(),
                     genres
@@ -53,7 +48,7 @@ public record PopularNovelGetResponse(
                 feed.getFeedContent(),
                 keywords,
                 novel.getAuthor(),
-                novel.getFirstGenreImage(),
+                novel.getFirstGenreName(),
                 novel.getNovelDescription(),
                 novel.getIsCompleted(),
                 genres

--- a/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
@@ -47,10 +47,10 @@ public class Novel {
     @OneToMany(mappedBy = "novel", fetch = FetchType.LAZY)
     private List<NovelGenre> novelGenres = new ArrayList<>();
 
-    public Optional<String> getFirstGenreImage(){
+    public String getFirstGenreName(){
         return novelGenres.stream()
                 .findFirst()
-                .map(novelGenre -> novelGenre.getGenre().getGenreImage());
+                .map(novelGenre -> novelGenre.getGenre().getGenreName()).orElse(null);
     }
 
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#517 -> dev
- close #517

## Key Changes
<!-- 최대한 자세히 -->
1. Novel 도메인 객체에 만들어져 있던 getFirstGenreUrl 을 getFirstGenreName으로 변경
2. PopularNovelGetResponse의 반환값을 novelGenreImage(url 문자열) 에서, genreName으로 변경

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
1. Novel 도메인 객체에 만들어둔 getFirstGenreName에서, 조회 결과가 없을 경우 null을 반환을 하는데, 장르가 없을 경우 에러로 반환 해야할까요?

## References
<!-- 참고한 자료-->
정책 회의 https://app.notion.com/p/kimmjabc/API-3789e64a4532805aa1c6c02d5f343c20?source=copy_link
