### PR TITLE
[REFACTOR] JWT 발급 및 검증 책임 정리

### DIFF
--- a/src/main/java/org/websoso/WSSServer/auth/application/AuthApplication.java
+++ b/src/main/java/org/websoso/WSSServer/auth/application/AuthApplication.java
@@ -3,8 +3,6 @@ package org.websoso.WSSServer.auth.application;
 import static org.websoso.WSSServer.exception.error.CustomAuthError.INVALID_TOKEN;
 
 import io.jsonwebtoken.Claims;
-import java.security.PublicKey;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,11 +17,11 @@ import org.websoso.WSSServer.auth.jwt.JwtProvider;
 import org.websoso.WSSServer.auth.jwt.JwtValidationType;
 import org.websoso.WSSServer.auth.repository.RefreshTokenRepository;
 import org.websoso.WSSServer.auth.client.AppleClient;
+import org.websoso.WSSServer.auth.client.AppleIdTokenVerifier;
 import org.websoso.WSSServer.auth.client.AppleKeyGenerator;
 import org.websoso.WSSServer.auth.service.AppleService;
 import org.websoso.WSSServer.auth.client.KakaoService;
 import org.websoso.WSSServer.auth.service.TokenService;
-import org.websoso.WSSServer.auth.client.dto.ApplePublicKeys;
 import org.websoso.WSSServer.auth.client.dto.KakaoUserInfo;
 import org.websoso.WSSServer.dto.user.LoginResponse;
 import org.websoso.WSSServer.exception.exception.CustomAuthException;
