### PR TITLE
[FEAT] 소설 필터 검색 시 플랫폼 필터 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
@@ -100,7 +100,7 @@ public class SearchNovelApplication {
 
     //TODO: 추후 novelRating 제거
     @Transactional(readOnly = true)
-    public FilteredNovelsResponse getFilteredNovels(List<String> genreNames, List<Integer> keywordIds, Boolean isCompleted, Float novelRating, Float novelRatingStart, Float novelRatingEnd, int page, int size) {
+    public FilteredNovelsResponse getFilteredNovels(List<String> genreNames, List<Integer> keywordIds, Boolean isCompleted, Float novelRating, Float novelRatingStart, Float novelRatingEnd, List<String> platformNames, int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size);
 
         List<Genre> genres = genreService.getGenresOrException(genreNames);
@@ -110,9 +110,9 @@ public class SearchNovelApplication {
         Page<Novel> novels;
 
         if (novelRating == null) {
-            novels = novelService.findFilteredNovels(pageRequest, genres, keywords, isCompleted, novelRatingStart, novelRatingEnd);
+            novels = novelService.findFilteredNovels(pageRequest, genres, keywords, isCompleted, novelRatingStart, novelRatingEnd, platformNames);
         } else {
-            novels = novelService.findFilteredNovels(pageRequest, genres, keywords, isCompleted, novelRating, novelRatingEnd);
+            novels = novelService.findFilteredNovels(pageRequest, genres, keywords, isCompleted, novelRating, novelRatingEnd, platformNames);
         }
 
         List<NovelSummaryResponse> novelGetResponsePreviews = novels.stream()

--- a/src/main/java/org/websoso/WSSServer/controller/NovelController.java
+++ b/src/main/java/org/websoso/WSSServer/controller/NovelController.java
@@ -84,12 +84,13 @@ public class NovelController {
             @RequestParam(required = false, defaultValue = "0.0") Float novelRatingStart,
             @RequestParam(required = false, defaultValue = "5.0") Float novelRatingEnd,
             @RequestParam(required = false) List<Integer> keywordIds,
+            @RequestParam(required = false) List<String> platformNames,
             @RequestParam int page,
             @RequestParam int size) {
         return ResponseEntity
                 .status(OK)
                 .body(searchNovelApplication.getFilteredNovels(genres, keywordIds, isCompleted, novelRating,
-                        novelRatingStart, novelRatingEnd, page, size));
+                        novelRatingStart, novelRatingEnd, platformNames, page, size));
     }
 
     /**

--- a/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
@@ -47,6 +47,9 @@ public class Novel {
     @OneToMany(mappedBy = "novel", fetch = FetchType.LAZY)
     private List<NovelGenre> novelGenres = new ArrayList<>();
 
+    @OneToMany(mappedBy = "novel", fetch = FetchType.LAZY)
+    private List<NovelPlatform> novelPlatforms = new ArrayList<>();
+
     public String getFirstGenreName(){
         return novelGenres.stream()
                 .findFirst()

--- a/src/main/java/org/websoso/WSSServer/novel/domain/Platform.java
+++ b/src/main/java/org/websoso/WSSServer/novel/domain/Platform.java
@@ -2,13 +2,13 @@ package org.websoso.WSSServer.novel.domain;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -24,5 +24,8 @@ public class Platform {
 
     @Column(columnDefinition = "text", nullable = false)
     private String platformImage;
+
+    @OneToMany(mappedBy = "platform", fetch = FetchType.LAZY)
+    private List<NovelPlatform> novelPlatforms = new ArrayList<>();
 
 }

--- a/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepository.java
@@ -11,7 +11,7 @@ public interface NovelCustomRepository {
 
     Page<Novel> findSearchedNovels(Pageable pageable, String query);
 
-    Page<Novel> findFilteredNovels(Pageable pageable, List<Genre> genres, Boolean isCompleted, Float novelRatingStart, Float novelRatingEnd, List<Keyword> keywords);
+    Page<Novel> findFilteredNovels(Pageable pageable, List<Genre> genres, Boolean isCompleted, Float novelRatingStart, Float novelRatingEnd, List<Keyword> keywords, List<String> platformNames);
 
     List<Novel> findAutocompleteNovels(String searchQuery, int limitSize);
 

--- a/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
@@ -6,6 +6,8 @@ import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHING;
 import static org.websoso.WSSServer.library.domain.QUserNovel.userNovel;
 import static org.websoso.WSSServer.novel.domain.QNovel.novel;
 import static org.websoso.WSSServer.novel.domain.QNovelGenre.novelGenre;
+import static org.websoso.WSSServer.novel.domain.QNovelPlatform.novelPlatform;
+import static org.websoso.WSSServer.novel.domain.QPlatform.platform;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
@@ -75,7 +77,7 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 
     @Override
     public Page<Novel> findFilteredNovels(Pageable pageable, List<Genre> genres, Boolean isCompleted, Float novelRatingStart,
-                                          Float novelRatingEnd, List<Keyword> keywords) {
+                                          Float novelRatingEnd, List<Keyword> keywords, List<String> platformNames) {
 
         NumberTemplate<Long> popularity = Expressions.numberTemplate(Long.class,
                 "(SELECT COUNT(un) FROM UserNovel un WHERE un.novel = {0} AND (un.isInterest = true OR un.status <> 'QUIT'))",
@@ -85,6 +87,8 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
                 .selectFrom(novel)
                 .distinct()
                 .join(novel.novelGenres, novelGenre)
+                .leftJoin(novel.novelPlatforms, novelPlatform)
+                .leftJoin(novelPlatform.platform, platform)
                 .where(
                         genres.isEmpty()
                                 ? null
@@ -95,7 +99,11 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
                         getAverageRatingCondition(novel, novelRatingStart, novelRatingEnd),
                         keywords.isEmpty()
                                 ? null
-                                : getKeywordCount(novel, keywords).eq(keywords.size())
+                                : getKeywordCount(novel, keywords).eq(keywords.size()),
+                        platformNames == null || platformNames.isEmpty()
+                                ? null
+                                : platform.platformName.in(platformNames)
+
                 )
                 .orderBy(popularity.desc());
 

--- a/src/main/java/org/websoso/WSSServer/novel/service/NovelServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/service/NovelServiceImpl.java
@@ -51,8 +51,8 @@ public class NovelServiceImpl {
     }
 
     public Page<Novel> findFilteredNovels(PageRequest pageRequest, List<Genre> genres, List<Keyword> keywords,
-                                          Boolean isCompleted, Float novelRatingStart, Float novelRatingEnd) {
-        return novelRepository.findFilteredNovels(pageRequest, genres, isCompleted, novelRatingStart, novelRatingEnd, keywords);
+                                          Boolean isCompleted, Float novelRatingStart, Float novelRatingEnd, List<String> platformNames) {
+        return novelRepository.findFilteredNovels(pageRequest, genres, isCompleted, novelRatingStart, novelRatingEnd, keywords, platformNames);
     }
 
     public List<NovelGenre> getGenresByNovel(Novel novel) {


### PR DESCRIPTION
  - /novels/filtered API에 platformNames(Array<String>) 파라미터 추가
  - platformNames가 존재하면 해당 플랫폼에 등록된 소설만 조회
  - NovelGenre 조인을 INNER → LEFT JOIN으로 변경하여 플랫폼 없는 소설도 포함)

## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#535 -> dev
- close #535

## Key Changes
<!-- 최대한 자세히 -->
- `/novels/filtered` API에 `platformNames(Array<String>)` 쿼리 파라미터 추가
- `platformNames`가 존재하는 경우 해당 플랫폼에 등록된 소설만 조회
- `platformNames`가 없는 경우 기존과 동일하게 전체 조회
- `Novel`, `Platform` 엔티티에 `novelPlatforms` OneToMany 연관관계 추가
- `NovelCustomRepositoryImpl`에 `NovelPlatform`, `Platform` LEFT JOIN 및 플랫폼 필터 조건 추가

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
