### PR TITLE
[FIX] 테이블명이 포함된 신고 유니크 키 판별 오류 수정

### DIFF
--- a/src/main/java/org/websoso/WSSServer/feed/report/repository/ReportConstraintViolationDetector.java
+++ b/src/main/java/org/websoso/WSSServer/feed/report/repository/ReportConstraintViolationDetector.java
@@ -22,11 +22,27 @@ public class ReportConstraintViolationDetector {
 
         while (cause != null) {
             if (cause instanceof ConstraintViolationException constraintViolationException) {
-                return constraintName.equalsIgnoreCase(constraintViolationException.getConstraintName());
+                String detectedConstraintName = normalizeConstraintName(
+                        constraintViolationException.getConstraintName()
+                );
+                return constraintName.equalsIgnoreCase(detectedConstraintName);
             }
             cause = cause.getCause();
         }
 
         return false;
+    }
+
+    private String normalizeConstraintName(String constraintName) {
+        if (constraintName == null) {
+            return null;
+        }
+
+        int tableNameSeparatorIndex = constraintName.lastIndexOf('.');
+        if (tableNameSeparatorIndex < 0) {
+            return constraintName;
+        }
+
+        return constraintName.substring(tableNameSeparatorIndex + 1);
     }
 }

--- a/src/test/java/org/websoso/WSSServer/feed/report/repository/ReportConstraintViolationDetectorTest.java
+++ b/src/test/java/org/websoso/WSSServer/feed/report/repository/ReportConstraintViolationDetectorTest.java
@@ -7,18 +7,37 @@ import java.sql.SQLException;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.websoso.WSSServer.feed.report.domain.ReportedComment;
 
 class ReportConstraintViolationDetectorTest {
 
     private final ReportConstraintViolationDetector detector = new ReportConstraintViolationDetector();
 
-    @DisplayName("피드 신고 유니크 키 위반을 중복 신고로 판별한다")
-    @Test
-    void detectsDuplicateFeedReport() {
-        DataIntegrityViolationException exception = dataIntegrityViolation(UNIQUE_CONSTRAINT_NAME);
+    @DisplayName("테이블명 포함 여부와 관계없이 피드 신고 유니크 키 위반을 중복 신고로 판별한다")
+    @ParameterizedTest
+    @ValueSource(strings = {
+            UNIQUE_CONSTRAINT_NAME,
+            "reported_feed." + UNIQUE_CONSTRAINT_NAME
+    })
+    void detectsDuplicateFeedReport(String constraintName) {
+        DataIntegrityViolationException exception = dataIntegrityViolation(constraintName);
 
         assertThat(detector.isDuplicateFeedReport(exception)).isTrue();
+    }
+
+    @DisplayName("테이블명 포함 여부와 관계없이 댓글 신고 유니크 키 위반을 중복 신고로 판별한다")
+    @ParameterizedTest
+    @ValueSource(strings = {
+            ReportedComment.UNIQUE_CONSTRAINT_NAME,
+            "reported_comment." + ReportedComment.UNIQUE_CONSTRAINT_NAME
+    })
+    void detectsDuplicateCommentReport(String constraintName) {
+        DataIntegrityViolationException exception = dataIntegrityViolation(constraintName);
+
+        assertThat(detector.isDuplicateCommentReport(exception)).isTrue();
     }
 
     @DisplayName("다른 무결성 제약조건 위반은 중복 신고로 판별하지 않는다")


### PR DESCRIPTION
## Related Issue

- fix/#552 -> dev
- Closes #552

## Key Changes

- MySQL/Hibernate가 제약조건명을 `테이블명.제약조건명` 형식으로 반환하는 경우, 마지막 `.` 앞의 테이블명 접두사를 제거한 뒤 신고 유니크 키를 판별하도록 수정했습니다.
- 피드와 댓글 신고 모두 테이블명 포함 여부와 관계없이 중복 신고를 식별하며, 관련 없는 데이터 무결성 예외는 기존과 동일하게 그대로 전파합니다.
- 기본 형식과 `reported_feed.*`, `reported_comment.*` 형식을 함께 검증하는 파라미터 테스트를 추가해 v2 신고 API의 중복 요청 `204 No Content` 정책이 유지되도록 했습니다.

## To Reviewers

- 신고 API 경로와 응답 정책, 유니크 제약조건 및 DDL 변경은 없습니다.
- 다른 도메인의 제약조건 판별 로직과 공통화하지 않고 이슈 범위에 따라 신고 판별기만 수정했습니다.

## References

- #550
- 차단 유니크 키의 동일 문제 수정 커밋: [`f111b939`](https://github.com/Team-WSS/WSS-Server/commit/f111b939463a4893ef2d0556c01abcebeac5a29f)