@@ -47,6 +45,7 @@ public class AuthApplication {
     private static final String KAKAO_PREFIX = "kakao";
     private static final String APPLE_PREFIX = "apple";
     private final AppleKeyGenerator appleKeyGenerator;
+    private final AppleIdTokenVerifier appleIdTokenVerifier;
 
     @Transactional
     public ReissueResponse reissue(String refreshToken) {
@@ -93,36 +92,31 @@ public class AuthApplication {
 
     @Transactional
     public AuthResponse loginApple(String authorizationCode, String appleToken) {
-        // 1. 공개키 가져오기 & 헤더 파싱
-        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
-        Map<String, String> headers = jwtProvider.parseAppleTokenHeader(appleToken);
+        // 1. Apple ID Token 검증 (헤더 파싱 + 공개키 조회 + 서명 검증)
+        Claims claims = appleIdTokenVerifier.verify(appleToken);
 
-        // 2. 공개키 생성 및 검증 (서명 확인)
-        PublicKey publicKey = appleKeyGenerator.generatePublicKey(headers, applePublicKeys);
-        Claims claims = jwtProvider.extractClaims(appleToken, publicKey);
-
-        // 3. 애플 서버에서 Refresh Token 받아오기
+        // 2. 애플 서버에서 Refresh Token 받아오기
         String clientSecret = appleKeyGenerator.createClientSecret();
         AppleTokenResponse appleTokenResponse = appleClient.requestAppleToken(authorizationCode, clientSecret);
 
-        // 4. 유저 정보 추출
+        // 3. 유저 정보 추출
         String email = claims.get("email", String.class);
         String userIdentifier = claims.get("sub", String.class);
         String customSocialId = APPLE_PREFIX + "_" + userIdentifier;
         String defaultNickname = APPLE_PREFIX.charAt(0) + "*" + userIdentifier.substring(7, 15);
 
-        // 5. 유저 처리
+        // 4. 유저 처리
         User user = userService.getOrCreateAppleUser(customSocialId, email, defaultNickname);
 
-        // 6. 애플 Refresh Token 저장
+        // 5. 애플 Refresh Token 저장
         appleService.upsertRefreshToken(user, appleTokenResponse.getRefreshToken());
 
-        // 7. Access / Refresh Token 생성
+        // 6. Access / Refresh Token 생성
         CustomAuthenticationToken customAuthenticationToken = CustomAuthenticationToken.create(user.getUserId());
         String accessToken = jwtProvider.generateAccessToken(customAuthenticationToken);
         String refreshToken = jwtProvider.generateRefreshToken(customAuthenticationToken);
 
-        // 8. Refresh Token 저장
+        // 7. Refresh Token 저장
         tokenService.saveRefreshToken(user, refreshToken);
 
         boolean isRegister = !user.isTemporaryNickname();

--- a/src/main/java/org/websoso/WSSServer/auth/client/AppleIdTokenVerifier.java
+++ b/src/main/java/org/websoso/WSSServer/auth/client/AppleIdTokenVerifier.java
@@ -1,0 +1,75 @@
+package org.websoso.WSSServer.auth.client;
+
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.EMPTY_JWT;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.HEADER_PARSING_FAILED;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.INVALID_APPLE_TOKEN_FORMAT;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.JWT_VERIFICATION_FAILED;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.UNSUPPORTED_JWT_TYPE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.UnsupportedJwtException;
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.websoso.WSSServer.auth.client.dto.ApplePublicKeys;
+import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
+
+/**
+ * Apple ID Token(idToken)의 헤더 파싱, 공개키 매칭, 서명 검증을 담당한다.
+ * 서비스 JWT 발급(JwtProvider)과는 별개의 책임이다.
+ */
+@Component
+@RequiredArgsConstructor
+public class AppleIdTokenVerifier {
+
+    private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";
+    private static final int HEADER_INDEX = 0;
+
+    private final AppleClient appleClient;
+    private final AppleKeyGenerator appleKeyGenerator;
+    private final ObjectMapper objectMapper;
+
+    public Claims verify(String appleIdToken) {
+        Map<String, String> header = parseHeader(appleIdToken);
+        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
+        PublicKey publicKey = appleKeyGenerator.generatePublicKey(header, applePublicKeys);
+        return extractClaims(appleIdToken, publicKey);
+    }
+
+    private Map<String, String> parseHeader(String appleIdToken) {
+        try {
+            String encodedHeader = appleIdToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
+            String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
+            return objectMapper.readValue(decodedHeader, Map.class);
+        } catch (JsonMappingException e) {
+            throw new CustomAppleLoginException(INVALID_APPLE_TOKEN_FORMAT,
+                    "make sure the idToken value is in jwt format and that the value is valid");
+        } catch (JsonProcessingException e) {
+            throw new CustomAppleLoginException(HEADER_PARSING_FAILED,
+                    "the decoded header cannot be classified as a Map, please check the header");
+        }
+    }
+
+    private Claims extractClaims(String appleIdToken, PublicKey publicKey) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(appleIdToken)
+                    .getBody();
+        } catch (UnsupportedJwtException e) {
+            throw new CustomAppleLoginException(UNSUPPORTED_JWT_TYPE, "unsupported JWT types");
+        } catch (IllegalArgumentException e) {
+            throw new CustomAppleLoginException(EMPTY_JWT, "empty jwt");
+        } catch (JwtException e) {
+            throw new CustomAppleLoginException(JWT_VERIFICATION_FAILED, "jwt validation or analysis failed");
+        }
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/auth/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/auth/controller/AuthController.java
@@ -21,7 +21,7 @@ import org.websoso.WSSServer.auth.controller.dto.AuthResponse;
 import org.websoso.WSSServer.auth.controller.dto.LogoutRequest;
 import org.websoso.WSSServer.auth.controller.dto.ReissueRequest;
 import org.websoso.WSSServer.auth.controller.dto.ReissueResponse;
-import org.websoso.WSSServer.auth.jwt.JwtProvider;
+import org.websoso.WSSServer.auth.jwt.JWTUtil;
 import org.websoso.WSSServer.auth.service.AppleService;
 import org.websoso.WSSServer.user.domain.User;
 import org.websoso.WSSServer.dto.user.WithdrawalRequest;
@@ -37,7 +37,7 @@ public class AuthController {
     private final AccountApplication accountApplication;
 
     // 애플 로그인 토큰 만료로 인한 임시 의존성 주입
-    private final JwtProvider jwtProvider;
+    private final JWTUtil jwtUtil;
     private final UserRepository userRepository;
 
     // Access Token 재발급
@@ -72,7 +72,7 @@ public class AuthController {
             @RequestHeader(HttpHeaders.AUTHORIZATION) String bearerToken,
             @Valid @RequestBody AppleIdUpdateRequest request
     ) {
-        Long userId = jwtProvider.getUserIdFromToken(bearerToken);
+        Long userId = jwtUtil.getUserIdFromToken(bearerToken);
 
         User user = userRepository.findById(userId).orElse(null);
 

--- a/src/main/java/org/websoso/WSSServer/auth/jwt/JWTUtil.java
+++ b/src/main/java/org/websoso/WSSServer/auth/jwt/JWTUtil.java
@@ -15,18 +15,36 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class JWTUtil {
 
-    private final JwtProvider jwtProvider;
+    private final JwtKeyProvider jwtKeyProvider;
 
     public Long getUserIdFromJwt(String token) {
         Claims claims = getClaim(token);
         return Long.valueOf(claims.get(CLAIM_USER_ID).toString());
     }
 
+    /**
+     * Bearer 접두사를 제거하고, 만료된 토큰이어도 클레임에서 userId를 추출한다.
+     * 그 외 파싱 실패는 모두 null을 반환한다. deprecated /auth/apple/sync 전용.
+     */
+    public Long getUserIdFromToken(String token) {
+        if (token != null && token.startsWith("Bearer ")) {
+            token = token.substring(7);
+        }
+
+        try {
+            Claims claims = getClaim(token);
+            return extractUserId(claims);
+        } catch (ExpiredJwtException e) {
+            return extractUserId(e.getClaims());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     public JwtValidationType validateJWT(String token) {
         try {
             final Claims claims = getClaim(token);
-            String tokenType = claims.getSubject();
-            if (tokenType.equals("access")) {
+            if (TokenType.from(claims.getSubject()) == TokenType.ACCESS) {
                 return JwtValidationType.VALID_ACCESS;
             }
             return JwtValidationType.VALID_REFRESH;
@@ -35,8 +53,7 @@ public class JWTUtil {
         } catch (MalformedJwtException ex) {
             return JwtValidationType.INVALID_TOKEN;
         } catch (ExpiredJwtException ex) {
-            String tokenType = ex.getClaims().getSubject();
-            if (tokenType.equals("access")) {
+            if (TokenType.from(ex.getClaims().getSubject()) == TokenType.ACCESS) {
                 return JwtValidationType.EXPIRED_ACCESS;
             }
             return JwtValidationType.EXPIRED_REFRESH;
@@ -47,9 +64,17 @@ public class JWTUtil {
         }
     }
 
+    private Long extractUserId(Claims claims) {
+        Object userId = claims.get(CLAIM_USER_ID);
+        if (userId instanceof Integer) {
+            return ((Integer) userId).longValue();
+        }
+        return (Long) userId;
+    }
+
     private Claims getClaim(final String token) {
         return Jwts.parserBuilder()
-                .setSigningKey(jwtProvider.getSigningKey())
+                .setSigningKey(jwtKeyProvider.getSigningKey())
                 .build()
                 .parseClaimsJws(token)
                 .getBody();

--- a/src/main/java/org/websoso/WSSServer/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/websoso/WSSServer/auth/jwt/JwtAuthenticationFilter.java
@@ -1,10 +1,6 @@
 package org.websoso.WSSServer.auth.jwt;
 
-import static org.websoso.WSSServer.auth.jwt.JwtValidationType.EXPIRED_ACCESS;
-import static org.websoso.WSSServer.auth.jwt.JwtValidationType.INVALID_SIGNATURE;
-import static org.websoso.WSSServer.auth.jwt.JwtValidationType.INVALID_TOKEN;
-import static org.websoso.WSSServer.auth.jwt.JwtValidationType.VALID_ACCESS;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,6 +17,8 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.websoso.WSSServer.exception.error.CustomAuthError;
+import org.websoso.common.exception.ErrorResult;
 
 @Slf4j
 @Component
@@ -29,6 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final static String TOKEN_PREFIX = "Bearer ";
     private final JWTUtil jwtUtil;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
@@ -38,17 +37,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (StringUtils.hasText(token)) {
             final JwtValidationType validationResult = jwtUtil.validateJWT(token);
-            if (validationResult == VALID_ACCESS) {
-                Long userId = jwtUtil.getUserIdFromJwt(token);
-                CustomAuthenticationToken customAuthenticationToken = new CustomAuthenticationToken(userId, null, null);
-                customAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext().setAuthentication(customAuthenticationToken);
-            } else if (validationResult == EXPIRED_ACCESS) {
-                handleExpiredAccessToken(request, response);
-                return;
-            } else if (validationResult == INVALID_TOKEN || validationResult == INVALID_SIGNATURE) {
-                handleInvalidToken(response);
-                return;
+            switch (validationResult) {
+                case VALID_ACCESS -> {
+                    Long userId = jwtUtil.getUserIdFromJwt(token);
+                    CustomAuthenticationToken customAuthenticationToken =
+                            new CustomAuthenticationToken(userId, null, null);
+                    customAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(customAuthenticationToken);
+                }
+                case EXPIRED_ACCESS -> {
+                    writeError(response, CustomAuthError.ACCESS_TOKEN_EXPIRED);
+                    return;
+                }
+                case VALID_REFRESH, EXPIRED_REFRESH -> {
+                    writeError(response, CustomAuthError.WRONG_TOKEN_TYPE);
+                    return;
+                }
+                case INVALID_TOKEN, INVALID_SIGNATURE, UNSUPPORTED_TOKEN, EMPTY_TOKEN -> {
+                    writeError(response, CustomAuthError.INVALID_TOKEN);
+                    return;
+                }
             }
         } else {
             SecurityContextHolder.getContext().setAuthentication(
@@ -69,18 +77,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return null;
     }
 
-    private void handleExpiredAccessToken(HttpServletRequest request,
-                                          HttpServletResponse response) throws IOException {
+    private void writeError(HttpServletResponse response, CustomAuthError error) throws IOException {
         response.setContentType("application/json");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter()
-                .write("{\"code\": \"AUTH-000\", \"message\": \"Access Token Expired. Use Refresh Token to reissue.\"}");
-    }
-
-    private void handleInvalidToken(HttpServletResponse response) throws IOException {
-        response.setContentType("application/json");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter()
-                .write("{\"code\": \"AUTH-001\", \"message\": \"Invalid token.\"}");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(error.getStatusCode().value());
+        response.getWriter().write(
+                objectMapper.writeValueAsString(new ErrorResult(error.getCode(), error.getDescription())));
     }
 }

--- a/src/main/java/org/websoso/WSSServer/auth/jwt/JwtKeyProvider.java
+++ b/src/main/java/org/websoso/WSSServer/auth/jwt/JwtKeyProvider.java
@@ -1,0 +1,23 @@
+package org.websoso.WSSServer.auth.jwt;
+
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtKeyProvider {
+
+    private final SecretKey signingKey;
+
+    public JwtKeyProvider(@Value("${jwt.secret}") String secret) {
+        String encoded = Base64.getEncoder().encodeToString(secret.getBytes(StandardCharsets.UTF_8));
+        this.signingKey = Keys.hmacShaKeyFor(encoded.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public SecretKey getSigningKey() {
+        return signingKey;
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/auth/jwt/JwtProvider.java
+++ b/src/main/java/org/websoso/WSSServer/auth/jwt/JwtProvider.java
@@ -1,146 +1,55 @@
 package org.websoso.WSSServer.auth.jwt;
 
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.EMPTY_JWT;
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.HEADER_PARSING_FAILED;
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.INVALID_APPLE_TOKEN_FORMAT;
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.JWT_VERIFICATION_FAILED;
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.UNSUPPORTED_JWT_TYPE;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Header;
-import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.UnsupportedJwtException;
-import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.PostConstruct;
-import java.nio.charset.StandardCharsets;
-import java.security.PublicKey;
-import java.util.Base64;
 import java.util.Date;
-import java.util.Map;
-import javax.crypto.SecretKey;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
-import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
 
 @Component
-@RequiredArgsConstructor
 public class JwtProvider {
 
-    protected static final String CLAIM_USER_ID = "userId";
+    public static final String CLAIM_USER_ID = "userId";
 
-    private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";
-    private static final int HEADER_INDEX = 0;
+    private final JwtKeyProvider jwtKeyProvider;
+    private final Long accessTokenExpirationTime;
+    private final Long refreshTokenExpirationTime;
 
-    private final ObjectMapper objectMapper;
-
-    @Value("${jwt.secret}")
-    private String JWT_SECRET_KEY;
-
-    @Value("${jwt.expiration-time.access-token}")
-    private Long ACCESS_TOKEN_EXPIRATION_TIME;
-
-    @Value("${jwt.expiration-time.refresh-token}")
-    private Long REFRESH_TOKEN_EXPIRATION_TIME;
-
-    @PostConstruct
-    protected void init() {
-        JWT_SECRET_KEY = Base64.getEncoder().encodeToString(JWT_SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+    public JwtProvider(JwtKeyProvider jwtKeyProvider,
+                       @Value("${jwt.expiration-time.access-token}") Long accessTokenExpirationTime,
+                       @Value("${jwt.expiration-time.refresh-token}") Long refreshTokenExpirationTime) {
+        this.jwtKeyProvider = jwtKeyProvider;
+        this.accessTokenExpirationTime = accessTokenExpirationTime;
+        this.refreshTokenExpirationTime = refreshTokenExpirationTime;
     }
 
     public String generateAccessToken(Authentication authentication) {
-        return generateJWT(authentication, ACCESS_TOKEN_EXPIRATION_TIME, "access");
+        return generateJWT(authentication, accessTokenExpirationTime, TokenType.ACCESS);
     }
 
     public String generateRefreshToken(Authentication authentication) {
-        return generateJWT(authentication, REFRESH_TOKEN_EXPIRATION_TIME, "refresh");
+        return generateJWT(authentication, refreshTokenExpirationTime, TokenType.REFRESH);
     }
 
-    public String generateJWT(Authentication authentication, Long expirationTime, String tokenType) {
+    String generateJWT(Authentication authentication, Long expirationTime, TokenType tokenType) {
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
                 .setClaims(generateClaims(authentication, expirationTime, tokenType))
-                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .signWith(jwtKeyProvider.getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
     }
 
-    public Long getUserIdFromToken(String token) {
-        if (token != null && token.startsWith("Bearer ")) {
-            token = token.substring(7);
-        }
-
-        try {
-            Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(getSigningKey())
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody();
-
-            return extractUserId(claims);
-
-        } catch (io.jsonwebtoken.ExpiredJwtException e) {
-            return extractUserId(e.getClaims());
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    public Claims extractClaims(String appleToken, PublicKey publicKey) {
-        try {
-            return Jwts.parserBuilder()
-                    .setSigningKey(publicKey)
-                    .build()
-                    .parseClaimsJws(appleToken)
-                    .getBody();
-        } catch (UnsupportedJwtException e) {
-            throw new CustomAppleLoginException(UNSUPPORTED_JWT_TYPE, "unsupported JWT types");
-        } catch (IllegalArgumentException e) {
-            throw new CustomAppleLoginException(EMPTY_JWT, "empty jwt");
-        } catch (JwtException e) {
-            throw new CustomAppleLoginException(JWT_VERIFICATION_FAILED, "jwt validation or analysis failed");
-        }
-    }
-
-    public Map<String, String> parseAppleTokenHeader(String appleToken) {
-        try {
-            String encodedHeader = appleToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
-            String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
-            return objectMapper.readValue(decodedHeader, Map.class);
-        } catch (JsonMappingException e) {
-            throw new CustomAppleLoginException(INVALID_APPLE_TOKEN_FORMAT,
-                    "make sure the idToken value is in jwt format and that the value is valid");
-        } catch (JsonProcessingException e) {
-            throw new CustomAppleLoginException(HEADER_PARSING_FAILED,
-                    "the decoded header cannot be classified as a Map, please check the header");
-        }
-    }
-
-    private Long extractUserId(Claims claims) {
-        Object userId = claims.get(CLAIM_USER_ID);
-        if (userId instanceof Integer) {
-            return ((Integer) userId).longValue();
-        }
-        return (Long) userId;
-    }
-
-    private Claims generateClaims(Authentication authentication, Long expirationTime, String tokenType) {
+    private Claims generateClaims(Authentication authentication, Long expirationTime, TokenType tokenType) {
         long now = System.currentTimeMillis();
         final Claims claims = Jwts.claims()
-                .setSubject(tokenType)
+                .setSubject(tokenType.getValue())
                 .setIssuedAt(new Date(now))
                 .setExpiration(new Date(now + expirationTime));
         claims.put(CLAIM_USER_ID, authentication.getPrincipal());
 
         return claims;
-    }
-
-    protected SecretKey getSigningKey() {
-        return Keys.hmacShaKeyFor(JWT_SECRET_KEY.getBytes());
     }
 }

--- a/src/main/java/org/websoso/WSSServer/auth/jwt/TokenType.java
+++ b/src/main/java/org/websoso/WSSServer/auth/jwt/TokenType.java
@@ -1,0 +1,26 @@
+package org.websoso.WSSServer.auth.jwt;
+
+import java.util.Arrays;
+
+public enum TokenType {
+
+    ACCESS("access"),
+    REFRESH("refresh");
+
+    private final String value;
+
+    TokenType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static TokenType from(String value) {
+        return Arrays.stream(values())
+                .filter(tokenType -> tokenType.value.equals(value))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/auth/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/auth/service/AppleService.java
@@ -1,64 +1,24 @@
 package org.websoso.WSSServer.auth.service;
 
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.CLIENT_SECRET_CREATION_FAILED;
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.EMPTY_JWT;
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.HEADER_PARSING_FAILED;
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.INVALID_APPLE_KEY;
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.INVALID_APPLE_TOKEN_FORMAT;
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.JWT_VERIFICATION_FAILED;
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.PRIVATE_KEY_READ_FAILED;
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.TOKEN_REQUEST_FAILED;
-import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.UNSUPPORTED_JWT_TYPE;
 import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.USER_APPLE_REFRESH_TOKEN_NOT_FOUND;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.JWSSigner;
-import com.nimbusds.jose.crypto.ECDSASigner;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.UnsupportedJwtException;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.math.BigInteger;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.PublicKey;
-import java.security.interfaces.ECPrivateKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.RSAPublicKeySpec;
-import java.util.Base64;
-import java.util.Date;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.bouncycastle.util.io.pem.PemReader;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
-import org.websoso.WSSServer.auth.controller.dto.AppleIdUpdateRequest;
+import org.websoso.WSSServer.auth.client.AppleClient;
+import org.websoso.WSSServer.auth.client.AppleIdTokenVerifier;
+import org.websoso.WSSServer.auth.client.AppleKeyGenerator;
 import org.websoso.WSSServer.auth.client.dto.AppleTokenResponse;
+import org.websoso.WSSServer.auth.controller.dto.AppleIdUpdateRequest;
 import org.websoso.WSSServer.auth.domain.UserAppleToken;
-import org.websoso.WSSServer.auth.jwt.JwtProvider;
-import org.websoso.WSSServer.auth.repository.RefreshTokenRepository;
 import org.websoso.WSSServer.auth.repository.UserAppleTokenRepository;
-import org.websoso.WSSServer.auth.client.dto.ApplePublicKey;
-import org.websoso.WSSServer.auth.client.dto.ApplePublicKeys;
-import org.websoso.WSSServer.user.domain.User;
 import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
-import org.websoso.WSSServer.user.repository.UserRepository;
-import org.websoso.WSSServer.infrastructure.discord.DiscordMessageClient;
+import org.websoso.WSSServer.user.domain.User;
 
 @Transactional
 @Service
@@ -66,45 +26,18 @@ import org.websoso.WSSServer.infrastructure.discord.DiscordMessageClient;
 public class AppleService {
 
     private static final String APPLE_PREFIX = "apple";
-    private static final String CLAIM_EMAIL = "email";
     private static final String CLAIM_SUB = "sub";
-    private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";
-    private static final int HEADER_INDEX = 0;
-    private static final String SIGN_ALGORITHM_HEADER = "alg";
-    private static final String KEY_ID_HEADER = "kid";
-    private static final int POSITIVE_SIGN_NUMBER = 1;
-    private final ObjectMapper objectMapper;
-    private final RefreshTokenRepository refreshTokenRepository;
-    private final UserRepository userRepository;
+
     private final UserAppleTokenRepository userAppleTokenRepository;
-    private final JwtProvider jwtProvider;
-    private final DiscordMessageClient discordMessageClient;
-
-    @Value("${apple.public-keys-url}")
-    private String applePublicKeysUrl;
-
-    @Value("${apple.expiration-time}")
-    private long tokenExpirationTime;
-
-    @Value("${apple.team-id}")
-    private String appleTeamId;
-
-    @Value("${apple.key.id}")
-    private String appleLoginKey;
+    private final AppleClient appleClient;
+    private final AppleKeyGenerator appleKeyGenerator;
+    private final AppleIdTokenVerifier appleIdTokenVerifier;
 
     @Value("${apple.client-id}")
     private String appleClientId;
 
-    @Value("${apple.redirect-url}")
-    private String appleRedirectUrl;
-
-    @Value("${apple.key.path}")
-    private String appleKeyPath;
-
     @Value("${apple.iss}")
     private String appleAuthUrl;
-
-    private final ResourceLoader resourceLoader;
 
     public void upsertRefreshToken(User user, String appleRefreshToken) {
         userAppleTokenRepository.findByUser(user)
@@ -123,7 +56,7 @@ public class AppleService {
         restClient.post()
                 .uri(appleAuthUrl + "/auth/revoke")
                 .headers(headers -> headers.add("Content-Type", "application/x-www-form-urlencoded"))
-                .body(createUserRevokeParams(createClientSecret(), userAppleToken.getAppleRefreshToken()))
+                .body(createUserRevokeParams(appleKeyGenerator.createClientSecret(), userAppleToken.getAppleRefreshToken()))
                 .retrieve()
                 .body(String.class);
 
@@ -146,155 +79,16 @@ public class AppleService {
         }
 
         String appleToken = request.idToken();
-        Map<String, String> appleTokenHeader = parseAppleTokenHeader(appleToken);
-        ApplePublicKeys applePublicKeys = getApplePublicKeys();
-        PublicKey publicKey = generatePublicKeyFromHeaders(appleTokenHeader, applePublicKeys);
-        Claims claims = extractClaims(appleToken, publicKey);
+        Claims claims = appleIdTokenVerifier.verify(appleToken);
 
-        AppleTokenResponse appleTokenResponse = requestAppleToken(request.authorizationCode(), createClientSecret());
+        AppleTokenResponse appleTokenResponse = appleClient.requestAppleToken(request.authorizationCode(),
+                appleKeyGenerator.createClientSecret());
 
         String userIdentifier = claims.get(CLAIM_SUB, String.class);
         String customSocialId = APPLE_PREFIX + "_" + userIdentifier;
 
         user.syncSocialId(customSocialId);
         userAppleToken.syncRefreshToken(appleTokenResponse.getRefreshToken());
-    }
-
-    private Map<String, String> parseAppleTokenHeader(String appleToken) {
-        try {
-            String encodedHeader = appleToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
-            String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
-            return objectMapper.readValue(decodedHeader, Map.class);
-        } catch (JsonMappingException e) {
-            throw new CustomAppleLoginException(INVALID_APPLE_TOKEN_FORMAT,
-                    "make sure the idToken value is in jwt format and that the value is valid");
-        } catch (JsonProcessingException e) {
-            throw new CustomAppleLoginException(HEADER_PARSING_FAILED,
-                    "the decoded header cannot be classified as a Map, please check the header");
-        }
-    }
-
-    private ApplePublicKeys getApplePublicKeys() {
-        RestClient restClient = RestClient.create();
-        return restClient.get()
-                .uri(applePublicKeysUrl)
-                .retrieve()
-                .body(ApplePublicKeys.class);
-    }
-
-    private PublicKey generatePublicKeyFromHeaders(Map<String, String> headers,
-                                                   ApplePublicKeys publicKeys) {
-        ApplePublicKey applePublicKey = publicKeys.getMatchingKey(
-                headers.get(SIGN_ALGORITHM_HEADER),
-                headers.get(KEY_ID_HEADER)
-        );
-        return generatePublicKey(applePublicKey);
-    }
-
-    private PublicKey generatePublicKey(ApplePublicKey applePublicKey) {
-        byte[] nBytes = Base64.getUrlDecoder().decode(applePublicKey.n());
-        byte[] eBytes = Base64.getUrlDecoder().decode(applePublicKey.e());
-
-        BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
-        BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
-        RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(n, e);
-
-        try {
-            KeyFactory keyFactory = KeyFactory.getInstance(applePublicKey.kty());
-            return keyFactory.generatePublic(rsaPublicKeySpec);
-        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
-            throw new CustomAppleLoginException(INVALID_APPLE_KEY, "invalid apple key");
-        }
-    }
-
-    private Claims extractClaims(String appleToken, PublicKey publicKey) {
-        try {
-            return Jwts.parserBuilder()
-                    .setSigningKey(publicKey)
-                    .build()
-                    .parseClaimsJws(appleToken)
-                    .getBody();
-        } catch (UnsupportedJwtException e) {
-            throw new CustomAppleLoginException(UNSUPPORTED_JWT_TYPE, "unsupported JWT types");
-        } catch (IllegalArgumentException e) {
-            throw new CustomAppleLoginException(EMPTY_JWT, "empty jwt");
-        } catch (JwtException e) {
-            throw new CustomAppleLoginException(JWT_VERIFICATION_FAILED, "jwt validation or analysis failed");
-        }
-    }
-
-    private String createClientSecret() {
-        try {
-            JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(appleLoginKey).build();
-            JWTClaimsSet claimsSet = buildJwtClaimsSet();
-
-            SignedJWT jwt = new SignedJWT(header, claimsSet);
-            signJwt(jwt);
-
-            return jwt.serialize();
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new CustomAppleLoginException(CLIENT_SECRET_CREATION_FAILED, "failed to generate client secret");
-        }
-    }
-
-    private JWTClaimsSet buildJwtClaimsSet() {
-        Date now = new Date();
-        JWTClaimsSet claimsSet = new JWTClaimsSet();
-
-        claimsSet.setIssuer(appleTeamId);
-        claimsSet.setIssueTime(now);
-        claimsSet.setExpirationTime(new Date(now.getTime() + tokenExpirationTime));
-        claimsSet.setAudience(appleAuthUrl);
-        claimsSet.setSubject(appleClientId);
-
-        return claimsSet;
-    }
-
-    private void signJwt(SignedJWT jwt) {
-        try {
-            PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(readPrivateKey(appleKeyPath));
-            KeyFactory keyFactory = KeyFactory.getInstance("EC");
-            ECPrivateKey ecPrivateKey = (ECPrivateKey) keyFactory.generatePrivate(spec);
-            JWSSigner signer = new ECDSASigner(ecPrivateKey.getS());
-            jwt.sign(signer);
-        } catch (Exception e) {
-            throw new CustomAppleLoginException(CLIENT_SECRET_CREATION_FAILED, "failed to create client secret");
-        }
-    }
-
-    private byte[] readPrivateKey(String keyPath) {
-        Resource resource = resourceLoader.getResource("file:" + keyPath);
-        try (PemReader pemReader = new PemReader(new InputStreamReader(resource.getInputStream()))) {
-            return pemReader.readPemObject().getContent();
-        } catch (IOException e) {
-            throw new CustomAppleLoginException(PRIVATE_KEY_READ_FAILED, "failed to read private key");
-        }
-    }
-
-    private AppleTokenResponse requestAppleToken(String authorizationCode, String clientSecret) {
-        try {
-            RestClient restClient = RestClient.create();
-            return restClient.post()
-                    .uri(appleAuthUrl + "/auth/token")
-                    .headers(headers -> headers.add("Content-Type", "application/x-www-form-urlencoded"))
-                    .body(createTokenRequestParams(authorizationCode, clientSecret))
-                    .retrieve()
-                    .body(AppleTokenResponse.class);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new CustomAppleLoginException(TOKEN_REQUEST_FAILED, "failed to get token from Apple server");
-        }
-    }
-
-    private MultiValueMap<String, String> createTokenRequestParams(String authorizationCode, String clientSecret) {
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", appleClientId);
-        params.add("client_secret", clientSecret);
-        params.add("code", authorizationCode);
-        params.add("redirect_uri", appleRedirectUrl);
-        return params;
     }
 
     private MultiValueMap<String, String> createUserRevokeParams(String clientSecret, String appleRefreshToken) {

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomAuthError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomAuthError.java
@@ -12,8 +12,10 @@ import org.websoso.common.exception.ICustomError;
 @AllArgsConstructor
 public enum CustomAuthError implements ICustomError {
 
+    ACCESS_TOKEN_EXPIRED("AUTH-000", "Access Token이 만료되었습니다. Refresh Token으로 재발급하세요.", UNAUTHORIZED),
     INVALID_TOKEN("AUTH-001", "유효하지 않은 토큰입니다.", UNAUTHORIZED),
-    UNSUPPORTED_SOCIAL_LOGIN_TYPE("AUTH-002", "지원되지 않는 소셜 로그인 유형입니다.", BAD_REQUEST);
+    UNSUPPORTED_SOCIAL_LOGIN_TYPE("AUTH-002", "지원되지 않는 소셜 로그인 유형입니다.", BAD_REQUEST),
+    WRONG_TOKEN_TYPE("AUTH-003", "잘못된 토큰 유형입니다.", UNAUTHORIZED);
 
     private final String code;
     private final String description;

--- a/src/test/java/org/websoso/WSSServer/auth/jwt/JWTUtilTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/jwt/JWTUtilTest.java
@@ -1,0 +1,102 @@
+package org.websoso.WSSServer.auth.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JWTUtilTest {
+
+    private static final Long USER_ID = 42L;
+
+    private final TestTokenFactory testTokenFactory = new TestTokenFactory();
+    private final JWTUtil jwtUtil = new JWTUtil(new JwtKeyProvider(TestTokenFactory.TEST_SECRET));
+
+    @DisplayName("유효한 Access Token은 VALID_ACCESS를 반환한다")
+    @Test
+    void validateJWT_validAccessToken_returnsValidAccess() {
+        String token = testTokenFactory.createAccessToken(USER_ID);
+
+        assertThat(jwtUtil.validateJWT(token)).isEqualTo(JwtValidationType.VALID_ACCESS);
+    }
+
+    @DisplayName("유효한 Refresh Token은 VALID_REFRESH를 반환한다")
+    @Test
+    void validateJWT_validRefreshToken_returnsValidRefresh() {
+        String token = testTokenFactory.createRefreshToken(USER_ID);
+
+        assertThat(jwtUtil.validateJWT(token)).isEqualTo(JwtValidationType.VALID_REFRESH);
+    }
+
+    @DisplayName("만료된 Access Token은 EXPIRED_ACCESS를 반환한다")
+    @Test
+    void validateJWT_expiredAccessToken_returnsExpiredAccess() {
+        String token = testTokenFactory.createExpiredAccessToken(USER_ID);
+
+        assertThat(jwtUtil.validateJWT(token)).isEqualTo(JwtValidationType.EXPIRED_ACCESS);
+    }
+
+    @DisplayName("만료된 Refresh Token은 EXPIRED_REFRESH를 반환한다")
+    @Test
+    void validateJWT_expiredRefreshToken_returnsExpiredRefresh() {
+        String token = testTokenFactory.createExpiredRefreshToken(USER_ID);
+
+        assertThat(jwtUtil.validateJWT(token)).isEqualTo(JwtValidationType.EXPIRED_REFRESH);
+    }
+
+    @DisplayName("다른 시크릿으로 서명된 토큰은 INVALID_SIGNATURE를 반환한다")
+    @Test
+    void validateJWT_wrongSignature_returnsInvalidSignature() {
+        String token = testTokenFactory.createTokenWithInvalidSignature(USER_ID);
+
+        assertThat(jwtUtil.validateJWT(token)).isEqualTo(JwtValidationType.INVALID_SIGNATURE);
+    }
+
+    @DisplayName("형식이 깨진 토큰 문자열은 INVALID_TOKEN을 반환한다")
+    @Test
+    void validateJWT_malformedToken_returnsInvalidToken() {
+        String token = "not-a-valid-jwt-token";
+
+        assertThat(jwtUtil.validateJWT(token)).isEqualTo(JwtValidationType.INVALID_TOKEN);
+    }
+
+    @DisplayName("서명 없는(alg=none) 토큰은 UNSUPPORTED_TOKEN을 반환한다")
+    @Test
+    void validateJWT_unsignedToken_returnsUnsupportedToken() {
+        String token = Jwts.builder()
+                .setSubject(TokenType.ACCESS.getValue())
+                .claim(JwtProvider.CLAIM_USER_ID, USER_ID)
+                .compact();
+
+        assertThat(jwtUtil.validateJWT(token)).isEqualTo(JwtValidationType.UNSUPPORTED_TOKEN);
+    }
+
+    @DisplayName("빈 토큰은 EMPTY_TOKEN을 반환한다")
+    @Test
+    void validateJWT_emptyToken_returnsEmptyToken() {
+        assertThat(jwtUtil.validateJWT("")).isEqualTo(JwtValidationType.EMPTY_TOKEN);
+    }
+
+    @DisplayName("getUserIdFromJwt는 유효한 토큰에서 userId를 추출한다")
+    @Test
+    void getUserIdFromJwt_validToken_returnsUserId() {
+        String token = testTokenFactory.createAccessToken(USER_ID);
+
+        assertThat(jwtUtil.getUserIdFromJwt(token)).isEqualTo(USER_ID);
+    }
+
+    @DisplayName("getUserIdFromToken은 Bearer 접두사를 제거하고 만료된 토큰이어도 userId를 추출한다")
+    @Test
+    void getUserIdFromToken_expiredToken_stillReturnsUserId() {
+        String token = testTokenFactory.createExpiredAccessToken(USER_ID);
+
+        assertThat(jwtUtil.getUserIdFromToken("Bearer " + token)).isEqualTo(USER_ID);
+    }
+
+    @DisplayName("getUserIdFromToken은 파싱 불가능한 토큰이면 null을 반환한다")
+    @Test
+    void getUserIdFromToken_garbageToken_returnsNull() {
+        assertThat(jwtUtil.getUserIdFromToken("Bearer not-a-valid-jwt-token")).isNull();
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/auth/jwt/JwtAuthenticationFilterRealTokenTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/jwt/JwtAuthenticationFilterRealTokenTest.java
@@ -1,0 +1,97 @@
+package org.websoso.WSSServer.auth.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * TestTokenFactory가 발급한 실제 형식의 토큰이 실제(mock 아닌) JWTUtil/JwtProvider를 거쳐
+ * JwtAuthenticationFilter를 그대로 통과하는지 확인하는 end-to-end 테스트.
+ * Spring 컨텍스트/DB/Redis 없이 순수 자바 객체 조합만으로 동작한다 (issue #556 완료조건:
+ * "발급한 테스트 Access Token을 JWT 인증 필터에 적용할 수 있습니다").
+ */
+class JwtAuthenticationFilterRealTokenTest {
+
+    private static final Long USER_ID = 42L;
+
+    private final TestTokenFactory testTokenFactory = new TestTokenFactory();
+    private final JWTUtil jwtUtil = new JWTUtil(new JwtKeyProvider(TestTokenFactory.TEST_SECRET));
+    private final FilterChain filterChain = mock(FilterChain.class);
+    private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil, new ObjectMapper());
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @DisplayName("실제로 발급한 Access Token은 실제 필터를 통과해 SecurityContext에 인증 정보를 남긴다")
+    @Test
+    void realAccessToken_passesThroughRealFilter() throws Exception {
+        String token = testTokenFactory.createAccessToken(USER_ID);
+
+        MockHttpServletResponse response = doFilter(bearerRequest(token));
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication.getPrincipal()).isEqualTo(USER_ID);
+        assertThat(response.getStatus()).isEqualTo(200);
+        verify(filterChain).doFilter(any(), any());
+    }
+
+    @DisplayName("실제로 발급한 만료 Access Token은 실제 필터에서 401과 AUTH-000으로 차단된다")
+    @Test
+    void realExpiredAccessToken_blockedByRealFilter() throws Exception {
+        String token = testTokenFactory.createExpiredAccessToken(USER_ID);
+
+        MockHttpServletResponse response = doFilter(bearerRequest(token));
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("AUTH-000");
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+
+    @DisplayName("실제로 발급한 Refresh Token으로 인증을 시도하면 실제 필터에서 401과 AUTH-003으로 차단된다")
+    @Test
+    void realRefreshTokenUsedAsAccess_blockedByRealFilter() throws Exception {
+        String token = testTokenFactory.createRefreshToken(USER_ID);
+
+        MockHttpServletResponse response = doFilter(bearerRequest(token));
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("AUTH-003");
+    }
+
+    @DisplayName("변조된 토큰은 실제 필터에서 401과 AUTH-001로 차단된다")
+    @Test
+    void tamperedToken_blockedByRealFilter() throws Exception {
+        String token = testTokenFactory.createAccessToken(USER_ID) + "tampered";
+
+        MockHttpServletResponse response = doFilter(bearerRequest(token));
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("AUTH-001");
+    }
+
+    private MockHttpServletRequest bearerRequest(String token) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        return request;
+    }
+
+    private MockHttpServletResponse doFilter(MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, filterChain);
+        return response;
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/auth/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,122 @@
+package org.websoso.WSSServer.auth.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class JwtAuthenticationFilterTest {
+
+    private static final String TOKEN = "dummy-token";
+
+    private final JWTUtil jwtUtil = mock(JWTUtil.class);
+    private final FilterChain filterChain = mock(FilterChain.class);
+    private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil, new ObjectMapper());
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @DisplayName("유효한 Access Token이면 인증 정보를 설정하고 필터 체인을 계속 진행한다")
+    @Test
+    void validAccessToken_authenticatesAndContinues() throws Exception {
+        given(jwtUtil.validateJWT(TOKEN)).willReturn(JwtValidationType.VALID_ACCESS);
+        given(jwtUtil.getUserIdFromJwt(TOKEN)).willReturn(42L);
+
+        MockHttpServletResponse response = doFilter(bearerRequest(TOKEN));
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication.getPrincipal()).isEqualTo(42L);
+        verify(filterChain).doFilter(any(), any());
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @DisplayName("만료된 Access Token이면 401과 AUTH-000을 응답하고 체인을 중단한다")
+    @Test
+    void expiredAccessToken_returnsAuthTokenExpired() throws Exception {
+        given(jwtUtil.validateJWT(TOKEN)).willReturn(JwtValidationType.EXPIRED_ACCESS);
+
+        MockHttpServletResponse response = doFilter(bearerRequest(TOKEN));
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("AUTH-000");
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+
+    @DisplayName("Refresh Token으로 인증을 시도하면(VALID_REFRESH) 401과 AUTH-003을 응답한다")
+    @Test
+    void validRefreshTokenUsedAsAccess_returnsWrongTokenType() throws Exception {
+        given(jwtUtil.validateJWT(TOKEN)).willReturn(JwtValidationType.VALID_REFRESH);
+
+        MockHttpServletResponse response = doFilter(bearerRequest(TOKEN));
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("AUTH-003");
+    }
+
+    @DisplayName("만료된 Refresh Token으로 인증을 시도해도 401과 AUTH-003을 응답한다")
+    @Test
+    void expiredRefreshTokenUsedAsAccess_returnsWrongTokenType() throws Exception {
+        given(jwtUtil.validateJWT(TOKEN)).willReturn(JwtValidationType.EXPIRED_REFRESH);
+
+        MockHttpServletResponse response = doFilter(bearerRequest(TOKEN));
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("AUTH-003");
+    }
+
+    @DisplayName("변조/미지원/빈 토큰이면 401과 AUTH-001을 응답한다")
+    @Test
+    void tamperedOrUnsupportedToken_returnsInvalidToken() throws Exception {
+        for (JwtValidationType type : new JwtValidationType[]{
+                JwtValidationType.INVALID_TOKEN,
+                JwtValidationType.INVALID_SIGNATURE,
+                JwtValidationType.UNSUPPORTED_TOKEN,
+                JwtValidationType.EMPTY_TOKEN
+        }) {
+            given(jwtUtil.validateJWT(TOKEN)).willReturn(type);
+
+            MockHttpServletResponse response = doFilter(bearerRequest(TOKEN));
+
+            assertThat(response.getStatus()).isEqualTo(401);
+            assertThat(response.getContentAsString()).contains("AUTH-001");
+        }
+    }
+
+    @DisplayName("Authorization 헤더가 없으면 익명 인증으로 설정하고 필터 체인을 계속 진행한다")
+    @Test
+    void noToken_setsAnonymousAuthenticationAndContinues() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        doFilter(request);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isInstanceOf(AnonymousAuthenticationToken.class);
+    }
+
+    private MockHttpServletRequest bearerRequest(String token) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        return request;
+    }
+
+    private MockHttpServletResponse doFilter(MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, filterChain);
+        return response;
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/auth/jwt/JwtProviderTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/jwt/JwtProviderTest.java
@@ -1,0 +1,69 @@
+package org.websoso.WSSServer.auth.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JwtProviderTest {
+
+    private static final Long USER_ID = 42L;
+
+    private final JwtKeyProvider jwtKeyProvider = new JwtKeyProvider(TestTokenFactory.TEST_SECRET);
+    private final JwtProvider jwtProvider = new JwtProvider(jwtKeyProvider,
+            TestTokenFactory.ACCESS_TOKEN_EXPIRATION, TestTokenFactory.REFRESH_TOKEN_EXPIRATION);
+
+    @DisplayName("Access Token 발급 시 sub 클레임은 access, userId 클레임은 전달한 값이다")
+    @Test
+    void generateAccessToken_hasExpectedClaims() {
+        CustomAuthenticationToken authentication = CustomAuthenticationToken.create(USER_ID);
+
+        String token = jwtProvider.generateAccessToken(authentication);
+        Claims claims = parseClaims(token);
+
+        assertThat(claims.getSubject()).isEqualTo("access");
+        assertThat(claims.get(JwtProvider.CLAIM_USER_ID).toString()).isEqualTo(USER_ID.toString());
+    }
+
+    @DisplayName("Refresh Token 발급 시 sub 클레임은 refresh, userId 클레임은 전달한 값이다")
+    @Test
+    void generateRefreshToken_hasExpectedClaims() {
+        CustomAuthenticationToken authentication = CustomAuthenticationToken.create(USER_ID);
+
+        String token = jwtProvider.generateRefreshToken(authentication);
+        Claims claims = parseClaims(token);
+
+        assertThat(claims.getSubject()).isEqualTo("refresh");
+        assertThat(claims.get(JwtProvider.CLAIM_USER_ID).toString()).isEqualTo(USER_ID.toString());
+    }
+
+    @DisplayName("만료 시간이 지난 토큰도 정상적으로 발급되고 클레임에 만료시간이 반영된다")
+    @Test
+    void generateJWT_negativeExpiration_producesAlreadyExpiredToken() {
+        CustomAuthenticationToken authentication = CustomAuthenticationToken.create(USER_ID);
+
+        String token = jwtProvider.generateJWT(authentication, -1_000L, TokenType.ACCESS);
+        Claims claims = parseClaimsIgnoringExpiration(token);
+
+        assertThat(claims.getExpiration()).isBefore(new java.util.Date());
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(jwtKeyProvider.getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private Claims parseClaimsIgnoringExpiration(String token) {
+        try {
+            return parseClaims(token);
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/auth/jwt/TestTokenFactory.java
+++ b/src/test/java/org/websoso/WSSServer/auth/jwt/TestTokenFactory.java
@@ -1,0 +1,39 @@
+package org.websoso.WSSServer.auth.jwt;
+
+public class TestTokenFactory {
+
+    public static final String TEST_SECRET = "test-only-jwt-secret-never-used-in-production-0123456789";
+    public static final long ACCESS_TOKEN_EXPIRATION = 3_600_000L;
+    public static final long REFRESH_TOKEN_EXPIRATION = 1_209_600_000L;
+
+    private final JwtProvider jwtProvider;
+
+    public TestTokenFactory() {
+        this(TEST_SECRET);
+    }
+
+    public TestTokenFactory(String secret) {
+        this.jwtProvider = new JwtProvider(new JwtKeyProvider(secret), ACCESS_TOKEN_EXPIRATION, REFRESH_TOKEN_EXPIRATION);
+    }
+
+    public String createAccessToken(Long userId) {
+        return jwtProvider.generateAccessToken(CustomAuthenticationToken.create(userId));
+    }
+
+    public String createRefreshToken(Long userId) {
+        return jwtProvider.generateRefreshToken(CustomAuthenticationToken.create(userId));
+    }
+
+    public String createExpiredAccessToken(Long userId) {
+        return jwtProvider.generateJWT(CustomAuthenticationToken.create(userId), -1_000L, TokenType.ACCESS);
+    }
+
+    public String createExpiredRefreshToken(Long userId) {
+        return jwtProvider.generateJWT(CustomAuthenticationToken.create(userId), -1_000L, TokenType.REFRESH);
+    }
+
+    public String createTokenWithInvalidSignature(Long userId) {
+        return new TestTokenFactory("a-completely-different-test-secret-not-matching-the-real-one-987654")
+                .createAccessToken(userId);
+    }
+}


### PR DESCRIPTION
## Related Issue
- refactor/#556 -> dev
- close #556

## Key Changes
- JWT 발급 책임을 `JwtProvider`에 집중하고, 서명 키 생성을 `JwtKeyProvider`로 분리했습니다.
- JWT 검증과 사용자 ID 추출 책임을 `JWTUtil`로 정리하고, Access/Refresh 토큰 타입을 `TokenType`으로 명시했습니다.
- Apple ID Token 헤더 파싱, 공개키 조회, 서명 검증 책임을 `AppleIdTokenVerifier`로 분리해 `AppleService`와 `AuthApplication`의 중복 검증 로직을 제거했습니다.
- `JwtAuthenticationFilter`가 JWT 검증 결과별로 `CustomAuthError` 기반 JSON 에러 응답을 반환하도록 정리했습니다.
- 만료된 Access Token과 잘못된 토큰 타입 에러를 `CustomAuthError`에 추가했습니다.
- JWT 발급, 검증, 필터 동작을 검증하는 auth 단위 테스트를 추가했습니다.

## To Reviewers
- auth 단위 테스트 24개는 로컬에서 DB/Redis 의존성 없이 통과했습니다.
- 기존 전체 테스트 스위트 실행 시 이 변경과 무관한 기존 실패만 발생했고, base commit에서도 동일하게 재현되는 것을 확인했습니다.

## References
- #556
