### PR TITLE
[REFACTOR] 기존 사용자 로그인 API Deprecated 전환

### DIFF
--- a/src/main/java/org/websoso/WSSServer/auth/application/AuthApplication.java
+++ b/src/main/java/org/websoso/WSSServer/auth/application/AuthApplication.java
@@ -123,6 +123,11 @@ public class AuthApplication {
     }
 
     // TODO: getUserOrException -> existUserOrException 변경
+    /**
+     * @deprecated 기존 클라이언트 호환을 위해 사용자 ID로 Access Token만 발급합니다.
+     * 신규 클라이언트는 소셜 로그인 후 Access Token 만료 시 {@code POST /reissue}를 사용해야 합니다.
+     */
+    @Deprecated
     @Transactional(readOnly = true)
     public LoginResponse login(Long userId) {
         User user = userService.getUserOrException(userId);

--- a/src/main/java/org/websoso/WSSServer/auth/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/auth/controller/AuthController.java
@@ -23,6 +23,7 @@ import org.websoso.WSSServer.auth.controller.dto.ReissueRequest;
 import org.websoso.WSSServer.auth.controller.dto.ReissueResponse;
 import org.websoso.WSSServer.auth.jwt.JWTUtil;
 import org.websoso.WSSServer.auth.service.AppleService;
+import org.websoso.WSSServer.dto.user.LoginResponse;
 import org.websoso.WSSServer.user.domain.User;
 import org.websoso.WSSServer.dto.user.WithdrawalRequest;
 import org.websoso.WSSServer.application.AccountApplication;
@@ -46,6 +47,14 @@ public class AuthController {
         return ResponseEntity
                 .status(OK)
                 .body(authApplication.reissue(reissueRequest.refreshToken()));
+    }
+
+    @PostMapping("/users/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody String userId) {
+        LoginResponse response = authApplication.login(Long.valueOf(userId));
+        return ResponseEntity
+                .status(OK)
+                .body(response);
     }
 
     @PostMapping("/auth/login/kakao")

--- a/src/main/java/org/websoso/WSSServer/auth/controller/AuthController.java
+++ b/src/main/java/org/websoso/WSSServer/auth/controller/AuthController.java
@@ -49,6 +49,12 @@ public class AuthController {
                 .body(authApplication.reissue(reissueRequest.refreshToken()));
     }
 
+    /**
+     * @deprecated 기존 클라이언트 호환을 위해 사용자 ID로 Access Token만 발급하는 API입니다.
+     * 신규 클라이언트는 소셜 로그인 후 Access Token 만료 시 {@code POST /reissue}를 사용해야 합니다.
+     * 기존 클라이언트의 미사용이 확인되면 별도 이슈에서 제거합니다.
+     */
+    @Deprecated
     @PostMapping("/users/login")
     public ResponseEntity<LoginResponse> login(@RequestBody String userId) {
         LoginResponse response = authApplication.login(Long.valueOf(userId));

--- a/src/main/java/org/websoso/WSSServer/user/controller/UserController.java
+++ b/src/main/java/org/websoso/WSSServer/user/controller/UserController.java
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.websoso.WSSServer.auth.application.AuthApplication;
 import org.websoso.WSSServer.user.domain.User;
 import org.websoso.WSSServer.domain.common.SortCriteria;
 import org.websoso.WSSServer.dto.keyword.KeywordPopularGetResponse;
@@ -29,7 +28,6 @@ import org.websoso.WSSServer.dto.user.PushSettingGetResponse;
 import org.websoso.WSSServer.dto.user.PushSettingRequest;
 import org.websoso.WSSServer.dto.user.EditMyInfoRequest;
 import org.websoso.WSSServer.dto.user.EditProfileStatusRequest;
-import org.websoso.WSSServer.dto.user.LoginResponse;
 import org.websoso.WSSServer.dto.user.MyProfileResponse;
 import org.websoso.WSSServer.dto.user.NicknameValidation;
 import org.websoso.WSSServer.dto.user.ProfileGetResponse;
@@ -58,16 +56,6 @@ public class UserController {
 
     private final UserService userService;
     private final UserNovelService userNovelService;
-    private final AuthApplication authApplication;
-
-    // TODO: AUTH 패키지로 이동해야 함, 그리고 가장 위험한 보안 취약점
-    @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody String userId) {
-        LoginResponse response = authApplication.login(Long.valueOf(userId));
-        return ResponseEntity
-                .status(OK)
-                .body(response);
-    }
 
     // TODO: 닉네임 중복체크를 로그인했을때만 가능하다는게 좀 이상한 것 같기도?
     @GetMapping("/nickname/check")


### PR DESCRIPTION
## Related Issue
- refactor/#558 -> dev
- Closes #558

## Key Changes
- [`de54ce68`](https://github.com/Team-WSS/WSS-Server/pull/576/changes/de54ce68f99ee9740b75a03145db7c8e6a76f24b) 기존 `POST /users/login` 엔드포인트를 사용자 도메인 Controller에서 인증 도메인 Controller로 이동했습니다. 경로와 요청·응답 계약은 그대로 유지합니다.
- [`3274a346`](https://github.com/Team-WSS/WSS-Server/pull/576/changes/3274a346fcf6be2a3da1ff36e34da607b21bf7cd) Controller와 Application의 사용자 ID 기반 Access Token 발급 메서드를 Deprecated 처리하고, 소셜 로그인 후 `POST /reissue`를 사용하는 대체 흐름과 제거 조건을 명시했습니다.

## To Reviewers
- 기존 클라이언트 호환을 위해 해당 API를 제거하거나 호출 차단하지 않았습니다.

## References