### PR TITLE
[REFACTOR] Refresh Token 저장소 접근 책임 정리

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/AccountApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/AccountApplication.java
@@ -10,8 +10,8 @@ import org.websoso.WSSServer.feed.feed.service.FeedServiceImpl;
 import org.websoso.WSSServer.infrastructure.discord.DiscordMessageClient;
 import org.websoso.WSSServer.infrastructure.discord.DiscordWebhookMessage;
 import org.websoso.WSSServer.dto.user.WithdrawalRequest;
-import org.websoso.WSSServer.auth.repository.RefreshTokenRepository;
 import org.websoso.WSSServer.auth.service.AppleService;
+import org.websoso.WSSServer.auth.service.TokenService;
 import org.websoso.WSSServer.auth.client.KakaoClient;
 import org.websoso.WSSServer.user.domain.User;
 import org.websoso.WSSServer.user.domain.WithdrawalReason;
@@ -30,7 +30,7 @@ public class AccountApplication {
     private final DiscordMessageClient discordMessageClient;
     private final AppleService appleService;
     private final UserRepository userRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenService tokenService;
     private final KakaoClient kakaoClient;
     private final CommentServiceImpl commentService;
     private final FeedServiceImpl feedService;
@@ -65,7 +65,7 @@ public class AccountApplication {
     }
 
     private void cleanupUserData(Long userId) {
-        refreshTokenRepository.deleteAll(refreshTokenRepository.findAllByUserId(userId));
+        tokenService.deleteAllRefreshTokensByUserId(userId);
         commentService.updateWriterToUnknown(userId);
         feedService.updateWriterToUnknown(userId);
         userRepository.deleteById(userId);

--- a/src/main/java/org/websoso/WSSServer/auth/service/TokenService.java
+++ b/src/main/java/org/websoso/WSSServer/auth/service/TokenService.java
@@ -43,4 +43,9 @@ public class TokenService {
         refreshTokenRepository.findByRefreshToken(refreshToken)
                 .ifPresent(refreshTokenRepository::delete);
     }
+
+    // 해당 사용자의 모든 리프레시 토큰을 삭제한다. 존재하지 않아도 예외를 던지지 않는다.
+    public void deleteAllRefreshTokensByUserId(Long userId) {
+        refreshTokenRepository.deleteAll(refreshTokenRepository.findAllByUserId(userId));
+    }
 }

--- a/src/main/java/org/websoso/WSSServer/auth/service/TokenService.java
+++ b/src/main/java/org/websoso/WSSServer/auth/service/TokenService.java
@@ -45,6 +45,7 @@ public class TokenService {
     }
 
     // 해당 사용자의 모든 리프레시 토큰을 삭제한다. 존재하지 않아도 예외를 던지지 않는다.
+    @Transactional
     public void deleteAllRefreshTokensByUserId(Long userId) {
         refreshTokenRepository.deleteAll(refreshTokenRepository.findAllByUserId(userId));
     }

--- a/src/test/java/org/websoso/WSSServer/application/AccountApplicationTest.java
+++ b/src/test/java/org/websoso/WSSServer/application/AccountApplicationTest.java
@@ -1,0 +1,69 @@
+package org.websoso.WSSServer.application;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.websoso.WSSServer.auth.client.KakaoClient;
+import org.websoso.WSSServer.auth.service.AppleService;
+import org.websoso.WSSServer.auth.service.TokenService;
+import org.websoso.WSSServer.dto.user.WithdrawalRequest;
+import org.websoso.WSSServer.feed.comment.service.CommentServiceImpl;
+import org.websoso.WSSServer.feed.feed.service.FeedServiceImpl;
+import org.websoso.WSSServer.infrastructure.discord.DiscordMessageClient;
+import org.websoso.WSSServer.user.domain.User;
+import org.websoso.WSSServer.user.repository.UserRepository;
+import org.websoso.WSSServer.user.repository.WithdrawalReasonRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AccountApplicationTest {
+
+    private static final Long USER_ID = 1L;
+
+    @InjectMocks
+    private AccountApplication accountApplication;
+
+    @Mock
+    private WithdrawalReasonRepository withdrawalReasonRepository;
+
+    @Mock
+    private DiscordMessageClient discordMessageClient;
+
+    @Mock
+    private AppleService appleService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private KakaoClient kakaoClient;
+
+    @Mock
+    private CommentServiceImpl commentService;
+
+    @Mock
+    private FeedServiceImpl feedService;
+
+    @Mock
+    private User user;
+
+    @DisplayName("회원 탈퇴 시 탈퇴한 사용자의 리프레시 토큰 정리를 토큰 서비스에 위임한다")
+    @Test
+    void delegatesRefreshTokenCleanupOnWithdraw() {
+        given(user.getSocialId()).willReturn("kakao_1234");
+        given(user.getUserId()).willReturn(USER_ID);
+
+        accountApplication.withdrawUser(user, new WithdrawalRequest("탈퇴 사유"));
+
+        then(tokenService).should().deleteAllRefreshTokensByUserId(USER_ID);
+        then(userRepository).should().deleteById(USER_ID);
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/auth/service/TokenServiceTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/service/TokenServiceTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.never;
 import static org.websoso.WSSServer.exception.error.CustomAuthError.INVALID_TOKEN;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +28,7 @@ import org.websoso.WSSServer.user.domain.User;
 class TokenServiceTest {
 
     private static final Long USER_ID = 1L;
+    private static final Long OTHER_USER_ID = 2L;
     private static final String REFRESH_TOKEN = "refresh-token-value";
 
     @InjectMocks
@@ -105,5 +109,36 @@ class TokenServiceTest {
         tokenService.deleteRefreshToken(REFRESH_TOKEN);
 
         then(refreshTokenRepository).should(never()).delete(ArgumentMatchers.any());
+    }
+
+    @DisplayName("대상 사용자의 리프레시 토큰만 모두 삭제하고 다른 사용자의 토큰은 유지한다")
+    @Test
+    void deletesAllRefreshTokensOfGivenUserOnly() {
+        RefreshToken firstDeviceToken = new RefreshToken(REFRESH_TOKEN, USER_ID);
+        RefreshToken secondDeviceToken = new RefreshToken("another-device-token", USER_ID);
+        RefreshToken otherUserToken = new RefreshToken("other-user-token", OTHER_USER_ID);
+        List<RefreshToken> stored = new ArrayList<>(List.of(firstDeviceToken, secondDeviceToken, otherUserToken));
+        given(refreshTokenRepository.findAllByUserId(USER_ID)).willAnswer(invocation -> stored.stream()
+                .filter(token -> token.getUserId().equals(invocation.getArgument(0)))
+                .toList());
+        willAnswer(invocation -> {
+            Iterable<RefreshToken> deleted = invocation.getArgument(0);
+            deleted.forEach(stored::remove);
+            return null;
+        }).given(refreshTokenRepository).deleteAll(ArgumentMatchers.any());
+
+        tokenService.deleteAllRefreshTokensByUserId(USER_ID);
+
+        assertThat(stored).containsExactly(otherUserToken);
+    }
+
+    @DisplayName("리프레시 토큰이 없는 사용자의 전체 삭제 요청도 예외 없이 처리한다")
+    @Test
+    void ignoresDeletingAllRefreshTokensOfUserWithoutToken() {
+        given(refreshTokenRepository.findAllByUserId(USER_ID)).willReturn(List.of());
+
+        tokenService.deleteAllRefreshTokensByUserId(USER_ID);
+
+        then(refreshTokenRepository).should().deleteAll(List.of());
     }
 }


### PR DESCRIPTION
## Related Issue
- refactor/#571 -> dev
- Closes #571

## Key Changes
- `TokenService`에 사용자 ID 기준 전체 Refresh Token 삭제 기능을 추가하고, Repository 조회·삭제 책임을 한곳으로 모았습니다. ([`0ba29ded`](https://github.com/Team-WSS/WSS-Server/commit/0ba29dedba47187b30343fc4a13d858eba49bea7))
- `AccountApplication`의 `RefreshTokenRepository` 직접 의존을 제거하고 회원 탈퇴 데이터 정리 과정에서 `TokenService`에 토큰 삭제를 위임합니다. ([`0ba29ded`](https://github.com/Team-WSS/WSS-Server/commit/0ba29dedba47187b30343fc4a13d858eba49bea7))
- 대상 사용자의 토큰만 삭제되는지와 회원 탈퇴 호출 경로에서 토큰 정리가 위임되는지를 단위 테스트로 검증합니다. ([`0ba29ded`](https://github.com/Team-WSS/WSS-Server/commit/0ba29dedba47187b30343fc4a13d858eba49bea7))
- 기존 `TokenService`의 Repository 접근 메서드와 일관되게 사용자별 전체 삭제 메서드에도 `@Transactional`을 명시했습니다. ([`e0cd5213`](https://github.com/Team-WSS/WSS-Server/commit/e0cd52132c3a52af0b034930b96b6725654da6d9))

## To Reviewers
- 회원 탈퇴 시 신규 `TokenService` 메서드는 기존 `AccountApplication` 트랜잭션에 참여하며, 단독 호출에서도 클래스의 기존 메서드와 동일한 트랜잭션 경계를 가집니다.
- Refresh Token 재발급 동시성 제어(#572), 키, TTL, 회원 탈퇴의 다른 정리 순서는 변경하지 않았습니다.
- DB 제약조건 및 배포 설정 변경은 없습니다.

## References
- #557