### PR TITLE
[FIX] 인기 키워드 조회시 로그인 필요 없도록 수정 및 오늘의 발견 미사용 필드 제거

### DIFF
--- a/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
             "/auth/login/apple",
             "/auth/apple/sync",
             "/minimum-version",
+            "/keywords/popular",
     };
 
     private static final String[] swaggerPaths = {

--- a/src/main/java/org/websoso/WSSServer/dto/popularNovel/PopularNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/popularNovel/PopularNovelGetResponse.java
@@ -16,12 +16,11 @@ public record PopularNovelGetResponse(
         String author,
         String genreName,
         String novelDescription,
-        boolean isNovelCompleted,
-        List<String> novelGenres
+        boolean isNovelCompleted
 
 ) {
 
-    public static PopularNovelGetResponse of(Novel novel, AvatarProfile avatarProfile, Feed feed, List<String> keywords, List<String> genres) {
+    public static PopularNovelGetResponse of(Novel novel, AvatarProfile avatarProfile, Feed feed, List<String> keywords) {
         if (avatarProfile == null && feed == null) {
             return new PopularNovelGetResponse(
                     novel.getNovelId(),
@@ -34,8 +33,7 @@ public record PopularNovelGetResponse(
                     novel.getAuthor(),
                     novel.getFirstGenreName(),
                     novel.getNovelDescription(),
-                    novel.getIsCompleted(),
-                    genres
+                    novel.getIsCompleted()
 
             );
         }
@@ -50,8 +48,7 @@ public record PopularNovelGetResponse(
                 novel.getAuthor(),
                 novel.getFirstGenreName(),
                 novel.getNovelDescription(),
-                novel.getIsCompleted(),
-                genres
+                novel.getIsCompleted()
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/popularNovel/PopularNovelsGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/popularNovel/PopularNovelsGetResponse.java
@@ -3,7 +3,6 @@ package org.websoso.WSSServer.dto.popularNovel;
 import java.util.List;
 import java.util.Map;
 
-import org.websoso.WSSServer.dto.keyword.KeywordGetResponse;
 import org.websoso.WSSServer.library.domain.Keyword;
 import org.websoso.WSSServer.user.domain.AvatarProfile;
 import org.websoso.WSSServer.feed.domain.Feed;
@@ -23,14 +22,12 @@ public record PopularNovelsGetResponse(
                     List<String> keywordGetResponsesList = keywords.get(novel.getNovelId()).stream()
                             .map(keyword -> keyword.getKeywordName())
                             .toList();
-                    List<String> genres = novel.getNovelGenres().stream()
-                            .map(novelGenre -> novelGenre.getGenre().getGenreName())
-                            .toList();
+
                     if (feed == null) {
-                        return PopularNovelGetResponse.of(novel, null, null, keywordGetResponsesList, genres);
+                        return PopularNovelGetResponse.of(novel, null, null, keywordGetResponsesList);
                     }
                     AvatarProfile avatar = avatarMap.get(feed.getUser().getAvatarProfileId());
-                    return PopularNovelGetResponse.of(novel, avatar, feed, keywordGetResponsesList, genres);
+                    return PopularNovelGetResponse.of(novel, avatar, feed, keywordGetResponsesList);
                 })
                 .toList();
         return new PopularNovelsGetResponse(popularNovelResponses);


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#523 -> dev
- close #523

## Key Changes
<!-- 최대한 자세히 -->
1. 비회원도 인기 키워드 조회가 가능 하도록 SecurityConfig 파일의 permitAllPaths에 /keywords/popular 필드를 추가하였습니다.
2. PopularNovelGetResponse 파일에 있던 List<String> novelGenres 필드를 더이상 사용하지 않아 필드에서 제거하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
