### PR TITLE
[REFACTOR] 소설 필터 조회 최적화 - 소설 통계 데이터 추가

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/LibraryEvaluationApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/LibraryEvaluationApplication.java
@@ -28,7 +28,9 @@ import org.websoso.WSSServer.library.service.AttractivePointService;
 import org.websoso.WSSServer.library.service.KeywordService;
 import org.websoso.WSSServer.library.service.LibraryService;
 import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.novel.domain.NovelStatisticsContribution;
 import org.websoso.WSSServer.novel.service.NovelServiceImpl;
+import org.websoso.WSSServer.novel.service.NovelStatisticsService;
 
 /**
  * 서재 평가는 서재와 매력 포인트, 키워드가 핵심 도메인이다.
@@ -39,6 +41,7 @@ public class LibraryEvaluationApplication {
 
     private final NovelServiceImpl novelService;
     private final LibraryService libraryService;
+    private final NovelStatisticsService novelStatisticsService;
     private final AttractivePointService attractivePointService;
     private final KeywordService keywordService;
 
@@ -55,6 +58,11 @@ public class LibraryEvaluationApplication {
         try {
             UserNovel userNovel = libraryService.createLibrary(request.status(), request.userNovelRating(),
                     request.startDate(), request.endDate(), user, novel);
+            novelStatisticsService.updateByDelta(
+                    novel.getNovelId(),
+                    NovelStatisticsContribution.EMPTY,
+                    NovelStatisticsContribution.from(userNovel)
+            );
 
             attractivePointService.createUserNovelAttractivePoints(userNovel, request.attractivePoints());
             keywordService.createNovelKeywords(userNovel, request.keywordIds());
@@ -94,9 +102,15 @@ public class LibraryEvaluationApplication {
     @Transactional
     public void updateEvaluation(User user, Long novelId, UserNovelUpdateRequest request) {
         UserNovel userNovel = libraryService.getLibraryForUpdateOrException(user, novelId);
+        NovelStatisticsContribution before = NovelStatisticsContribution.from(userNovel);
 
         libraryService.updateEvaluation(userNovel, request.userNovelRating(), request.status(), request.startDate(),
                 request.endDate());
+        novelStatisticsService.updateByDelta(
+                novelId,
+                before,
+                NovelStatisticsContribution.from(userNovel)
+        );
 
         updateAttractivePoints(userNovel, request.attractivePoints());
 
@@ -112,6 +126,7 @@ public class LibraryEvaluationApplication {
     @Transactional
     public void deleteEvaluation(User user, Long novelId) {
         UserNovel userNovel = libraryService.getLibraryForUpdateOrException(user, novelId);
+        NovelStatisticsContribution before = NovelStatisticsContribution.from(userNovel);
 
         if (userNovel.getStatus() == null) {
             throw new CustomUserNovelException(NOT_EVALUATED, "this novel has not been evaluated by the user");
@@ -119,11 +134,21 @@ public class LibraryEvaluationApplication {
 
         if (userNovel.getIsInterest()) {
             libraryService.deleteEvaluation(userNovel);
+            novelStatisticsService.updateByDelta(
+                    novelId,
+                    before,
+                    NovelStatisticsContribution.from(userNovel)
+            );
 
             attractivePointService.deleteUserNovelAttractivePoints(userNovel.getUserNovelAttractivePoints());
             keywordService.deleteUserNovelKeywords(userNovel.getUserNovelKeywords());
         } else {
             libraryService.delete(userNovel);
+            novelStatisticsService.updateByDelta(
+                    novelId,
+                    before,
+                    NovelStatisticsContribution.EMPTY
+            );
         }
     }
 

--- a/src/main/java/org/websoso/WSSServer/application/LibraryEvaluationApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/LibraryEvaluationApplication.java
@@ -93,9 +93,10 @@ public class LibraryEvaluationApplication {
      */
     @Transactional
     public void updateEvaluation(User user, Long novelId, UserNovelUpdateRequest request) {
-        UserNovel userNovel = libraryService.getLibraryOrException(user, novelId);
+        UserNovel userNovel = libraryService.getLibraryForUpdateOrException(user, novelId);
 
-        userNovel.updateUserNovel(request.userNovelRating(), request.status(), request.startDate(), request.endDate());
+        libraryService.updateEvaluation(userNovel, request.userNovelRating(), request.status(), request.startDate(),
+                request.endDate());
 
         updateAttractivePoints(userNovel, request.attractivePoints());
 
@@ -110,14 +111,14 @@ public class LibraryEvaluationApplication {
      */
     @Transactional
     public void deleteEvaluation(User user, Long novelId) {
-        UserNovel userNovel = libraryService.getLibraryOrException(user, novelId);
+        UserNovel userNovel = libraryService.getLibraryForUpdateOrException(user, novelId);
 
         if (userNovel.getStatus() == null) {
             throw new CustomUserNovelException(NOT_EVALUATED, "this novel has not been evaluated by the user");
         }
 
         if (userNovel.getIsInterest()) {
-            userNovel.deleteEvaluation();
+            libraryService.deleteEvaluation(userNovel);
 
             attractivePointService.deleteUserNovelAttractivePoints(userNovel.getUserNovelAttractivePoints());
             keywordService.deleteUserNovelKeywords(userNovel.getUserNovelKeywords());

--- a/src/main/java/org/websoso/WSSServer/application/LibraryInterestApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/LibraryInterestApplication.java
@@ -4,9 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.user.domain.User;
+import org.websoso.WSSServer.library.domain.UserNovel;
 import org.websoso.WSSServer.library.service.LibraryService;
 import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.novel.domain.NovelStatisticsContribution;
 import org.websoso.WSSServer.novel.service.NovelServiceImpl;
+import org.websoso.WSSServer.novel.service.NovelStatisticsService;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +17,7 @@ public class LibraryInterestApplication {
 
     private final NovelServiceImpl novelService;
     private final LibraryService libraryService;
+    private final NovelStatisticsService novelStatisticsService;
 
     /**
      * 관심있어요를 남긴다.
@@ -24,8 +28,15 @@ public class LibraryInterestApplication {
     @Transactional
     public void registerAsInterest(User user, Long novelId) {
         Novel novel = novelService.getNovelOrException(novelId);
+        UserNovel library = libraryService.getOrCreateLibraryForInterest(user, novel);
+        NovelStatisticsContribution before = NovelStatisticsContribution.from(library);
 
-        libraryService.registerInterest(user, novel);
+        libraryService.registerInterest(library);
+        novelStatisticsService.updateByDelta(
+                novelId,
+                before,
+                NovelStatisticsContribution.from(library)
+        );
     }
 
     /**
@@ -36,7 +47,19 @@ public class LibraryInterestApplication {
      */
     @Transactional
     public void unregisterAsInterest(User user, Long novelId) {
-        libraryService.unregisterInterest(user, novelId);
+        UserNovel library = libraryService.getLibraryForUpdateOrNull(user, novelId);
+
+        if (library == null || Boolean.FALSE.equals(library.getIsInterest())) {
+            return;
+        }
+
+        NovelStatisticsContribution before = NovelStatisticsContribution.from(library);
+        libraryService.unregisterInterest(library);
+        novelStatisticsService.updateByDelta(
+                novelId,
+                before,
+                NovelStatisticsContribution.from(library)
+        );
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/application/LibraryInterestApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/LibraryInterestApplication.java
@@ -1,13 +1,9 @@
 package org.websoso.WSSServer.application;
 
-import static org.websoso.WSSServer.exception.error.CustomUserNovelError.NOT_INTERESTED;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.user.domain.User;
-import org.websoso.WSSServer.exception.exception.CustomUserNovelException;
-import org.websoso.WSSServer.library.domain.UserNovel;
 import org.websoso.WSSServer.library.service.LibraryService;
 import org.websoso.WSSServer.novel.domain.Novel;
 import org.websoso.WSSServer.novel.service.NovelServiceImpl;
@@ -40,13 +36,7 @@ public class LibraryInterestApplication {
      */
     @Transactional
     public void unregisterAsInterest(User user, Long novelId) {
-        UserNovel library = libraryService.getLibraryOrNull(user, novelId);
-
-        if (library == null) {
-            return;
-        }
-
-        libraryService.unregisterInterest(library);
+        libraryService.unregisterInterest(user, novelId);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
@@ -42,11 +42,9 @@ import org.websoso.WSSServer.library.domain.Keyword;
 import org.websoso.WSSServer.library.service.LibraryService;
 import org.websoso.WSSServer.novel.domain.Novel;
 import org.websoso.WSSServer.novel.domain.NovelGenre;
-import org.websoso.WSSServer.novel.domain.NovelStatistics;
 import org.websoso.WSSServer.novel.service.GenreServiceImpl;
 import org.websoso.WSSServer.novel.service.KeywordServiceImpl;
 import org.websoso.WSSServer.novel.service.NovelServiceImpl;
-import org.websoso.WSSServer.novel.service.NovelStatisticsService;
 import org.websoso.WSSServer.novel.service.PopularNovelService;
 import org.websoso.WSSServer.repository.GenrePreferenceRepository;
 
@@ -61,7 +59,6 @@ public class SearchNovelApplication {
     private final KeywordService libraryKeywordService;
     private final KeywordServiceImpl keywordService;
     private final LibraryService libraryService;
-    private final NovelStatisticsService novelStatisticsService;
     private final ApplicationEventPublisher eventPublisher;
 
     // TODO: 삭제될 레포지토리 의존성
@@ -232,12 +229,9 @@ public class SearchNovelApplication {
                 .map(Novel::getNovelId)
                 .toList();
         Map<Long, Long> interestCounts = libraryService.getInterestCountsByNovelIds(novelIds);
-        Map<Long, NovelStatistics> statistics = novelStatisticsService.getStatisticsByNovelIds(novelIds);
-
         return novels.stream()
                 .map(novel -> NovelSummaryResponse.of(
                         novel,
-                        statistics.get(novel.getNovelId()),
                         interestCounts.getOrDefault(novel.getNovelId(), 0L)
                 ))
                 .toList();

--- a/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
@@ -42,9 +42,11 @@ import org.websoso.WSSServer.library.domain.Keyword;
 import org.websoso.WSSServer.library.service.LibraryService;
 import org.websoso.WSSServer.novel.domain.Novel;
 import org.websoso.WSSServer.novel.domain.NovelGenre;
+import org.websoso.WSSServer.novel.domain.NovelStatistics;
 import org.websoso.WSSServer.novel.service.GenreServiceImpl;
 import org.websoso.WSSServer.novel.service.KeywordServiceImpl;
 import org.websoso.WSSServer.novel.service.NovelServiceImpl;
+import org.websoso.WSSServer.novel.service.NovelStatisticsService;
 import org.websoso.WSSServer.novel.service.PopularNovelService;
 import org.websoso.WSSServer.repository.GenrePreferenceRepository;
 
@@ -59,6 +61,7 @@ public class SearchNovelApplication {
     private final KeywordService libraryKeywordService;
     private final KeywordServiceImpl keywordService;
     private final LibraryService libraryService;
+    private final NovelStatisticsService novelStatisticsService;
     private final ApplicationEventPublisher eventPublisher;
 
     // TODO: 삭제될 레포지토리 의존성
@@ -229,10 +232,12 @@ public class SearchNovelApplication {
                 .map(Novel::getNovelId)
                 .toList();
         Map<Long, Long> interestCounts = libraryService.getInterestCountsByNovelIds(novelIds);
+        Map<Long, NovelStatistics> statistics = novelStatisticsService.getStatisticsByNovelIds(novelIds);
 
         return novels.stream()
                 .map(novel -> NovelSummaryResponse.of(
                         novel,
+                        statistics.get(novel.getNovelId()),
                         interestCounts.getOrDefault(novel.getNovelId(), 0L)
                 ))
                 .toList();

--- a/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
@@ -39,7 +39,6 @@ import org.websoso.WSSServer.exception.exception.CustomGenreException;
 import org.websoso.WSSServer.feed.feed.domain.Feed;
 import org.websoso.WSSServer.feed.feed.repository.FeedRepository;
 import org.websoso.WSSServer.library.domain.Keyword;
-import org.websoso.WSSServer.library.domain.UserNovel;
 import org.websoso.WSSServer.library.service.LibraryService;
 import org.websoso.WSSServer.novel.domain.Novel;
 import org.websoso.WSSServer.novel.domain.NovelGenre;
@@ -86,9 +85,7 @@ public class SearchNovelApplication {
 
         Page<Novel> novels = novelService.searchNovels(pageRequest, searchQuery);
 
-        List<NovelSummaryResponse> novelGetResponsePreviews = novels.stream()
-                .map(this::convertToDTO2)
-                .toList();
+        List<NovelSummaryResponse> novelGetResponsePreviews = convertToNovelSummaries(novels.getContent());
 
         // 로그인한 사용자이며, 검색어가 있는 경우에만 검색 기록에 저장한다.
         if (user != null && user.getUserId() != null && !searchQuery.isBlank()) {
@@ -115,9 +112,7 @@ public class SearchNovelApplication {
             novels = novelService.findFilteredNovels(pageRequest, genres, keywords, isCompleted, novelRating, novelRatingEnd, platformNames);
         }
 
-        List<NovelSummaryResponse> novelGetResponsePreviews = novels.stream()
-                .map(this::convertToDTO2)
-                .toList();
+        List<NovelSummaryResponse> novelGetResponsePreviews = convertToNovelSummaries(novels.getContent());
 
         return FilteredNovelsResponse.of(novelGetResponsePreviews, novels.getTotalElements(), novels.hasNext());
     }
@@ -229,31 +224,18 @@ public class SearchNovelApplication {
                 .replaceAll("[^a-zA-Z0-9가-힣]", "");
     }
 
-    private NovelSummaryResponse convertToDTO2(Novel novel) {
-        // TODO: Repository에서 NovelSummaryResponse에 맞게 데이터를 불러오는게 좋을듯
-        List<UserNovel> userNovels = novel.getUserNovels();
+    private List<NovelSummaryResponse> convertToNovelSummaries(List<Novel> novels) {
+        List<Long> novelIds = novels.stream()
+                .map(Novel::getNovelId)
+                .toList();
+        Map<Long, Long> interestCounts = libraryService.getInterestCountsByNovelIds(novelIds);
 
-        long interestCount = userNovels.stream()
-                .filter(UserNovel::getIsInterest)
-                .count();
-        long novelRatingCount = userNovels.stream()
-                .filter(un -> un.getUserNovelRating() != 0.0f)
-                .count();
-        double novelRatingSum = userNovels.stream()
-                .filter(un -> un.getUserNovelRating() != 0.0f)
-                .mapToDouble(UserNovel::getUserNovelRating)
-                .sum();
-
-        float novelRatingAverage = novelRatingCount == 0
-                ? 0.0f
-                : Math.round((float) (novelRatingSum / novelRatingCount) * 10.0f) / 10.0f;
-
-        return NovelSummaryResponse.of(
-                novel,
-                interestCount,
-                novelRatingAverage,
-                novelRatingCount
-        );
+        return novels.stream()
+                .map(novel -> NovelSummaryResponse.of(
+                        novel,
+                        interestCounts.getOrDefault(novel.getNovelId(), 0L)
+                ))
+                .toList();
     }
 
     private String getNovelGenreNames(List<NovelGenre> novelGenres) {

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelSummaryResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelSummaryResponse.java
@@ -11,8 +11,9 @@ public record NovelSummaryResponse(
         float novelRating,
         long novelRatingCount
 ) {
-    public static NovelSummaryResponse of(Novel novel, long interestCount, float novelRating,
-                                             long novelRatingCount) {
+    public static NovelSummaryResponse of(Novel novel, long interestCount) {
+        float novelRating = Math.round(novel.getAverageRating().floatValue() * 10.0f) / 10.0f;
+
         return new NovelSummaryResponse(
                 novel.getNovelId(),
                 novel.getNovelImage(),
@@ -20,7 +21,7 @@ public record NovelSummaryResponse(
                 novel.getAuthor(),
                 interestCount,
                 novelRating,
-                novelRatingCount
+                novel.getRatingCount()
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelSummaryResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelSummaryResponse.java
@@ -12,7 +12,11 @@ public record NovelSummaryResponse(
         float novelRating,
         long novelRatingCount
 ) {
-    public static NovelSummaryResponse of(Novel novel, NovelStatistics statistics, long interestCount) {
+    /**
+     * 작품과 연결된 통계로 검색 결과 요약 응답을 생성한다.
+     */
+    public static NovelSummaryResponse of(Novel novel, long interestCount) {
+        NovelStatistics statistics = novel.getNovelStatistics();
         float novelRating = statistics == null
                 ? 0.0f
                 : Math.round(statistics.getAverageRating().floatValue() * 10.0f) / 10.0f;

--- a/src/main/java/org/websoso/WSSServer/dto/novel/NovelSummaryResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/novel/NovelSummaryResponse.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.dto.novel;
 
 import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.novel.domain.NovelStatistics;
 
 public record NovelSummaryResponse(
         long novelId,
@@ -11,8 +12,13 @@ public record NovelSummaryResponse(
         float novelRating,
         long novelRatingCount
 ) {
-    public static NovelSummaryResponse of(Novel novel, long interestCount) {
-        float novelRating = Math.round(novel.getAverageRating().floatValue() * 10.0f) / 10.0f;
+    public static NovelSummaryResponse of(Novel novel, NovelStatistics statistics, long interestCount) {
+        float novelRating = statistics == null
+                ? 0.0f
+                : Math.round(statistics.getAverageRating().floatValue() * 10.0f) / 10.0f;
+        long novelRatingCount = statistics == null
+                ? 0L
+                : statistics.getRatingCount();
 
         return new NovelSummaryResponse(
                 novel.getNovelId(),
@@ -21,7 +27,7 @@ public record NovelSummaryResponse(
                 novel.getAuthor(),
                 interestCount,
                 novelRating,
-                novel.getRatingCount()
+                novelRatingCount
         );
     }
 }

--- a/src/main/java/org/websoso/WSSServer/library/controller/LibraryController.java
+++ b/src/main/java/org/websoso/WSSServer/library/controller/LibraryController.java
@@ -1,4 +1,4 @@
-package org.websoso.WSSServer.controller;
+package org.websoso.WSSServer.library.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;

--- a/src/main/java/org/websoso/WSSServer/library/domain/UserNovelStatistics.java
+++ b/src/main/java/org/websoso/WSSServer/library/domain/UserNovelStatistics.java
@@ -1,0 +1,27 @@
+package org.websoso.WSSServer.library.domain;
+
+import static org.websoso.WSSServer.domain.common.ReadStatus.QUIT;
+
+import java.math.BigDecimal;
+
+public record UserNovelStatistics(
+        BigDecimal ratingSum,
+        long ratingCount,
+        long popularity
+) {
+
+    public static final UserNovelStatistics EMPTY = new UserNovelStatistics(BigDecimal.ZERO, 0L, 0L);
+
+    public static UserNovelStatistics from(UserNovel userNovel) {
+        float rating = userNovel.getUserNovelRating();
+        boolean hasRating = Float.compare(rating, UserNovel.DEFAULT_RATING) != 0;
+        boolean isPopular = Boolean.TRUE.equals(userNovel.getIsInterest())
+                || (userNovel.getStatus() != null && userNovel.getStatus() != QUIT);
+
+        return new UserNovelStatistics(
+                hasRating ? new BigDecimal(Float.toString(rating)) : BigDecimal.ZERO,
+                hasRating ? 1L : 0L,
+                isPopular ? 1L : 0L
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/library/repository/UserNovelCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/library/repository/UserNovelCustomRepository.java
@@ -2,15 +2,22 @@ package org.websoso.WSSServer.library.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.websoso.WSSServer.domain.Genre;
 import org.websoso.WSSServer.domain.common.UserNovelSortType;
 import org.websoso.WSSServer.library.repository.cursor.UserNovelCursor;
+import org.websoso.WSSServer.library.repository.projection.NovelInterestCount;
 import org.websoso.WSSServer.novel.domain.Novel;
 import org.websoso.WSSServer.library.domain.UserNovel;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
+import org.websoso.WSSServer.user.domain.User;
 
 public interface UserNovelCustomRepository {
+
+    Optional<UserNovel> findByNovelIdAndUserForUpdate(Long novelId, User user);
+
+    List<NovelInterestCount> findInterestCountsByNovelIds(List<Long> novelIds);
 
     UserNovelCountGetResponse findUserNovelStatistics(Long userId);
 

--- a/src/main/java/org/websoso/WSSServer/library/repository/UserNovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/library/repository/UserNovelCustomRepositoryImpl.java
@@ -13,6 +13,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,7 +28,9 @@ import org.websoso.WSSServer.domain.common.ReadStatus;
 import org.websoso.WSSServer.domain.common.UserNovelSortType;
 import org.websoso.WSSServer.dto.user.UserNovelCountGetResponse;
 import org.websoso.WSSServer.library.repository.cursor.UserNovelCursor;
+import org.websoso.WSSServer.library.repository.projection.NovelInterestCount;
 import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.user.domain.User;
 
 @Repository
 @RequiredArgsConstructor
@@ -35,6 +38,35 @@ public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository 
 
     private static final long NO_CURSOR = 0L;
     private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<UserNovel> findByNovelIdAndUserForUpdate(Long novelId, User user) {
+        return Optional.ofNullable(jpaQueryFactory
+                .selectFrom(userNovel)
+                .where(
+                        userNovel.novel.novelId.eq(novelId),
+                        userNovel.user.eq(user)
+                )
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .fetchOne());
+    }
+
+    @Override
+    public List<NovelInterestCount> findInterestCountsByNovelIds(List<Long> novelIds) {
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        NovelInterestCount.class,
+                        userNovel.novel.novelId,
+                        userNovel.count()
+                ))
+                .from(userNovel)
+                .where(
+                        userNovel.novel.novelId.in(novelIds),
+                        userNovel.isInterest.isTrue()
+                )
+                .groupBy(userNovel.novel.novelId)
+                .fetch();
+    }
 
     @Override
     public UserNovelCountGetResponse findUserNovelStatistics(Long userId) {

--- a/src/main/java/org/websoso/WSSServer/library/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/library/repository/UserNovelRepository.java
@@ -1,11 +1,12 @@
 package org.websoso.WSSServer.library.repository;
 
-import io.lettuce.core.dynamic.annotation.Param;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.websoso.WSSServer.novel.domain.Novel;
 import org.websoso.WSSServer.user.domain.User;
@@ -32,9 +33,9 @@ public interface UserNovelRepository extends JpaRepository<UserNovel, Long>, Use
 
     Optional<UserNovel> findByNovel_NovelIdAndUser(Long novelId, User user);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query(value = """
-        INSERT INTO user_novel (
+        INSERT IGNORE INTO user_novel (
             user_id, novel_id, is_interest, 
             user_novel_rating, status, 
             created_date, modified_date
@@ -44,15 +45,36 @@ public interface UserNovelRepository extends JpaRepository<UserNovel, Long>, Use
             :#{#defaultStatus?.name()},
             NOW(), NOW()
         )
-        ON DUPLICATE KEY UPDATE
-            is_interest = true,
-            modified_date = NOW()
         """, nativeQuery = true)
-    void upsertInterest(
+    int insertInterestIfAbsent(
             @Param("userId") Long userId,
             @Param("novelId") Long novelId,
             @Param("defaultRating") Float defaultRating,
             @Param("defaultStatus") ReadStatus defaultStatus
+    );
+
+    @Modifying
+    @Query(value = """
+        UPDATE novel n
+        SET
+            n.average_rating = CASE
+                WHEN n.rating_count + :ratingCountDelta = 0 THEN 0
+                ELSE CAST(ROUND(
+                    (n.rating_sum + :ratingSumDelta)
+                    / (n.rating_count + :ratingCountDelta),
+                    3
+                ) AS DECIMAL(4, 3))
+            END,
+            n.rating_sum = n.rating_sum + :ratingSumDelta,
+            n.rating_count = n.rating_count + :ratingCountDelta,
+            n.popularity = n.popularity + :popularityDelta
+        WHERE n.novel_id = :novelId
+        """, nativeQuery = true)
+    void updateNovelStatisticsByDelta(
+            @Param("novelId") Long novelId,
+            @Param("ratingSumDelta") BigDecimal ratingSumDelta,
+            @Param("ratingCountDelta") Long ratingCountDelta,
+            @Param("popularityDelta") Long popularityDelta
     );
 
 }

--- a/src/main/java/org/websoso/WSSServer/library/repository/UserNovelRepository.java
+++ b/src/main/java/org/websoso/WSSServer/library/repository/UserNovelRepository.java
@@ -1,6 +1,5 @@
 package org.websoso.WSSServer.library.repository;
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -40,41 +39,17 @@ public interface UserNovelRepository extends JpaRepository<UserNovel, Long>, Use
             user_novel_rating, status, 
             created_date, modified_date
         ) VALUES (
-            :userId, :novelId, true, 
+            :userId, :novelId, false,
             :defaultRating, 
             :#{#defaultStatus?.name()},
             NOW(), NOW()
         )
         """, nativeQuery = true)
-    int insertInterestIfAbsent(
+    int insertLibraryIfAbsent(
             @Param("userId") Long userId,
             @Param("novelId") Long novelId,
             @Param("defaultRating") Float defaultRating,
             @Param("defaultStatus") ReadStatus defaultStatus
-    );
-
-    @Modifying
-    @Query(value = """
-        UPDATE novel n
-        SET
-            n.average_rating = CASE
-                WHEN n.rating_count + :ratingCountDelta = 0 THEN 0
-                ELSE CAST(ROUND(
-                    (n.rating_sum + :ratingSumDelta)
-                    / (n.rating_count + :ratingCountDelta),
-                    3
-                ) AS DECIMAL(4, 3))
-            END,
-            n.rating_sum = n.rating_sum + :ratingSumDelta,
-            n.rating_count = n.rating_count + :ratingCountDelta,
-            n.popularity = n.popularity + :popularityDelta
-        WHERE n.novel_id = :novelId
-        """, nativeQuery = true)
-    void updateNovelStatisticsByDelta(
-            @Param("novelId") Long novelId,
-            @Param("ratingSumDelta") BigDecimal ratingSumDelta,
-            @Param("ratingCountDelta") Long ratingCountDelta,
-            @Param("popularityDelta") Long popularityDelta
     );
 
 }

--- a/src/main/java/org/websoso/WSSServer/library/repository/projection/NovelInterestCount.java
+++ b/src/main/java/org/websoso/WSSServer/library/repository/projection/NovelInterestCount.java
@@ -1,0 +1,7 @@
+package org.websoso.WSSServer.library.repository.projection;
+
+public record NovelInterestCount(
+        Long novelId,
+        Long interestCount
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/library/service/LibraryService.java
+++ b/src/main/java/org/websoso/WSSServer/library/service/LibraryService.java
@@ -5,8 +5,11 @@ import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHED;
 import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHING;
 import static org.websoso.WSSServer.exception.error.CustomUserNovelError.USER_NOVEL_NOT_FOUND;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -16,7 +19,9 @@ import org.websoso.WSSServer.user.domain.User;
 import org.websoso.WSSServer.domain.common.ReadStatus;
 import org.websoso.WSSServer.exception.exception.CustomUserNovelException;
 import org.websoso.WSSServer.library.domain.UserNovel;
+import org.websoso.WSSServer.library.domain.UserNovelStatistics;
 import org.websoso.WSSServer.library.repository.UserNovelRepository;
+import org.websoso.WSSServer.library.repository.projection.NovelInterestCount;
 import org.websoso.WSSServer.novel.domain.Novel;
 
 @Service
@@ -26,9 +31,9 @@ public class LibraryService {
     private final UserNovelRepository userNovelRepository;
 
     // TODO: novelId로 불러옴
-    @Transactional(readOnly = true)
-    public UserNovel getLibraryOrException(User user, Long novelId) {
-        return userNovelRepository.findByNovel_NovelIdAndUser(novelId, user)
+    @Transactional
+    public UserNovel getLibraryForUpdateOrException(User user, Long novelId) {
+        return userNovelRepository.findByNovelIdAndUserForUpdate(novelId, user)
                 .orElseThrow(() -> new CustomUserNovelException(USER_NOVEL_NOT_FOUND,
                         "user novel with the given user and novel is not found"));
     }
@@ -56,13 +61,15 @@ public class LibraryService {
     @Transactional
     public UserNovel createLibrary(ReadStatus status, Float userNovelRating, LocalDate startDate, LocalDate endDate,
                                    User user, Novel novel) {
-        return userNovelRepository.save(UserNovel.create(
+        UserNovel userNovel = userNovelRepository.save(UserNovel.create(
                 status,
                 userNovelRating,
                 startDate,
                 endDate,
                 user,
                 novel));
+        updateNovelStatistics(UserNovelStatistics.EMPTY, UserNovelStatistics.from(userNovel), novel);
+        return userNovel;
     }
 
     /**
@@ -74,36 +81,112 @@ public class LibraryService {
      */
     @Transactional
     public void registerInterest(User user, Novel novel) {
-        userNovelRepository.upsertInterest(
+        int insertedCount = userNovelRepository.insertInterestIfAbsent(
                 user.getUserId(),
                 novel.getNovelId(),
                 UserNovel.DEFAULT_RATING,
                 UserNovel.DEFAULT_STATUS
         );
+
+        UserNovel library = userNovelRepository.findByNovelIdAndUserForUpdate(novel.getNovelId(), user)
+                .orElseThrow(() -> new IllegalStateException("inserted user novel could not be found"));
+
+        UserNovelStatistics before = insertedCount == 1
+                ? UserNovelStatistics.EMPTY
+                : UserNovelStatistics.from(library);
+
+        library.markAsInterested();
+        updateNovelStatistics(before, UserNovelStatistics.from(library), novel);
     }
 
     /**
      * <p>관심있어요를 해제한다.</p>
      * 만약, 서재 정보가 없다면 삭제한다.
      *
-     * @param library 서재 Entity
+     * @param user    사용자 Entity
+     * @param novelId 소설 ID
      */
     @Transactional
-    public void unregisterInterest(UserNovel library) {
+    public void unregisterInterest(User user, Long novelId) {
+        UserNovel library = userNovelRepository.findByNovelIdAndUserForUpdate(novelId, user).orElse(null);
+
+        if (library == null) {
+            return;
+        }
+
         if (Boolean.FALSE.equals(library.getIsInterest())) {
             return;
         }
 
+        UserNovelStatistics before = UserNovelStatistics.from(library);
         library.unmarkAsInterested();
 
         if (library.isSafeToDelete()) {
             userNovelRepository.delete(library);
+            updateNovelStatistics(before, UserNovelStatistics.EMPTY, library.getNovel());
+            return;
         }
+
+        updateNovelStatistics(before, UserNovelStatistics.from(library), library.getNovel());
+    }
+
+    @Transactional
+    public void updateEvaluation(UserNovel library, Float userNovelRating, ReadStatus status, LocalDate startDate,
+                                 LocalDate endDate) {
+        UserNovelStatistics before = UserNovelStatistics.from(library);
+        library.updateUserNovel(userNovelRating, status, startDate, endDate);
+        updateNovelStatistics(before, UserNovelStatistics.from(library), library.getNovel());
+    }
+
+    @Transactional
+    public void deleteEvaluation(UserNovel library) {
+        UserNovelStatistics before = UserNovelStatistics.from(library);
+        library.deleteEvaluation();
+        updateNovelStatistics(before, UserNovelStatistics.from(library), library.getNovel());
     }
 
     @Transactional
     public void delete(UserNovel library) {
+        UserNovelStatistics before = UserNovelStatistics.from(library);
         userNovelRepository.delete(library);
+        updateNovelStatistics(before, UserNovelStatistics.EMPTY, library.getNovel());
+    }
+
+    /**
+     * UserNovel 변경 전후의 통계 기여분 차이를 계산해 작품의 역정규화 통계를 원자적으로 갱신한다.
+     * 평점 합, 평점 수, 인기도에 변화가 없으면 UPDATE 쿼리를 실행하지 않는다.
+     */
+    private void updateNovelStatistics(UserNovelStatistics before, UserNovelStatistics after, Novel novel) {
+        BigDecimal ratingSumDelta = after.ratingSum().subtract(before.ratingSum());
+        long ratingCountDelta = after.ratingCount() - before.ratingCount();
+        long popularityDelta = after.popularity() - before.popularity();
+
+        if (ratingSumDelta.signum() == 0
+                && ratingCountDelta == 0
+                && popularityDelta == 0) {
+            return;
+        }
+
+        userNovelRepository.flush();
+        userNovelRepository.updateNovelStatisticsByDelta(
+                novel.getNovelId(),
+                ratingSumDelta,
+                ratingCountDelta,
+                popularityDelta
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, Long> getInterestCountsByNovelIds(List<Long> novelIds) {
+        if (novelIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return userNovelRepository.findInterestCountsByNovelIds(novelIds).stream()
+                .collect(Collectors.toMap(
+                        NovelInterestCount::novelId,
+                        NovelInterestCount::interestCount
+                ));
     }
 
     public int getRatingCount(Novel novel) {
@@ -146,4 +229,5 @@ public class LibraryService {
     public List<Long> getTodayPopularNovelIds(PageRequest pageRequest) {
         return userNovelRepository.findTodayPopularNovelsId(pageRequest);
     }
+
 }

--- a/src/main/java/org/websoso/WSSServer/library/service/LibraryService.java
+++ b/src/main/java/org/websoso/WSSServer/library/service/LibraryService.java
@@ -5,7 +5,6 @@ import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHED;
 import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHING;
 import static org.websoso.WSSServer.exception.error.CustomUserNovelError.USER_NOVEL_NOT_FOUND;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -19,7 +18,6 @@ import org.websoso.WSSServer.user.domain.User;
 import org.websoso.WSSServer.domain.common.ReadStatus;
 import org.websoso.WSSServer.exception.exception.CustomUserNovelException;
 import org.websoso.WSSServer.library.domain.UserNovel;
-import org.websoso.WSSServer.library.domain.UserNovelStatistics;
 import org.websoso.WSSServer.library.repository.UserNovelRepository;
 import org.websoso.WSSServer.library.repository.projection.NovelInterestCount;
 import org.websoso.WSSServer.novel.domain.Novel;
@@ -61,119 +59,61 @@ public class LibraryService {
     @Transactional
     public UserNovel createLibrary(ReadStatus status, Float userNovelRating, LocalDate startDate, LocalDate endDate,
                                    User user, Novel novel) {
-        UserNovel userNovel = userNovelRepository.save(UserNovel.create(
+        return userNovelRepository.saveAndFlush(UserNovel.create(
                 status,
                 userNovelRating,
                 startDate,
                 endDate,
                 user,
                 novel));
-        updateNovelStatistics(UserNovelStatistics.EMPTY, UserNovelStatistics.from(userNovel), novel);
-        return userNovel;
     }
 
-    /**
-     * <p>관심있어요를 등록한다.</p>
-     * 서재 내역이 없다면, 서재 내역을 생성하면서 등록한다.
-     *
-     * @param user  사용자 Entity
-     * @param novel 서재 Entity
-     */
     @Transactional
-    public void registerInterest(User user, Novel novel) {
-        int insertedCount = userNovelRepository.insertInterestIfAbsent(
+    public UserNovel getOrCreateLibraryForInterest(User user, Novel novel) {
+        userNovelRepository.insertLibraryIfAbsent(
                 user.getUserId(),
                 novel.getNovelId(),
                 UserNovel.DEFAULT_RATING,
                 UserNovel.DEFAULT_STATUS
         );
 
-        UserNovel library = userNovelRepository.findByNovelIdAndUserForUpdate(novel.getNovelId(), user)
+        return userNovelRepository.findByNovelIdAndUserForUpdate(novel.getNovelId(), user)
                 .orElseThrow(() -> new IllegalStateException("inserted user novel could not be found"));
-
-        UserNovelStatistics before = insertedCount == 1
-                ? UserNovelStatistics.EMPTY
-                : UserNovelStatistics.from(library);
-
-        library.markAsInterested();
-        updateNovelStatistics(before, UserNovelStatistics.from(library), novel);
     }
 
-    /**
-     * <p>관심있어요를 해제한다.</p>
-     * 만약, 서재 정보가 없다면 삭제한다.
-     *
-     * @param user    사용자 Entity
-     * @param novelId 소설 ID
-     */
     @Transactional
-    public void unregisterInterest(User user, Long novelId) {
-        UserNovel library = userNovelRepository.findByNovelIdAndUserForUpdate(novelId, user).orElse(null);
+    public void registerInterest(UserNovel library) {
+        library.markAsInterested();
+    }
 
-        if (library == null) {
-            return;
-        }
+    @Transactional
+    public UserNovel getLibraryForUpdateOrNull(User user, Long novelId) {
+        return userNovelRepository.findByNovelIdAndUserForUpdate(novelId, user).orElse(null);
+    }
 
-        if (Boolean.FALSE.equals(library.getIsInterest())) {
-            return;
-        }
-
-        UserNovelStatistics before = UserNovelStatistics.from(library);
+    @Transactional
+    public void unregisterInterest(UserNovel library) {
         library.unmarkAsInterested();
 
         if (library.isSafeToDelete()) {
             userNovelRepository.delete(library);
-            updateNovelStatistics(before, UserNovelStatistics.EMPTY, library.getNovel());
-            return;
         }
-
-        updateNovelStatistics(before, UserNovelStatistics.from(library), library.getNovel());
     }
 
     @Transactional
     public void updateEvaluation(UserNovel library, Float userNovelRating, ReadStatus status, LocalDate startDate,
                                  LocalDate endDate) {
-        UserNovelStatistics before = UserNovelStatistics.from(library);
         library.updateUserNovel(userNovelRating, status, startDate, endDate);
-        updateNovelStatistics(before, UserNovelStatistics.from(library), library.getNovel());
     }
 
     @Transactional
     public void deleteEvaluation(UserNovel library) {
-        UserNovelStatistics before = UserNovelStatistics.from(library);
         library.deleteEvaluation();
-        updateNovelStatistics(before, UserNovelStatistics.from(library), library.getNovel());
     }
 
     @Transactional
     public void delete(UserNovel library) {
-        UserNovelStatistics before = UserNovelStatistics.from(library);
         userNovelRepository.delete(library);
-        updateNovelStatistics(before, UserNovelStatistics.EMPTY, library.getNovel());
-    }
-
-    /**
-     * UserNovel 변경 전후의 통계 기여분 차이를 계산해 작품의 역정규화 통계를 원자적으로 갱신한다.
-     * 평점 합, 평점 수, 인기도에 변화가 없으면 UPDATE 쿼리를 실행하지 않는다.
-     */
-    private void updateNovelStatistics(UserNovelStatistics before, UserNovelStatistics after, Novel novel) {
-        BigDecimal ratingSumDelta = after.ratingSum().subtract(before.ratingSum());
-        long ratingCountDelta = after.ratingCount() - before.ratingCount();
-        long popularityDelta = after.popularity() - before.popularity();
-
-        if (ratingSumDelta.signum() == 0
-                && ratingCountDelta == 0
-                && popularityDelta == 0) {
-            return;
-        }
-
-        userNovelRepository.flush();
-        userNovelRepository.updateNovelStatisticsByDelta(
-                novel.getNovelId(),
-                ratingSumDelta,
-                ratingCountDelta,
-                popularityDelta
-        );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -15,6 +16,7 @@ import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
 import org.websoso.WSSServer.library.domain.UserNovel;
 
 @Entity
@@ -40,6 +42,22 @@ public class Novel {
 
     @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isCompleted;
+
+    @Column(nullable = false, columnDefinition = "decimal(4, 3) default 0.000")
+    @Comment("작품 평균 평점")
+    private BigDecimal averageRating = BigDecimal.ZERO;
+
+    @Column(nullable = false, columnDefinition = "decimal(19, 1) default 0.0")
+    @Comment("작품 평점 합계")
+    private BigDecimal ratingSum = BigDecimal.ZERO;
+
+    @Column(nullable = false, columnDefinition = "bigint default 0")
+    @Comment("작품 평점 등록 수")
+    private Long ratingCount = 0L;
+
+    @Column(nullable = false, columnDefinition = "bigint default 0")
+    @Comment("관심 등록 또는 하차 외 독서 상태인 사용자 수")
+    private Long popularity = 0L;
 
     @OneToMany(mappedBy = "novel", fetch = FetchType.LAZY)
     private List<UserNovel> userNovels = new ArrayList<>();

--- a/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
@@ -8,6 +8,8 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -40,6 +42,10 @@ public class Novel {
 
     @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isCompleted;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @PrimaryKeyJoinColumn(name = "novel_id", referencedColumnName = "novel_id")
+    private NovelStatistics novelStatistics;
 
     @OneToMany(mappedBy = "novel", fetch = FetchType.LAZY)
     private List<UserNovel> userNovels = new ArrayList<>();

--- a/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
@@ -8,7 +8,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -16,7 +15,6 @@ import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Comment;
 import org.websoso.WSSServer.library.domain.UserNovel;
 
 @Entity
@@ -42,22 +40,6 @@ public class Novel {
 
     @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isCompleted;
-
-    @Column(nullable = false, columnDefinition = "decimal(4, 3) default 0.000")
-    @Comment("작품 평균 평점")
-    private BigDecimal averageRating = BigDecimal.ZERO;
-
-    @Column(nullable = false, columnDefinition = "decimal(19, 1) default 0.0")
-    @Comment("작품 평점 합계")
-    private BigDecimal ratingSum = BigDecimal.ZERO;
-
-    @Column(nullable = false, columnDefinition = "bigint default 0")
-    @Comment("작품 평점 등록 수")
-    private Long ratingCount = 0L;
-
-    @Column(nullable = false, columnDefinition = "bigint default 0")
-    @Comment("관심 등록 또는 하차 외 독서 상태인 사용자 수")
-    private Long popularity = 0L;
 
     @OneToMany(mappedBy = "novel", fetch = FetchType.LAZY)
     private List<UserNovel> userNovels = new ArrayList<>();

--- a/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
+++ b/src/main/java/org/websoso/WSSServer/novel/domain/Novel.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
-import jakarta.persistence.PrimaryKeyJoinColumn;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -43,8 +42,7 @@ public class Novel {
     @Column(columnDefinition = "Boolean default false", nullable = false)
     private Boolean isCompleted;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @PrimaryKeyJoinColumn(name = "novel_id", referencedColumnName = "novel_id")
+    @OneToOne(mappedBy = "novel", fetch = FetchType.LAZY)
     private NovelStatistics novelStatistics;
 
     @OneToMany(mappedBy = "novel", fetch = FetchType.LAZY)

--- a/src/main/java/org/websoso/WSSServer/novel/domain/NovelStatistics.java
+++ b/src/main/java/org/websoso/WSSServer/novel/domain/NovelStatistics.java
@@ -3,7 +3,11 @@ package org.websoso.WSSServer.novel.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
+import jakarta.persistence.OneToOne;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -19,6 +23,11 @@ public class NovelStatistics {
     @Id
     @Column(name = "novel_id")
     private Long novelId;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "novel_id", referencedColumnName = "novel_id")
+    private Novel novel;
 
     @Column(nullable = false, precision = 4, scale = 3)
     @Comment("작품 평균 평점")

--- a/src/main/java/org/websoso/WSSServer/novel/domain/NovelStatistics.java
+++ b/src/main/java/org/websoso/WSSServer/novel/domain/NovelStatistics.java
@@ -1,0 +1,47 @@
+package org.websoso.WSSServer.novel.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Table(name = "novel_statistics")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NovelStatistics {
+
+    @Id
+    @Column(name = "novel_id")
+    private Long novelId;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "novel_id", nullable = false)
+    private Novel novel;
+
+    @Column(nullable = false, precision = 4, scale = 3)
+    @Comment("작품 평균 평점")
+    private BigDecimal averageRating = BigDecimal.ZERO;
+
+    @Column(nullable = false, precision = 19, scale = 1)
+    @Comment("작품 평점 합계")
+    private BigDecimal ratingSum = BigDecimal.ZERO;
+
+    @Column(nullable = false)
+    @Comment("작품 평점 등록 수")
+    private Long ratingCount = 0L;
+
+    @Column(nullable = false)
+    @Comment("관심 등록 또는 하차 외 독서 상태인 사용자 수")
+    private Long popularity = 0L;
+}

--- a/src/main/java/org/websoso/WSSServer/novel/domain/NovelStatistics.java
+++ b/src/main/java/org/websoso/WSSServer/novel/domain/NovelStatistics.java
@@ -2,11 +2,7 @@ package org.websoso.WSSServer.novel.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
@@ -23,11 +19,6 @@ public class NovelStatistics {
     @Id
     @Column(name = "novel_id")
     private Long novelId;
-
-    @MapsId
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "novel_id", nullable = false)
-    private Novel novel;
 
     @Column(nullable = false, precision = 4, scale = 3)
     @Comment("작품 평균 평점")

--- a/src/main/java/org/websoso/WSSServer/novel/domain/NovelStatisticsContribution.java
+++ b/src/main/java/org/websoso/WSSServer/novel/domain/NovelStatisticsContribution.java
@@ -1,24 +1,26 @@
-package org.websoso.WSSServer.library.domain;
+package org.websoso.WSSServer.novel.domain;
 
 import static org.websoso.WSSServer.domain.common.ReadStatus.QUIT;
 
 import java.math.BigDecimal;
+import org.websoso.WSSServer.library.domain.UserNovel;
 
-public record UserNovelStatistics(
+public record NovelStatisticsContribution(
         BigDecimal ratingSum,
         long ratingCount,
         long popularity
 ) {
 
-    public static final UserNovelStatistics EMPTY = new UserNovelStatistics(BigDecimal.ZERO, 0L, 0L);
+    public static final NovelStatisticsContribution EMPTY =
+            new NovelStatisticsContribution(BigDecimal.ZERO, 0L, 0L);
 
-    public static UserNovelStatistics from(UserNovel userNovel) {
+    public static NovelStatisticsContribution from(UserNovel userNovel) {
         float rating = userNovel.getUserNovelRating();
         boolean hasRating = Float.compare(rating, UserNovel.DEFAULT_RATING) != 0;
         boolean isPopular = Boolean.TRUE.equals(userNovel.getIsInterest())
                 || (userNovel.getStatus() != null && userNovel.getStatus() != QUIT);
 
-        return new UserNovelStatistics(
+        return new NovelStatisticsContribution(
                 hasRating ? new BigDecimal(Float.toString(rating)) : BigDecimal.ZERO,
                 hasRating ? 1L : 0L,
                 isPopular ? 1L : 0L

--- a/src/main/java/org/websoso/WSSServer/novel/job/NovelStatisticsCorrectionJob.java
+++ b/src/main/java/org/websoso/WSSServer/novel/job/NovelStatisticsCorrectionJob.java
@@ -1,0 +1,21 @@
+package org.websoso.WSSServer.novel.job;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.websoso.WSSServer.novel.service.NovelStatisticsService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NovelStatisticsCorrectionJob {
+
+    private final NovelStatisticsService novelStatisticsService;
+
+    @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
+    public void correct() {
+        int affectedRows = novelStatisticsService.correctAll();
+        log.info("novel statistics correction done. affectedRows={}", affectedRows);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
@@ -1,16 +1,13 @@
 package org.websoso.WSSServer.novel.repository;
 
 import static org.websoso.WSSServer.domain.QGenre.genre;
-import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHED;
-import static org.websoso.WSSServer.domain.common.ReadStatus.WATCHING;
-import static org.websoso.WSSServer.library.domain.QUserNovel.userNovel;
 import static org.websoso.WSSServer.novel.domain.QNovel.novel;
 import static org.websoso.WSSServer.novel.domain.QNovelGenre.novelGenre;
 import static org.websoso.WSSServer.novel.domain.QNovelPlatform.novelPlatform;
+import static org.websoso.WSSServer.novel.domain.QNovelStatistics.novelStatistics;
 import static org.websoso.WSSServer.novel.domain.QPlatform.platform;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.StringPath;
@@ -43,18 +40,16 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 
         List<Novel> novelsByTitle = jpaQueryFactory
                 .selectFrom(novel)
-                .leftJoin(novel.userNovels, userNovel)
+                .leftJoin(novelStatistics).on(novelStatistics.novelId.eq(novel.novelId))
                 .where(titleContainsQuery(searchQuery))
-                .groupBy(novel.novelId)
-                .orderBy(getPopularity(novel).desc())
+                .orderBy(novelStatistics.popularity.desc(), novel.novelId.asc())
                 .fetch();
 
         List<Novel> novelsByAuthor = jpaQueryFactory
                 .selectFrom(novel)
-                .leftJoin(novel.userNovels, userNovel)
+                .leftJoin(novelStatistics).on(novelStatistics.novelId.eq(novel.novelId))
                 .where(authorContainsQuery.and(titleContainsQuery(searchQuery).not()))
-                .groupBy(novel.novelId)
-                .orderBy(getPopularity(novel).desc())
+                .orderBy(novelStatistics.popularity.desc(), novel.novelId.asc())
                 .fetch();
 
         List<Novel> result = Stream
@@ -80,7 +75,8 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
                                           Float novelRatingEnd, List<Keyword> keywords, List<String> platformNames) {
 
         JPAQuery<Novel> query = jpaQueryFactory
-                .selectFrom(novel);
+                .selectFrom(novel)
+                .leftJoin(novelStatistics).on(novelStatistics.novelId.eq(novel.novelId));
 
         boolean hasGenreFilter = genres != null && !genres.isEmpty();
         boolean hasPlatformFilter = platformNames != null && !platformNames.isEmpty();
@@ -115,7 +111,7 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
                                 : null
 
                 )
-                .orderBy(novel.popularity.desc());
+                .orderBy(novelStatistics.popularity.desc(), novel.novelId.asc());
 
         return applyPagination(pageable, query);
     }
@@ -124,10 +120,9 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
     public List<Novel> findAutocompleteNovels(String searchQuery, int limitSize) {
         return jpaQueryFactory
                 .selectFrom(novel)
-                .leftJoin(novel.userNovels, userNovel)
+                .leftJoin(novelStatistics).on(novelStatistics.novelId.eq(novel.novelId))
                 .where(titleContainsQuery(searchQuery))
-                .groupBy(novel.novelId)
-                .orderBy(getPopularity(novel).desc())
+                .orderBy(novelStatistics.popularity.desc(), novel.novelId.asc())
                 .limit(limitSize)
                 .fetch();
     }
@@ -158,7 +153,7 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
             return null;
         }
 
-        return novel.averageRating.between(
+        return novelStatistics.averageRating.coalesce(BigDecimal.ZERO).between(
                 new BigDecimal(Float.toString(novelRatingStart)),
                 new BigDecimal(Float.toString(novelRatingEnd))
         );
@@ -168,15 +163,6 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
         return Expressions.numberTemplate(Integer.class,
                 "(SELECT COUNT(unk.keyword) FROM UserNovelKeyword unk WHERE unk.userNovel.novel = {0} AND unk.keyword IN ({1}) GROUP BY unk.userNovel.novel.id)",
                 novel, keywords);
-    }
-
-    private NumberExpression<Long> getPopularity(QNovel novel) {
-        return new CaseBuilder()
-                .when(userNovel.isInterest.isTrue()
-                        .or(userNovel.status.in(WATCHING, WATCHED)))
-                .then(1L)
-                .otherwise(0L)
-                .sum();
     }
 
     private Page<Novel> applyPagination(Pageable pageable, JPAQuery<Novel> query) {

--- a/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
@@ -13,11 +13,11 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
-import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -79,33 +79,43 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
     public Page<Novel> findFilteredNovels(Pageable pageable, List<Genre> genres, Boolean isCompleted, Float novelRatingStart,
                                           Float novelRatingEnd, List<Keyword> keywords, List<String> platformNames) {
 
-        NumberTemplate<Long> popularity = Expressions.numberTemplate(Long.class,
-                "(SELECT COUNT(un) FROM UserNovel un WHERE un.novel = {0} AND (un.isInterest = true OR un.status <> 'QUIT'))",
-                novel);
-
         JPAQuery<Novel> query = jpaQueryFactory
-                .selectFrom(novel)
-                .distinct()
-                .join(novel.novelGenres, novelGenre)
-                .leftJoin(novel.novelPlatforms, novelPlatform)
-                .leftJoin(novelPlatform.platform, platform)
+                .selectFrom(novel);
+
+        boolean hasGenreFilter = genres != null && !genres.isEmpty();
+        boolean hasPlatformFilter = platformNames != null && !platformNames.isEmpty();
+
+        if (hasGenreFilter) {
+            query.join(novel.novelGenres, novelGenre);
+        }
+
+        if (hasPlatformFilter) {
+            query.join(novel.novelPlatforms, novelPlatform)
+                    .join(novelPlatform.platform, platform);
+        }
+
+        if (hasGenreFilter || hasPlatformFilter) {
+            query.distinct();
+        }
+
+        query
                 .where(
-                        genres.isEmpty()
-                                ? null
-                                : novelGenre.genre.in(genres),
+                        hasGenreFilter
+                                ? novelGenre.genre.in(genres)
+                                : null,
                         isCompleted == null
                                 ? null
                                 : novel.isCompleted.eq(isCompleted),
-                        getAverageRatingCondition(novel, novelRatingStart, novelRatingEnd),
+                        getAverageRatingCondition(novelRatingStart, novelRatingEnd),
                         keywords.isEmpty()
                                 ? null
                                 : getKeywordCount(novel, keywords).eq(keywords.size()),
-                        platformNames == null || platformNames.isEmpty()
-                                ? null
-                                : platform.platformName.in(platformNames)
+                        hasPlatformFilter
+                                ? platform.platformName.in(platformNames)
+                                : null
 
                 )
-                .orderBy(popularity.desc());
+                .orderBy(novel.popularity.desc());
 
         return applyPagination(pageable, query);
     }
@@ -138,25 +148,20 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
     }
 
 
-    private NumberExpression<Double> getAverageRating(QNovel novel) {
-        return Expressions.numberTemplate(Double.class,
-                "(SELECT AVG(un.userNovelRating) FROM UserNovel un WHERE un.novel = {0} AND un.userNovelRating <> 0)",
-                novel);
-    }
-
-    private BooleanExpression getAverageRatingCondition(QNovel novel, Float novelRatingStart, Float novelRatingEnd) {
-        if (novelRatingStart == null) {
+    private BooleanExpression getAverageRatingCondition(Float novelRatingStart, Float novelRatingEnd) {
+        if (novelRatingStart == null || novelRatingEnd == null) {
             return null;
         }
 
-        NumberExpression<Double> averageRating = getAverageRating(novel);
-        BooleanExpression averageRatingBetween = averageRating.between(novelRatingStart, novelRatingEnd);
-
-        if (Float.compare(novelRatingStart, 0.0f) == 0) {
-            return averageRating.isNull().or(averageRatingBetween);
+        if (Float.compare(novelRatingStart, 0.0f) == 0
+                && Float.compare(novelRatingEnd, 5.0f) == 0) {
+            return null;
         }
 
-        return averageRatingBetween;
+        return novel.averageRating.between(
+                new BigDecimal(Float.toString(novelRatingStart)),
+                new BigDecimal(Float.toString(novelRatingEnd))
+        );
     }
 
     private NumberExpression<Integer> getKeywordCount(QNovel novel, List<Keyword> keywords) {

--- a/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/novel/repository/NovelCustomRepositoryImpl.java
@@ -40,14 +40,14 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 
         List<Novel> novelsByTitle = jpaQueryFactory
                 .selectFrom(novel)
-                .leftJoin(novelStatistics).on(novelStatistics.novelId.eq(novel.novelId))
+                .leftJoin(novel.novelStatistics, novelStatistics).fetchJoin()
                 .where(titleContainsQuery(searchQuery))
                 .orderBy(novelStatistics.popularity.desc(), novel.novelId.asc())
                 .fetch();
 
         List<Novel> novelsByAuthor = jpaQueryFactory
                 .selectFrom(novel)
-                .leftJoin(novelStatistics).on(novelStatistics.novelId.eq(novel.novelId))
+                .leftJoin(novel.novelStatistics, novelStatistics).fetchJoin()
                 .where(authorContainsQuery.and(titleContainsQuery(searchQuery).not()))
                 .orderBy(novelStatistics.popularity.desc(), novel.novelId.asc())
                 .fetch();
@@ -76,7 +76,7 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
 
         JPAQuery<Novel> query = jpaQueryFactory
                 .selectFrom(novel)
-                .leftJoin(novelStatistics).on(novelStatistics.novelId.eq(novel.novelId));
+                .leftJoin(novel.novelStatistics, novelStatistics).fetchJoin();
 
         boolean hasGenreFilter = genres != null && !genres.isEmpty();
         boolean hasPlatformFilter = platformNames != null && !platformNames.isEmpty();
@@ -120,7 +120,7 @@ public class NovelCustomRepositoryImpl implements NovelCustomRepository {
     public List<Novel> findAutocompleteNovels(String searchQuery, int limitSize) {
         return jpaQueryFactory
                 .selectFrom(novel)
-                .leftJoin(novelStatistics).on(novelStatistics.novelId.eq(novel.novelId))
+                .leftJoin(novel.novelStatistics, novelStatistics)
                 .where(titleContainsQuery(searchQuery))
                 .orderBy(novelStatistics.popularity.desc(), novel.novelId.asc())
                 .limit(limitSize)

--- a/src/main/java/org/websoso/WSSServer/novel/repository/NovelStatisticsRepository.java
+++ b/src/main/java/org/websoso/WSSServer/novel/repository/NovelStatisticsRepository.java
@@ -1,0 +1,89 @@
+package org.websoso.WSSServer.novel.repository;
+
+import java.math.BigDecimal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.novel.domain.NovelStatistics;
+
+@Repository
+public interface NovelStatisticsRepository extends JpaRepository<NovelStatistics, Long> {
+
+    @Modifying
+    @Query(value = """
+        INSERT IGNORE INTO novel_statistics (
+            novel_id,
+            average_rating,
+            rating_sum,
+            rating_count,
+            popularity
+        ) VALUES (
+            :novelId,
+            0.000,
+            0.0,
+            0,
+            0
+        )
+        """, nativeQuery = true)
+    int insertIfAbsent(@Param("novelId") Long novelId);
+
+    @Modifying
+    @Query(value = """
+        UPDATE novel_statistics ns
+        SET
+            ns.average_rating = CASE
+                WHEN ns.rating_count + :ratingCountDelta = 0 THEN 0
+                ELSE CAST(ROUND(
+                    (ns.rating_sum + :ratingSumDelta)
+                    / (ns.rating_count + :ratingCountDelta),
+                    3
+                ) AS DECIMAL(4, 3))
+            END,
+            ns.rating_sum = ns.rating_sum + :ratingSumDelta,
+            ns.rating_count = ns.rating_count + :ratingCountDelta,
+            ns.popularity = ns.popularity + :popularityDelta
+        WHERE ns.novel_id = :novelId
+        """, nativeQuery = true)
+    void updateByDelta(
+            @Param("novelId") Long novelId,
+            @Param("ratingSumDelta") BigDecimal ratingSumDelta,
+            @Param("ratingCountDelta") Long ratingCountDelta,
+            @Param("popularityDelta") Long popularityDelta
+    );
+
+    @Modifying
+    @Query(value = """
+        INSERT INTO novel_statistics (
+            novel_id,
+            average_rating,
+            rating_sum,
+            rating_count,
+            popularity
+        )
+        SELECT
+            n.novel_id,
+            CAST(
+                ROUND(COALESCE(AVG(NULLIF(un.user_novel_rating, 0)), 0), 3)
+                AS DECIMAL(4, 3)
+            ),
+            CAST(
+                ROUND(COALESCE(SUM(NULLIF(un.user_novel_rating, 0)), 0), 1)
+                AS DECIMAL(19, 1)
+            ),
+            COUNT(NULLIF(un.user_novel_rating, 0)),
+            COUNT(CASE
+                WHEN un.is_interest = TRUE OR un.status <> 'QUIT' THEN 1
+            END)
+        FROM novel n
+        LEFT JOIN user_novel un ON un.novel_id = n.novel_id
+        GROUP BY n.novel_id
+        ON DUPLICATE KEY UPDATE
+            average_rating = VALUES(average_rating),
+            rating_sum = VALUES(rating_sum),
+            rating_count = VALUES(rating_count),
+            popularity = VALUES(popularity)
+        """, nativeQuery = true)
+    int correctAll();
+}

--- a/src/main/java/org/websoso/WSSServer/novel/service/NovelStatisticsService.java
+++ b/src/main/java/org/websoso/WSSServer/novel/service/NovelStatisticsService.java
@@ -1,14 +1,9 @@
 package org.websoso.WSSServer.novel.service;
 
 import java.math.BigDecimal;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.websoso.WSSServer.novel.domain.NovelStatistics;
 import org.websoso.WSSServer.novel.domain.NovelStatisticsContribution;
 import org.websoso.WSSServer.novel.repository.NovelStatisticsRepository;
 
@@ -17,19 +12,6 @@ import org.websoso.WSSServer.novel.repository.NovelStatisticsRepository;
 public class NovelStatisticsService {
 
     private final NovelStatisticsRepository novelStatisticsRepository;
-
-    @Transactional(readOnly = true)
-    public Map<Long, NovelStatistics> getStatisticsByNovelIds(List<Long> novelIds) {
-        if (novelIds.isEmpty()) {
-            return Map.of();
-        }
-
-        return novelStatisticsRepository.findAllById(novelIds).stream()
-                .collect(Collectors.toMap(
-                        NovelStatistics::getNovelId,
-                        Function.identity()
-                ));
-    }
 
     @Transactional
     public void updateByDelta(Long novelId, NovelStatisticsContribution before,

--- a/src/main/java/org/websoso/WSSServer/novel/service/NovelStatisticsService.java
+++ b/src/main/java/org/websoso/WSSServer/novel/service/NovelStatisticsService.java
@@ -1,0 +1,60 @@
+package org.websoso.WSSServer.novel.service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.novel.domain.NovelStatistics;
+import org.websoso.WSSServer.novel.domain.NovelStatisticsContribution;
+import org.websoso.WSSServer.novel.repository.NovelStatisticsRepository;
+
+@Service
+@RequiredArgsConstructor
+public class NovelStatisticsService {
+
+    private final NovelStatisticsRepository novelStatisticsRepository;
+
+    @Transactional(readOnly = true)
+    public Map<Long, NovelStatistics> getStatisticsByNovelIds(List<Long> novelIds) {
+        if (novelIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return novelStatisticsRepository.findAllById(novelIds).stream()
+                .collect(Collectors.toMap(
+                        NovelStatistics::getNovelId,
+                        Function.identity()
+                ));
+    }
+
+    @Transactional
+    public void updateByDelta(Long novelId, NovelStatisticsContribution before,
+                              NovelStatisticsContribution after) {
+        BigDecimal ratingSumDelta = after.ratingSum().subtract(before.ratingSum());
+        long ratingCountDelta = after.ratingCount() - before.ratingCount();
+        long popularityDelta = after.popularity() - before.popularity();
+
+        if (ratingSumDelta.signum() == 0
+                && ratingCountDelta == 0
+                && popularityDelta == 0) {
+            return;
+        }
+
+        novelStatisticsRepository.insertIfAbsent(novelId);
+        novelStatisticsRepository.updateByDelta(
+                novelId,
+                ratingSumDelta,
+                ratingCountDelta,
+                popularityDelta
+        );
+    }
+
+    @Transactional
+    public int correctAll() {
+        return novelStatisticsRepository.correctAll();
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/application/LibraryInterestApplicationTest.java
+++ b/src/test/java/org/websoso/WSSServer/application/LibraryInterestApplicationTest.java
@@ -1,0 +1,84 @@
+package org.websoso.WSSServer.application;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willAnswer;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.websoso.WSSServer.library.domain.UserNovel;
+import org.websoso.WSSServer.library.service.LibraryService;
+import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.novel.domain.NovelStatisticsContribution;
+import org.websoso.WSSServer.novel.service.NovelServiceImpl;
+import org.websoso.WSSServer.novel.service.NovelStatisticsService;
+import org.websoso.WSSServer.user.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+class LibraryInterestApplicationTest {
+
+    private static final long NOVEL_ID = 1L;
+
+    @InjectMocks
+    private LibraryInterestApplication application;
+
+    @Mock
+    private NovelServiceImpl novelService;
+
+    @Mock
+    private LibraryService libraryService;
+
+    @Mock
+    private NovelStatisticsService novelStatisticsService;
+
+    @Mock
+    private User user;
+
+    @Mock
+    private Novel novel;
+
+    @DisplayName("관심 등록 전후의 UserNovel 통계 기여분을 작품 통계 서비스에 전달한다")
+    @Test
+    void registersInterestAndUpdatesStatistics() {
+        UserNovel library = UserNovel.create(null, 0.0f, null, null, user, novel);
+        given(novelService.getNovelOrException(NOVEL_ID)).willReturn(novel);
+        given(libraryService.getOrCreateLibraryForInterest(user, novel)).willReturn(library);
+        willAnswer(invocation -> {
+            library.markAsInterested();
+            return null;
+        }).given(libraryService).registerInterest(library);
+
+        application.registerAsInterest(user, NOVEL_ID);
+
+        then(novelStatisticsService).should().updateByDelta(
+                NOVEL_ID,
+                NovelStatisticsContribution.EMPTY,
+                new NovelStatisticsContribution(BigDecimal.ZERO, 0L, 1L)
+        );
+    }
+
+    @DisplayName("관심 해제 전후의 UserNovel 통계 기여분을 작품 통계 서비스에 전달한다")
+    @Test
+    void unregistersInterestAndUpdatesStatistics() {
+        UserNovel library = UserNovel.create(null, 0.0f, null, null, user, novel);
+        library.markAsInterested();
+        given(libraryService.getLibraryForUpdateOrNull(user, NOVEL_ID)).willReturn(library);
+        willAnswer(invocation -> {
+            library.unmarkAsInterested();
+            return null;
+        }).given(libraryService).unregisterInterest(library);
+
+        application.unregisterAsInterest(user, NOVEL_ID);
+
+        then(novelStatisticsService).should().updateByDelta(
+                NOVEL_ID,
+                new NovelStatisticsContribution(BigDecimal.ZERO, 0L, 1L),
+                NovelStatisticsContribution.EMPTY
+        );
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/library/service/LibraryServiceTest.java
+++ b/src/test/java/org/websoso/WSSServer/library/service/LibraryServiceTest.java
@@ -1,0 +1,141 @@
+package org.websoso.WSSServer.library.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.websoso.WSSServer.domain.common.ReadStatus;
+import org.websoso.WSSServer.library.domain.UserNovel;
+import org.websoso.WSSServer.library.repository.UserNovelRepository;
+import org.websoso.WSSServer.library.repository.projection.NovelInterestCount;
+import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.user.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+class LibraryServiceTest {
+
+    private static final long NOVEL_ID = 1L;
+
+    @InjectMocks
+    private LibraryService libraryService;
+
+    @Mock
+    private UserNovelRepository userNovelRepository;
+
+    @Mock
+    private User user;
+
+    @Mock
+    private Novel novel;
+
+    @DisplayName("평점과 상태 변경 시 기존값과 변경값의 차이만 작품 통계에 반영한다")
+    @Test
+    void updatesStatisticsByDelta() {
+        given(novel.getNovelId()).willReturn(NOVEL_ID);
+        UserNovel library = UserNovel.create(ReadStatus.QUIT, 2.0f, null, null, user, novel);
+
+        libraryService.updateEvaluation(library, 4.0f, ReadStatus.WATCHING, null, null);
+
+        then(userNovelRepository).should().flush();
+        then(userNovelRepository).should()
+                .updateNovelStatisticsByDelta(NOVEL_ID, new BigDecimal("2.0"), 0L, 1L);
+    }
+
+    @DisplayName("평점이 새로 생기면 평점 합과 평가 수를 각각 증가시킨다")
+    @Test
+    void addsRatingStatistics() {
+        given(novel.getNovelId()).willReturn(NOVEL_ID);
+        UserNovel library = UserNovel.create(ReadStatus.WATCHING, 0.0f, null, null, user, novel);
+
+        libraryService.updateEvaluation(library, 3.5f, ReadStatus.WATCHING, null, null);
+
+        then(userNovelRepository).should()
+                .updateNovelStatisticsByDelta(NOVEL_ID, new BigDecimal("3.5"), 1L, 0L);
+    }
+
+    @DisplayName("통계에 영향 없는 변경은 작품 통계 UPDATE를 실행하지 않는다")
+    @Test
+    void skipsStatisticsUpdateWhenDeltaIsZero() {
+        UserNovel library = UserNovel.create(ReadStatus.WATCHED, 4.0f, null, null, user, novel);
+
+        libraryService.updateEvaluation(
+                library,
+                4.0f,
+                ReadStatus.WATCHED,
+                LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 2)
+        );
+
+        then(userNovelRepository).should(never()).flush();
+        then(userNovelRepository).should(never())
+                .updateNovelStatisticsByDelta(anyLong(), any(BigDecimal.class), anyLong(), anyLong());
+    }
+
+    @DisplayName("서재 데이터 삭제 시 해당 데이터의 통계 기여분만 차감한다")
+    @Test
+    void subtractsStatisticsWhenDeletingLibrary() {
+        given(novel.getNovelId()).willReturn(NOVEL_ID);
+        UserNovel library = UserNovel.create(ReadStatus.WATCHED, 4.5f, null, null, user, novel);
+
+        libraryService.delete(library);
+
+        then(userNovelRepository).should().delete(library);
+        then(userNovelRepository).should()
+                .updateNovelStatisticsByDelta(NOVEL_ID, new BigDecimal("-4.5"), -1L, -1L);
+    }
+
+    @DisplayName("관심 서재 데이터가 새로 삽입되면 인기도만 증가시킨다")
+    @Test
+    void incrementsPopularityWhenInterestIsInserted() {
+        given(user.getUserId()).willReturn(10L);
+        given(novel.getNovelId()).willReturn(NOVEL_ID);
+        given(userNovelRepository.insertInterestIfAbsent(
+                10L,
+                NOVEL_ID,
+                UserNovel.DEFAULT_RATING,
+                UserNovel.DEFAULT_STATUS
+        )).willReturn(1);
+
+        UserNovel library = UserNovel.create(null, 0.0f, null, null, user, novel);
+        library.markAsInterested();
+        given(userNovelRepository.findByNovelIdAndUserForUpdate(NOVEL_ID, user))
+                .willReturn(Optional.of(library));
+
+        libraryService.registerInterest(user, novel);
+
+        then(userNovelRepository).should()
+                .updateNovelStatisticsByDelta(NOVEL_ID, BigDecimal.ZERO, 0L, 1L);
+    }
+
+    @DisplayName("작품별 관심 수를 한 번의 집계 조회 결과로 반환한다")
+    @Test
+    void getsInterestCountsByNovelIds() {
+        List<Long> novelIds = List.of(1L, 2L);
+        given(userNovelRepository.findInterestCountsByNovelIds(novelIds))
+                .willReturn(List.of(
+                        new NovelInterestCount(1L, 3L),
+                        new NovelInterestCount(2L, 5L)
+                ));
+
+        Map<Long, Long> result = libraryService.getInterestCountsByNovelIds(novelIds);
+
+        assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(
+                1L, 3L,
+                2L, 5L
+        ));
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/library/service/LibraryServiceTest.java
+++ b/src/test/java/org/websoso/WSSServer/library/service/LibraryServiceTest.java
@@ -3,12 +3,7 @@ package org.websoso.WSSServer.library.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.never;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -42,83 +37,55 @@ class LibraryServiceTest {
     @Mock
     private Novel novel;
 
-    @DisplayName("평점과 상태 변경 시 기존값과 변경값의 차이만 작품 통계에 반영한다")
+    @DisplayName("평가 정보를 변경하면 UserNovel만 수정한다")
     @Test
-    void updatesStatisticsByDelta() {
-        given(novel.getNovelId()).willReturn(NOVEL_ID);
+    void updatesEvaluation() {
         UserNovel library = UserNovel.create(ReadStatus.QUIT, 2.0f, null, null, user, novel);
 
         libraryService.updateEvaluation(library, 4.0f, ReadStatus.WATCHING, null, null);
 
-        then(userNovelRepository).should().flush();
-        then(userNovelRepository).should()
-                .updateNovelStatisticsByDelta(NOVEL_ID, new BigDecimal("2.0"), 0L, 1L);
+        assertThat(library.getUserNovelRating()).isEqualTo(4.0f);
+        assertThat(library.getStatus()).isEqualTo(ReadStatus.WATCHING);
     }
 
-    @DisplayName("평점이 새로 생기면 평점 합과 평가 수를 각각 증가시킨다")
+    @DisplayName("관심 등록용 UserNovel이 없으면 생성한 뒤 잠금 조회한다")
     @Test
-    void addsRatingStatistics() {
+    void getsOrCreatesLibraryForInterest() {
+        given(user.getUserId()).willReturn(10L);
         given(novel.getNovelId()).willReturn(NOVEL_ID);
-        UserNovel library = UserNovel.create(ReadStatus.WATCHING, 0.0f, null, null, user, novel);
+        UserNovel library = UserNovel.create(null, 0.0f, null, null, user, novel);
+        given(userNovelRepository.findByNovelIdAndUserForUpdate(NOVEL_ID, user))
+                .willReturn(Optional.of(library));
 
-        libraryService.updateEvaluation(library, 3.5f, ReadStatus.WATCHING, null, null);
+        UserNovel result = libraryService.getOrCreateLibraryForInterest(user, novel);
 
-        then(userNovelRepository).should()
-                .updateNovelStatisticsByDelta(NOVEL_ID, new BigDecimal("3.5"), 1L, 0L);
-    }
-
-    @DisplayName("통계에 영향 없는 변경은 작품 통계 UPDATE를 실행하지 않는다")
-    @Test
-    void skipsStatisticsUpdateWhenDeltaIsZero() {
-        UserNovel library = UserNovel.create(ReadStatus.WATCHED, 4.0f, null, null, user, novel);
-
-        libraryService.updateEvaluation(
-                library,
-                4.0f,
-                ReadStatus.WATCHED,
-                LocalDate.of(2026, 1, 1),
-                LocalDate.of(2026, 1, 2)
+        assertThat(result).isSameAs(library);
+        then(userNovelRepository).should().insertLibraryIfAbsent(
+                10L,
+                NOVEL_ID,
+                UserNovel.DEFAULT_RATING,
+                UserNovel.DEFAULT_STATUS
         );
-
-        then(userNovelRepository).should(never()).flush();
-        then(userNovelRepository).should(never())
-                .updateNovelStatisticsByDelta(anyLong(), any(BigDecimal.class), anyLong(), anyLong());
     }
 
-    @DisplayName("서재 데이터 삭제 시 해당 데이터의 통계 기여분만 차감한다")
+    @DisplayName("관심 등록 시 UserNovel의 관심 상태만 변경한다")
     @Test
-    void subtractsStatisticsWhenDeletingLibrary() {
-        given(novel.getNovelId()).willReturn(NOVEL_ID);
+    void registersInterest() {
+        UserNovel library = UserNovel.create(null, 0.0f, null, null, user, novel);
+
+        libraryService.registerInterest(library);
+
+        assertThat(library.getIsInterest()).isTrue();
+    }
+
+    @DisplayName("UserNovel 삭제를 저장소에 위임한다")
+    @Test
+    void deletesLibrary() {
         UserNovel library = UserNovel.create(ReadStatus.WATCHED, 4.5f, null, null, user, novel);
 
         libraryService.delete(library);
 
         then(userNovelRepository).should().delete(library);
-        then(userNovelRepository).should()
-                .updateNovelStatisticsByDelta(NOVEL_ID, new BigDecimal("-4.5"), -1L, -1L);
-    }
-
-    @DisplayName("관심 서재 데이터가 새로 삽입되면 인기도만 증가시킨다")
-    @Test
-    void incrementsPopularityWhenInterestIsInserted() {
-        given(user.getUserId()).willReturn(10L);
-        given(novel.getNovelId()).willReturn(NOVEL_ID);
-        given(userNovelRepository.insertInterestIfAbsent(
-                10L,
-                NOVEL_ID,
-                UserNovel.DEFAULT_RATING,
-                UserNovel.DEFAULT_STATUS
-        )).willReturn(1);
-
-        UserNovel library = UserNovel.create(null, 0.0f, null, null, user, novel);
-        library.markAsInterested();
-        given(userNovelRepository.findByNovelIdAndUserForUpdate(NOVEL_ID, user))
-                .willReturn(Optional.of(library));
-
-        libraryService.registerInterest(user, novel);
-
-        then(userNovelRepository).should()
-                .updateNovelStatisticsByDelta(NOVEL_ID, BigDecimal.ZERO, 0L, 1L);
     }
 
     @DisplayName("작품별 관심 수를 한 번의 집계 조회 결과로 반환한다")

--- a/src/test/java/org/websoso/WSSServer/novel/job/NovelStatisticsCorrectionJobTest.java
+++ b/src/test/java/org/websoso/WSSServer/novel/job/NovelStatisticsCorrectionJobTest.java
@@ -1,0 +1,29 @@
+package org.websoso.WSSServer.novel.job;
+
+import static org.mockito.BDDMockito.then;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.websoso.WSSServer.novel.service.NovelStatisticsService;
+
+@ExtendWith(MockitoExtension.class)
+class NovelStatisticsCorrectionJobTest {
+
+    @InjectMocks
+    private NovelStatisticsCorrectionJob job;
+
+    @Mock
+    private NovelStatisticsService novelStatisticsService;
+
+    @DisplayName("스케줄 실행 시 전체 작품 통계를 보정한다")
+    @Test
+    void correctsNovelStatistics() {
+        job.correct();
+
+        then(novelStatisticsService).should().correctAll();
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/novel/service/NovelStatisticsServiceTest.java
+++ b/src/test/java/org/websoso/WSSServer/novel/service/NovelStatisticsServiceTest.java
@@ -1,0 +1,93 @@
+package org.websoso.WSSServer.novel.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.websoso.WSSServer.novel.domain.NovelStatistics;
+import org.websoso.WSSServer.novel.domain.NovelStatisticsContribution;
+import org.websoso.WSSServer.novel.repository.NovelStatisticsRepository;
+
+@ExtendWith(MockitoExtension.class)
+class NovelStatisticsServiceTest {
+
+    @InjectMocks
+    private NovelStatisticsService novelStatisticsService;
+
+    @Mock
+    private NovelStatisticsRepository novelStatisticsRepository;
+
+    @Mock
+    private NovelStatistics firstStatistics;
+
+    @Mock
+    private NovelStatistics secondStatistics;
+
+    @DisplayName("변경 전후의 차이만 작품 통계에 반영한다")
+    @Test
+    void updatesStatisticsByDelta() {
+        NovelStatisticsContribution before =
+                new NovelStatisticsContribution(new BigDecimal("2.0"), 1L, 0L);
+        NovelStatisticsContribution after =
+                new NovelStatisticsContribution(new BigDecimal("4.0"), 1L, 1L);
+
+        novelStatisticsService.updateByDelta(1L, before, after);
+
+        then(novelStatisticsRepository).should().insertIfAbsent(1L);
+        then(novelStatisticsRepository).should()
+                .updateByDelta(1L, new BigDecimal("2.0"), 0L, 1L);
+    }
+
+    @DisplayName("통계 기여분에 변화가 없으면 UPDATE를 실행하지 않는다")
+    @Test
+    void skipsUpdateWhenDeltaIsZero() {
+        NovelStatisticsContribution contribution =
+                new NovelStatisticsContribution(new BigDecimal("4.0"), 1L, 1L);
+
+        novelStatisticsService.updateByDelta(1L, contribution, contribution);
+
+        then(novelStatisticsRepository).should(never()).insertIfAbsent(anyLong());
+        then(novelStatisticsRepository).should(never())
+                .updateByDelta(anyLong(), any(BigDecimal.class), anyLong(), anyLong());
+    }
+
+    @DisplayName("작품 ID 목록의 통계를 작품 ID를 키로 하는 Map으로 조회한다")
+    @Test
+    void getsStatisticsByNovelIds() {
+        List<Long> novelIds = List.of(1L, 2L);
+        given(firstStatistics.getNovelId()).willReturn(1L);
+        given(secondStatistics.getNovelId()).willReturn(2L);
+        given(novelStatisticsRepository.findAllById(novelIds))
+                .willReturn(List.of(firstStatistics, secondStatistics));
+
+        Map<Long, NovelStatistics> result = novelStatisticsService.getStatisticsByNovelIds(novelIds);
+
+        assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(
+                1L, firstStatistics,
+                2L, secondStatistics
+        ));
+    }
+
+    @DisplayName("전체 작품 통계를 원본 서재 데이터 기준으로 보정한다")
+    @Test
+    void correctsAllStatistics() {
+        given(novelStatisticsRepository.correctAll()).willReturn(10);
+
+        int affectedRows = novelStatisticsService.correctAll();
+
+        assertThat(affectedRows).isEqualTo(10);
+        then(novelStatisticsRepository).should().correctAll();
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/novel/service/NovelStatisticsServiceTest.java
+++ b/src/test/java/org/websoso/WSSServer/novel/service/NovelStatisticsServiceTest.java
@@ -8,15 +8,12 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
 import java.math.BigDecimal;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.websoso.WSSServer.novel.domain.NovelStatistics;
 import org.websoso.WSSServer.novel.domain.NovelStatisticsContribution;
 import org.websoso.WSSServer.novel.repository.NovelStatisticsRepository;
 
@@ -28,12 +25,6 @@ class NovelStatisticsServiceTest {
 
     @Mock
     private NovelStatisticsRepository novelStatisticsRepository;
-
-    @Mock
-    private NovelStatistics firstStatistics;
-
-    @Mock
-    private NovelStatistics secondStatistics;
 
     @DisplayName("변경 전후의 차이만 작품 통계에 반영한다")
     @Test
@@ -61,23 +52,6 @@ class NovelStatisticsServiceTest {
         then(novelStatisticsRepository).should(never()).insertIfAbsent(anyLong());
         then(novelStatisticsRepository).should(never())
                 .updateByDelta(anyLong(), any(BigDecimal.class), anyLong(), anyLong());
-    }
-
-    @DisplayName("작품 ID 목록의 통계를 작품 ID를 키로 하는 Map으로 조회한다")
-    @Test
-    void getsStatisticsByNovelIds() {
-        List<Long> novelIds = List.of(1L, 2L);
-        given(firstStatistics.getNovelId()).willReturn(1L);
-        given(secondStatistics.getNovelId()).willReturn(2L);
-        given(novelStatisticsRepository.findAllById(novelIds))
-                .willReturn(List.of(firstStatistics, secondStatistics));
-
-        Map<Long, NovelStatistics> result = novelStatisticsService.getStatisticsByNovelIds(novelIds);
-
-        assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(
-                1L, firstStatistics,
-                2L, secondStatistics
-        ));
     }
 
     @DisplayName("전체 작품 통계를 원본 서재 데이터 기준으로 보정한다")


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- refactor/#496 -> dev
- close #496

## Key Changes
<!-- 최대한 자세히 -->
소설 통계 데이터 역정규화
소설 필터 조회에서 매 작품마다 수행되던 평균 평점 및 인기도 집계 서브쿼리를 제거했습니다.
`Novel`에 평균 평점, 평점 합계, 평가 수, 인기도 컬럼을 추가했습니다.
평균 평점과 평점 합계는 부동소수점 오차를 방지하기 위해 `DECIMAL`을 사용하도록 했습니다.

UserNovel 변경 시 통계 차이 반영
`UserNovel` 생성, 수정, 삭제 및 관심 등록 상태 변경 시 작품 통계를 갱신하도록 추가했습니다.
전체 데이터를 다시 집계하지 않고 변경 전후의 평점 합계, 평가 수, 인기도 차이만 작품 테이블에 원자적으로 반영합니다.
통계에 영향을 주지 않는 변경은 작품 통계 UPDATE 쿼리를 실행하지 않도록 했습니다.

동시성 처리
동일한 사용자의 동일 작품 평가가 동시에 변경될 때 통계 차이가 중복 반영되지 않도록 `SELECT FOR UPDATE` 조회를 추가했습니다.
비관적 잠금 조회는 `UserNovelCustomRepository`에서 QueryDSL로 구현했습니다.
관심 등록은 `INSERT IGNORE` 후 잠금 조회를 수행해 신규 생성과 기존 데이터 변경을 구분하도록 했습니다.

소설 필터 조회 쿼리 개선
평균 평점 조건과 인기도 정렬이 작품 테이블의 역정규화 컬럼을 사용하도록 변경했습니다.
기본 평점 범위인 0.0~5.0 조회에서는 불필요한 평균 평점 조건을 추가하지 않도록 했습니다.
장르와 플랫폼 조인은 해당 필터가 요청된 경우에만 수행하도록 변경했습니다.

소설 목록 응답 N+1 완화
소설 목록 응답의 평균 평점과 평가 수는 작품 테이블의 역정규화 컬럼을 사용하도록 변경했습니다.
관심 수는 조회된 페이지의 작품 ID만 대상으로 한 번의 GROUP BY 쿼리로 조회하도록 변경했습니다.
작품별 관심 수 조회 결과는 `NovelInterestCount` projection으로 분리했습니다.

Library 패키지 구조 정리
기존 공용 controller 패키지의 `LibraryController`를 `library.controller` 패키지로 이동했습니다.
작품 통계 기여값을 나타내는 `UserNovelStatistics`를 `library.domain`의 별도 record로 분리했습니다.

테스트 추가
평점 및 인기도 차이 계산, 통계 UPDATE 생략, 삭제 시 통계 차감, 관심 수 집계에 대한 단위 테스트를 추가했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
애플리케이션 실행 전 DB에 `average_rating`, `rating_sum`, `rating_count`, `popularity` 컬럼이 반영되어 있어야 합니다.
소설 필터 조회의 평균 평점 및 인기도 집계 부하는 제거했지만, 장르, 플랫폼, 키워드 필터의 추가 인덱스 및 쿼리 튜닝은 실행 계획 측정 후 별도 작업으로 진행할 예정입니다.

개발 db에 아래 쿼리를 적용 하였습니다.

CREATE TABLE novel_statistics (
    novel_id BIGINT NOT NULL,
    average_rating DECIMAL(4, 3) NOT NULL DEFAULT 0.000 COMMENT '작품 평균 평점',
    rating_sum DECIMAL(19, 1) NOT NULL DEFAULT 0.0 COMMENT '작품 평점 합계',
    rating_count BIGINT NOT NULL DEFAULT 0 COMMENT '작품 평점 등록 수',
    popularity BIGINT NOT NULL DEFAULT 0 COMMENT '관심 등록 또는 하차 외 독서 상태인 사용자 수',
    PRIMARY KEY (novel_id),
    INDEX idx_novel_statistics_average_rating (average_rating),
    INDEX idx_novel_statistics_popularity (popularity),
    CONSTRAINT fk_novel_statistics_novel
        FOREIGN KEY (novel_id) REFERENCES novel (novel_id)
        ON DELETE CASCADE
);

INSERT INTO novel_statistics (
    novel_id,
    average_rating,
    rating_sum,
    rating_count,
    popularity
)
SELECT
    n.novel_id,
    CAST(
        ROUND(COALESCE(AVG(NULLIF(un.user_novel_rating, 0)), 0), 3)
        AS DECIMAL(4, 3)
    ),
    CAST(
        ROUND(COALESCE(SUM(NULLIF(un.user_novel_rating, 0)), 0), 1)
        AS DECIMAL(19, 1)
    ),
    COUNT(NULLIF(un.user_novel_rating, 0)),
    COUNT(CASE
        WHEN un.is_interest = TRUE OR un.status <> 'QUIT' THEN 1
    END)
FROM novel n
LEFT JOIN user_novel un ON un.novel_id = n.novel_id
GROUP BY n.novel_id
ON DUPLICATE KEY UPDATE
    average_rating = VALUES(average_rating),
    rating_sum = VALUES(rating_sum),
    rating_count = VALUES(rating_count),
    popularity = VALUES(popularity);


## References
<!-- 참고한 자료-->
