### PR TITLE
[REFACTOR] 홈/소소피드 추천글 로직 개선

### DIFF
--- a/src/main/java/org/websoso/WSSServer/feed/feed/application/FeedFindApplication.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/application/FeedFindApplication.java
@@ -37,6 +37,7 @@ import org.websoso.WSSServer.user.service.UserService;
 public class FeedFindApplication {
 
     private static final int DEFAULT_PAGE_NUMBER = 0;
+    private static final int POPULAR_FEED_CANDIDATE_SIZE = 20;
 
     private final GenreServiceImpl genreService;
     private final UserService userService;
@@ -106,13 +107,33 @@ public class FeedFindApplication {
     @Transactional(readOnly = true)
     public PopularFeedsGetResponse getPopularFeeds(User user, int size) {
 
+        Long userIdOrNull = user == null ? null : user.getUserId();
+
+        List<Genre> genres = user == null ? null : genreService.findUserPreferenceGenres(user);
+
         // 사용자의 차단 목록 조회
         List<Long> blockedUserIds = Optional.ofNullable(user)
                 .map(User::getUserId)
                 .map(blockService::findBlockRelationUserIds)
                 .orElseGet(Collections::emptyList);
 
-        return PopularFeedsGetResponse.of(feedQueryService.findPopularFeedRows(blockedUserIds, size));
+        int responseSize = Math.max(size, 0);
+        int candidateSize = Math.max(POPULAR_FEED_CANDIDATE_SIZE, responseSize);
+
+        List<Feed> candidates = feedServiceImpl.findPopularRecommendedFeeds(
+                userIdOrNull,
+                candidateSize,
+                genres,
+                blockedUserIds
+        );
+
+        Collections.shuffle(candidates);
+
+        List<Feed> selectedFeeds = candidates.stream()
+                .limit(responseSize)
+                .toList();
+
+        return PopularFeedsGetResponse.of(feedQueryService.findPopularFeedRows(selectedFeeds));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/websoso/WSSServer/feed/feed/application/FeedFindApplication.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/application/FeedFindApplication.java
@@ -117,12 +117,9 @@ public class FeedFindApplication {
                 .map(blockService::findBlockRelationUserIds)
                 .orElseGet(Collections::emptyList);
 
-        int responseSize = Math.max(size, 0);
-        int candidateSize = Math.max(POPULAR_FEED_CANDIDATE_SIZE, responseSize);
-
         List<Feed> candidates = feedServiceImpl.findPopularRecommendedFeeds(
                 userIdOrNull,
-                candidateSize,
+                POPULAR_FEED_CANDIDATE_SIZE,
                 genres,
                 blockedUserIds
         );
@@ -130,7 +127,7 @@ public class FeedFindApplication {
         Collections.shuffle(candidates);
 
         List<Feed> selectedFeeds = candidates.stream()
-                .limit(responseSize)
+                .limit(size)
                 .toList();
 
         return PopularFeedsGetResponse.of(feedQueryService.findPopularFeedRows(selectedFeeds));

--- a/src/main/java/org/websoso/WSSServer/feed/feed/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/controller/FeedController.java
@@ -119,7 +119,7 @@ public class FeedController {
 
     @GetMapping("/feeds/popular")
     public ResponseEntity<PopularFeedsGetResponse> getPopularFeeds(@AuthenticationPrincipal User user,
-                                                                   @RequestParam(name = "size", defaultValue = "9") int size) {
+                                                                   @RequestParam(name = "size", defaultValue = "6") int size) {
         return ResponseEntity
                 .status(OK)
                 .body(feedFindApplication.getPopularFeeds(user, size));

--- a/src/main/java/org/websoso/WSSServer/feed/feed/controller/FeedController.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/controller/FeedController.java
@@ -5,10 +5,13 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -41,6 +44,7 @@ import java.util.List;
 @RequestMapping
 @RestController
 @RequiredArgsConstructor
+@Validated
 public class FeedController {
 
     private final FeedManagementApplication feedManagementApplication;
@@ -119,7 +123,7 @@ public class FeedController {
 
     @GetMapping("/feeds/popular")
     public ResponseEntity<PopularFeedsGetResponse> getPopularFeeds(@AuthenticationPrincipal User user,
-                                                                   @RequestParam(name = "size", defaultValue = "6") int size) {
+                                                                   @RequestParam(name = "size", defaultValue = "6") @Min(1) @Max(20) int size) {
         return ResponseEntity
                 .status(OK)
                 .body(feedFindApplication.getPopularFeeds(user, size));

--- a/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedCustomRepository.java
@@ -21,9 +21,6 @@ public interface FeedCustomRepository {
     Slice<Feed> findRecommendedFeeds(Long lastFeedId, Long userId, PageRequest pageRequest, List<Genre> genres,
                                      List<Long> blockedUserIds);
 
-    Slice<Feed> findInterestedNovelFeeds(Long lastFeedId, Long userId, PageRequest pageRequest,
-                                         List<Long> blockedUserIds);
-
     Long countVisibleFeeds(User owner, Boolean isVisible,
                            Boolean isUnVisible, List<Genre> genres,
                            Long visitorId, boolean includeEtc);

--- a/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedCustomRepository.java
@@ -21,6 +21,8 @@ public interface FeedCustomRepository {
     Slice<Feed> findRecommendedFeeds(Long lastFeedId, Long userId, PageRequest pageRequest, List<Genre> genres,
                                      List<Long> blockedUserIds);
 
+    List<Feed> findPopularRecommendedFeeds(Long userId, int size, List<Genre> genres, List<Long> blockedUserIds);
+
     Long countVisibleFeeds(User owner, Boolean isVisible,
                            Boolean isUnVisible, List<Genre> genres,
                            Long visitorId, boolean includeEtc);

--- a/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedCustomRepositoryImpl.java
@@ -238,44 +238,16 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
                                             List<Long> blockedUserIds) {
         List<Feed> feeds = jpaQueryFactory
                 .selectFrom(feed)
+                .distinct()
                 .join(feed.user).fetchJoin()
                 .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
                 .leftJoin(novelGenre).on(novel.eq(novelGenre.novel))
                 .leftJoin(genre).on(novelGenre.genre.eq(genre))
                 .where(
                         ltFeedId(lastFeedId),
-                        checkPopularFeed(),
-                        checkGenresAndNovels(genres, true),
+                        recommendedFeedCondition(userId, genres),
                         excludeBlockedUsers(blockedUserIds),
                         checkHidden(),
-                        checkVisible(userId)
-                )
-                .limit(pageRequest.getPageSize() + 1)
-                .orderBy(feed.feedId.desc())
-                .fetch();
-
-        boolean hasNext = feeds.size() > pageRequest.getPageSize();
-
-        if (hasNext) {
-            feeds.remove(feeds.size() - 1);
-        }
-
-        return new SliceImpl<>(feeds, pageRequest, hasNext);
-    }
-
-    @Override
-    public Slice<Feed> findInterestedNovelFeeds(Long lastFeedId, Long userId, PageRequest pageRequest,
-                                                List<Long> blockedUserIds) {
-        List<Feed> feeds = jpaQueryFactory
-                .selectFrom(feed)
-                .join(feed.user).fetchJoin()
-                .join(novel).on(feed.novelId.eq(novel.novelId))
-                .join(userNovel).on(novel.eq(userNovel.novel))
-                .where(
-                        ltFeedId(lastFeedId),
-                        excludeBlockedUsers(blockedUserIds),
-                        checkHidden(),
-                        checkInterestedNovels(userId),
                         checkVisible(userId)
                 )
                 .limit(pageRequest.getPageSize() + 1)
@@ -297,6 +269,46 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
                 .from(like)
                 .where(like.feed.eq(feed))
                 .goe(POPULAR_FEED_LIKE_COUNT);
+    }
+
+    private BooleanExpression recommendedFeedCondition(Long userId, List<Genre> genres) {
+        BooleanExpression condition = checkPopularFeed();
+
+        BooleanExpression preferredGenreCondition = checkPreferredGenres(genres);
+        if (preferredGenreCondition != null) {
+            condition = condition.or(preferredGenreCondition);
+        }
+
+        BooleanExpression interestedNovelCondition = checkInterestedNovel(userId);
+        if (interestedNovelCondition != null) {
+            condition = condition.or(interestedNovelCondition);
+        }
+
+        return condition;
+    }
+
+    private BooleanExpression checkPreferredGenres(List<Genre> genres) {
+        if (genres == null || genres.isEmpty()) {
+            return null;
+        }
+
+        return genre.in(genres);
+    }
+
+    private BooleanExpression checkInterestedNovel(Long userId) {
+        if (userId == null) {
+            return null;
+        }
+
+        return JPAExpressions
+                .selectOne()
+                .from(userNovel)
+                .where(
+                        userNovel.user.userId.eq(userId),
+                        userNovel.isInterest.isTrue(),
+                        userNovel.novel.novelId.eq(feed.novelId)
+                )
+                .exists();
     }
 
     private BooleanExpression checkGenresAndNovels(List<Genre> genres, boolean isNotNovelConnect) {
@@ -352,13 +364,6 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
         }
 
         return feed.isPublic.isTrue().or(feed.user.userId.eq(userId));
-    }
-
-    private BooleanExpression checkInterestedNovels(Long userId) {
-        if (userId != null) {
-            return userNovel.user.userId.eq(userId).and(userNovel.isInterest.isTrue());
-        }
-        return null;
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedCustomRepositoryImpl.java
@@ -263,6 +263,27 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
         return new SliceImpl<>(feeds, pageRequest, hasNext);
     }
 
+    @Override
+    public List<Feed> findPopularRecommendedFeeds(Long userId, int size, List<Genre> genres,
+                                                  List<Long> blockedUserIds) {
+        return jpaQueryFactory
+                .selectFrom(feed)
+                .distinct()
+                .join(feed.user).fetchJoin()
+                .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
+                .leftJoin(novelGenre).on(novel.eq(novelGenre.novel))
+                .leftJoin(genre).on(novelGenre.genre.eq(genre))
+                .where(
+                        recommendedFeedCondition(userId, genres),
+                        excludeBlockedUsers(blockedUserIds),
+                        checkHidden(),
+                        feed.isPublic.isTrue()
+                )
+                .orderBy(feed.feedId.desc())
+                .limit(size)
+                .fetch();
+    }
+
     private BooleanExpression checkPopularFeed() {
         return JPAExpressions
                 .select(like.count())

--- a/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedQueryRepository.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedQueryRepository.java
@@ -12,6 +12,6 @@ public interface FeedQueryRepository {
 
     List<UserFeedInfoRow> findUserFeedInfoRows(List<Long> feedIds, Long visitorId);
 
-    List<PopularFeedInfoRow> findPopularFeedInfoRows(List<Long> blockedUserIds, int size);
+    List<PopularFeedInfoRow> findPopularFeedInfoRowsByFeedIds(List<Long> feedIds);
 
 }

--- a/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedQueryRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedQueryRepositoryImpl.java
@@ -1,13 +1,11 @@
 package org.websoso.WSSServer.feed.feed.repository;
 
 import static org.websoso.WSSServer.feed.feed.domain.QFeed.feed;
-import static org.websoso.WSSServer.feed.feed.domain.QPopularFeed.popularFeed;
 import static org.websoso.WSSServer.novel.domain.QNovel.novel;
 import static org.websoso.WSSServer.user.domain.QAvatarProfile.avatarProfile;
 
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
@@ -123,7 +121,11 @@ public class FeedQueryRepositoryImpl implements FeedQueryRepository {
     }
 
     @Override
-    public List<PopularFeedInfoRow> findPopularFeedInfoRows(List<Long> blockedUserIds, int size) {
+    public List<PopularFeedInfoRow> findPopularFeedInfoRowsByFeedIds(List<Long> feedIds) {
+        if (feedIds.isEmpty()) {
+            return List.of();
+        }
+
         return jpaQueryFactory
                 .select(Projections.constructor(
                         PopularFeedInfoRow.class,
@@ -137,16 +139,9 @@ public class FeedQueryRepositoryImpl implements FeedQueryRepository {
                         novel.novelImage,
                         firstGenreName()
                 ))
-                .from(popularFeed)
-                .join(popularFeed.feed, feed)
+                .from(feed)
                 .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
-                .where(
-                        feed.isPublic.isTrue(),
-                        feed.isHidden.isFalse(),
-                        excludeBlockedUsers(blockedUserIds)
-                )
-                .orderBy(popularFeed.popularFeedId.desc())
-                .limit(size)
+                .where(feed.feedId.in(feedIds))
                 .fetch();
     }
 
@@ -266,11 +261,4 @@ public class FeedQueryRepositoryImpl implements FeedQueryRepository {
                 );
     }
 
-    private BooleanExpression excludeBlockedUsers(List<Long> blockedUserIds) {
-        if (blockedUserIds == null || blockedUserIds.isEmpty()) {
-            return null;
-        }
-
-        return feed.user.userId.notIn(blockedUserIds);
-    }
 }

--- a/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedQueryRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedQueryRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.websoso.WSSServer.feed.feed.repository;
 
 import static org.websoso.WSSServer.feed.feed.domain.QFeed.feed;
 import static org.websoso.WSSServer.novel.domain.QNovel.novel;
+import static org.websoso.WSSServer.novel.domain.QNovelStatistics.novelStatistics;
 import static org.websoso.WSSServer.user.domain.QAvatarProfile.avatarProfile;
 
 import com.querydsl.core.types.Expression;
@@ -55,8 +56,8 @@ public class FeedQueryRepositoryImpl implements FeedQueryRepository {
                         commentCount(),
                         feed.novelId,
                         novel.title,
-                        novelRatingCount(),
-                        novelRating(),
+                        novelStatistics.ratingCount,
+                        novelStatistics.averageRating,
                         feed.isSpoiler,
                         feed.createdDate.ne(feed.modifiedDate),
                         isMyFeed(userId),
@@ -71,6 +72,7 @@ public class FeedQueryRepositoryImpl implements FeedQueryRepository {
                 .join(feed.user)
                 .leftJoin(avatarProfile).on(feed.user.avatarProfileId.eq(avatarProfile.avatarProfileId))
                 .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
+                .leftJoin(novel.novelStatistics, novelStatistics)
                 .leftJoin(thumbnailImage).on(
                         thumbnailImage.feedId.eq(feed.feedId),
                         thumbnailImage.feedImageType.eq(FeedImageType.FEED_THUMBNAIL)

--- a/src/main/java/org/websoso/WSSServer/feed/feed/repository/projection/FeedInfoRow.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/repository/projection/FeedInfoRow.java
@@ -1,5 +1,6 @@
 package org.websoso.WSSServer.feed.feed.repository.projection;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import org.websoso.WSSServer.feed.feed.controller.dto.FeedInfo;
 import org.websoso.WSSServer.util.TimeFormatUtil;
@@ -17,7 +18,7 @@ public record FeedInfoRow(
         Long novelId,
         String title,
         Long novelRatingCount,
-        Double novelRating,
+        BigDecimal novelRating,
         Boolean isSpoiler,
         Boolean isModified,
         Boolean isMyFeed,
@@ -60,7 +61,7 @@ public record FeedInfoRow(
         return value == null ? 0 : value.intValue();
     }
 
-    private static Float roundToFirstDecimal(Double value) {
+    private static Float roundToFirstDecimal(BigDecimal value) {
         if (value == null) {
             return null;
         }

--- a/src/main/java/org/websoso/WSSServer/feed/feed/service/FeedQueryService.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/service/FeedQueryService.java
@@ -56,8 +56,18 @@ public class FeedQueryService {
     }
 
     @Transactional(readOnly = true)
-    public List<PopularFeedGetResponse> findPopularFeedRows(List<Long> blockedUserIds, int size) {
-        return feedQueryRepository.findPopularFeedInfoRows(blockedUserIds, size).stream()
+    public List<PopularFeedGetResponse> findPopularFeedRows(List<Feed> feeds) {
+        List<Long> feedIds = feeds.stream()
+                .map(Feed::getFeedId)
+                .toList();
+
+        Map<Long, PopularFeedInfoRow> popularFeedInfoRowMap = feedQueryRepository
+                .findPopularFeedInfoRowsByFeedIds(feedIds).stream()
+                .collect(Collectors.toMap(PopularFeedInfoRow::feedId, Function.identity()));
+
+        return feedIds.stream()
+                .map(popularFeedInfoRowMap::get)
+                .filter(Objects::nonNull)
                 .map(PopularFeedInfoRow::toResponse)
                 .toList();
     }

--- a/src/main/java/org/websoso/WSSServer/feed/feed/service/FeedServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/service/FeedServiceImpl.java
@@ -101,4 +101,10 @@ public class FeedServiceImpl {
         return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, preferenceGenres, blockedUserIds);
     }
 
+    @Transactional(readOnly = true)
+    public List<Feed> findPopularRecommendedFeeds(Long userId, int size, List<Genre> preferenceGenres,
+                                                  List<Long> blockedUserIds) {
+        return feedRepository.findPopularRecommendedFeeds(userId, size, preferenceGenres, blockedUserIds);
+    }
+
 }

--- a/src/main/java/org/websoso/WSSServer/feed/feed/service/FeedServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/service/FeedServiceImpl.java
@@ -4,14 +4,11 @@ import static org.websoso.WSSServer.feed.feed.exception.CustomFeedError.FEED_NOT
 import static org.websoso.WSSServer.feed.feed.exception.CustomFeedError.HIDDEN_FEED_ACCESS;
 import static org.websoso.WSSServer.exception.error.CustomUserError.INVALID_AUTHORIZED;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Stream;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.websoso.WSSServer.domain.Genre;
@@ -101,27 +98,7 @@ public class FeedServiceImpl {
 
     @Transactional(readOnly = true)
     public Slice<Feed> findRecommendedFeeds(Long lastFeedId, Long userId, PageRequest pageRequest, List<Genre> preferenceGenres, List<Long> blockedUserIds) {
-        Slice<Feed> recommendedFeeds = feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, preferenceGenres, blockedUserIds);
-        Slice<Feed> interestedNovelFeeds = feedRepository.findInterestedNovelFeeds(lastFeedId, userId, pageRequest, blockedUserIds);
-
-        int pageSize = pageRequest.getPageSize();
-        List<Feed> combinedFeeds = Stream.concat(
-                        recommendedFeeds.getContent().stream(),
-                        interestedNovelFeeds.getContent().stream()
-                )
-                .distinct()
-                .sorted(Comparator.comparing(Feed::getFeedId).reversed())
-                .toList();
-
-        List<Feed> resultFeeds = combinedFeeds.stream()
-                .limit(pageSize)
-                .toList();
-
-        boolean hasNext = combinedFeeds.size() > pageSize
-                || recommendedFeeds.hasNext()
-                || interestedNovelFeeds.hasNext();
-
-        return new SliceImpl<>(resultFeeds, pageRequest, hasNext);
+        return feedRepository.findRecommendedFeeds(lastFeedId, userId, pageRequest, preferenceGenres, blockedUserIds);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/notification/service/NotificationService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/service/NotificationService.java
@@ -30,6 +30,7 @@ public class NotificationService {
     private static final int DEFAULT_PAGE_NUMBER = 0;
     private static final int NOTIFICATION_TITLE_MAX_LENGTH = 12;
     private static final int NOTIFICATION_TITLE_MIN_LENGTH = 0;
+    private static final String BECAME_POPULAR_NOTIFICATION_TITLE = "추천글 등극 🔥";
 
     private final NotificationRepository notificationRepository;
     private final NotificationTypeRepository notificationTypeRepository;
@@ -74,7 +75,7 @@ public class NotificationService {
 
         Long feedId = feed.getFeedId();
 
-        String notificationTitle = "지금 뜨는 글 등극\uD83D\uDE4C";
+        String notificationTitle = BECAME_POPULAR_NOTIFICATION_TITLE;
 
         String notificationBody = createNotificationBody(feed, novel);
 
@@ -238,11 +239,11 @@ public class NotificationService {
     }
 
     private String createNotificationBody(Feed feed, Novel novel) {
-        return String.format("내가 남긴 %s 글이 관심 받고 있어요!", generateNotificationBodyFragment(feed, novel));
+        return String.format("내가 남긴 %s글이 관심 받고 있어요!", generateNotificationBodyFragment(feed, novel));
     }
 
     private String generateNotificationBodyFragment(Feed feed, Novel novel) {
-        if (feed.getNovelId() == null) {
+        if (feed.getNovelId() == null || novel == null) {
             String feedContent = feed.getFeedContent();
             feedContent = feedContent.length() <= 12
                     ? feedContent

--- a/src/test/java/org/websoso/WSSServer/notification/service/NotificationServiceTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/service/NotificationServiceTest.java
@@ -2,12 +2,14 @@ package org.websoso.WSSServer.notification.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -21,11 +23,15 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.websoso.WSSServer.exception.exception.CustomNotificationException;
+import org.websoso.WSSServer.feed.feed.domain.Feed;
 import org.websoso.WSSServer.notification.domain.Notification;
 import org.websoso.WSSServer.notification.domain.NotificationType;
 import org.websoso.WSSServer.notification.dto.ReadNotificationDto;
 import org.websoso.WSSServer.notification.repository.NotificationRepository;
 import org.websoso.WSSServer.notification.repository.ReadNotificationRepository;
+import org.websoso.WSSServer.notification.repository.NotificationTypeRepository;
+import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.user.domain.User;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
@@ -35,6 +41,9 @@ class NotificationServiceTest {
 
     @Mock
     private NotificationRepository notificationRepository;
+
+    @Mock
+    private NotificationTypeRepository notificationTypeRepository;
 
     @Mock
     private ReadNotificationRepository readNotificationRepository;
@@ -156,6 +165,53 @@ class NotificationServiceTest {
     }
 
     @Nested
+    @DisplayName("추천글 등극 알림 생성 테스트")
+    class CreateBecamePopularFeedNotification {
+
+        @DisplayName("작품이 연결된 피드는 작품명을 포함한 알림을 생성한다")
+        @Test
+        void createsNotificationWithNovelTitleWhenFeedHasNovel() {
+            // given
+            User owner = createUser(1L, "작성자");
+            Feed feed = createFeed(100L, owner, "작품 연결 피드", 10L);
+            Novel novel = mock(Novel.class);
+            given(novel.getTitle()).willReturn("전지적 독자 시점");
+            givenPopularNotificationType();
+            given(notificationRepository.save(any(Notification.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            Notification result = notificationService.createBecamePopularFeedNotification(feed, novel);
+
+            // then
+            assertThat(result.getNotificationTitle()).isEqualTo("추천글 등극 🔥");
+            assertThat(result.getNotificationBody()).isEqualTo("내가 남긴 <전지적 독자 시점>글이 관심 받고 있어요!");
+            assertThat(result.getUserId()).isEqualTo(owner.getUserId());
+            assertThat(result.getFeedId()).isEqualTo(feed.getFeedId());
+        }
+
+        @DisplayName("작품이 연결되지 않은 피드는 게시글 앞 12자를 포함한 알림을 생성한다")
+        @Test
+        void createsNotificationWithFeedContentWhenFeedHasNoNovel() {
+            // given
+            User owner = createUser(1L, "작성자");
+            Feed feed = createFeed(100L, owner, "  1234567890이후내용", null);
+            givenPopularNotificationType();
+            given(notificationRepository.save(any(Notification.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            Notification result = notificationService.createBecamePopularFeedNotification(feed, null);
+
+            // then
+            assertThat(result.getNotificationTitle()).isEqualTo("추천글 등극 🔥");
+            assertThat(result.getNotificationBody()).isEqualTo("내가 남긴 '  1234567890...'글이 관심 받고 있어요!");
+            assertThat(result.getUserId()).isEqualTo(owner.getUserId());
+            assertThat(result.getFeedId()).isEqualTo(feed.getFeedId());
+        }
+    }
+
+    @Nested
     @DisplayName("알림 목록 조회 테스트")
     class GetNotifications {
 
@@ -182,6 +238,24 @@ class NotificationServiceTest {
             assertThat(result.notifications()).hasSize(1);
             assertThat(result.isLoadable()).isFalse();
         }
+    }
+
+    private void givenPopularNotificationType() {
+        NotificationType notificationType = mock(NotificationType.class);
+        given(notificationTypeRepository.findByNotificationTypeName("지금뜨는글"))
+                .willReturn(notificationType);
+    }
+
+    private User createUser(Long userId, String nickname) {
+        User user = User.createBySocial("social-" + userId, nickname, null);
+        ReflectionTestUtils.setField(user, "userId", userId);
+        return user;
+    }
+
+    private Feed createFeed(Long feedId, User owner, String content, Long novelId) {
+        Feed feed = Feed.create(content, novelId, false, true, owner, List.of());
+        ReflectionTestUtils.setField(feed, "feedId", feedId);
+        return feed;
     }
 
     private Notification createNotification(Long notificationId, Long userId, String title) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- refactor/#547 -> dev
- close #547 

## Key Changes
<!-- 최대한 자세히 -->
### 1. 추천글 판별 조건 개선

홈 화면과 소소피드 추천글에서 사용하는 추천글 판별 조건을 개선했습니다.

기존 추천 조건:
- 관심 등록한 작품 게시글
- 좋아요 5개 이상 게시글

개선 추천 조건:
- 선호 장르 기반 작품 게시글
- 관심 등록한 작품 게시글
- 좋아요 5개 이상 게시글

`GET /feeds?feedsOption=RECOMMENDED`는 기존처럼 최신순 무한 스크롤 방식을 유지하고, 추천글 판별 조건만 개선된 조건으로 변경했습니다.

### 2. 홈 화면 추천글 조회 정책 변경

`GET /feeds/popular` 조회 로직을 개선된 추천글 판별 조건 기반으로 변경했습니다.

- 최신 추천글 후보 `20개` 조회
- 후보 목록 랜덤 셔플
- 기본 `6개` 응답
- `size` 요청값은 최소 `1`, 최대 `20`까지만 허용
 
홈 화면 진입 시 클라이언트가 `GET /feeds/popular`를 재호출하면 서버에서 매번 후보를 다시 셔플하여 추천글이 새로고침됩니다.

### 3. PopularFeed 조회 의존 제거

`GET /feeds/popular` 응답 생성 시 더 이상 `popular_feed` 테이블을 직접 조회하지 않도록 변경했습니다.

다만 `PopularFeed` 도메인은 좋아요 5개 이상 도달 여부 확인, 인기글 등록, 추천글 등극 알림 중복 방지 흐름에서 계속 사용되므로 제거하지 않았습니다.

### 4. 피드 목록 소설 통계 조회 소스 변경

피드 목록 응답의 소설 평점/평점 수 조회를 기존 `user_novel` 집계 서브쿼리에서 `novel_statistics` 기반 조회로 변경했습니다.

- `novel_statistics.average_rating`
- `novel_statistics.rating_count`

`GET /feeds/popular` 응답에는 소설 평점/평점 수 필드가 없어 별도 변경 대상이 없었습니다.

### 5. 추천글 등극 푸시 알림 문구 변경

추천글 등극 푸시 알림 제목과 본문을 변경했습니다.

작품 연결 O:
- 제목: `추천글 등극 🔥`
- 내용: `내가 남긴 <{작품명}>글이 관심 받고 있어요!`

작품 연결 X:
- 제목: `추천글 등극 🔥`
- 내용: `내가 남긴 '{게시글 초반 공백 포함 12자}...'글이 관심 받고 있어요!`

작품 연결이 없는 경우 게시글 초반 12자는 앞 공백을 포함하여 자릅니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- `GET /feeds/popular`는 기본 응답 개수를 기존 `9개`에서 정책에 맞게 `6개`로 변경했습니다.
- `/feeds/popular`는 후보를 최신순으로 먼저 조회한 뒤 서버에서 랜덤 셔플합니다.
- `PopularFeed`는 조회 소스로는 사용하지 않지만 알림/중복 방지 흐름에서 여전히 사용합니다.

## References
<!-- 참고한 자료-->
