### PR TITLE
[TEST] 인증 Controller 테스트에 Access Token 적용 기반 마련

### DIFF
--- a/src/test/java/org/websoso/WSSServer/auth/controller/AuthControllerLogoutAuthenticationTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/controller/AuthControllerLogoutAuthenticationTest.java
@@ -1,0 +1,117 @@
+package org.websoso.WSSServer.auth.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.accessToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.refreshToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.tamperedAccessToken;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.websoso.WSSServer.application.AccountApplication;
+import org.websoso.WSSServer.auth.application.AuthApplication;
+import org.websoso.WSSServer.auth.controller.dto.LogoutRequest;
+import org.websoso.WSSServer.auth.service.AppleService;
+import org.websoso.WSSServer.support.auth.AuthenticatedControllerTest;
+import org.websoso.WSSServer.user.domain.User;
+import org.websoso.WSSServer.user.repository.UserRepository;
+import org.websoso.WSSServer.user.service.UserService;
+
+/**
+ * 실제 JwtAuthenticationFilter / JWTUtil을 통과하는 인증 Controller 요청 대표 테스트.
+ * 인증에 성공하면 토큰의 userId가 CustomUserArgumentResolver를 거쳐
+ * {@code @AuthenticationPrincipal User}로 전달되는 흐름까지 검증한다.
+ */
+@AuthenticatedControllerTest(AuthController.class)
+class AuthControllerLogoutAuthenticationTest {
+
+    private static final Long USER_ID = 42L;
+    private static final LogoutRequest LOGOUT_REQUEST = new LogoutRequest("refresh-token", "device-identifier");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private AuthApplication authApplication;
+
+    @MockBean
+    private AppleService appleService;
+
+    @MockBean
+    private AccountApplication accountApplication;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    private final User loginUser = mock(User.class);
+
+    @BeforeEach
+    void setUp() {
+        given(userService.getUserOrException(USER_ID)).willReturn(loginUser);
+    }
+
+    @DisplayName("유효한 Access Token 요청은 실제 JWT 필터를 통과하고 토큰의 사용자로 로그아웃된다")
+    @Test
+    void logoutWithValidAccessToken() throws Exception {
+        mockMvc.perform(logoutRequest().with(accessToken(USER_ID)))
+                .andExpect(status().isNoContent());
+
+        then(userService).should().getUserOrException(USER_ID);
+        then(authApplication).should().logout(loginUser, LOGOUT_REQUEST);
+    }
+
+    @DisplayName("Authorization 헤더가 없으면 401로 거부된다")
+    @Test
+    void logoutWithoutAuthorizationHeader() throws Exception {
+        mockMvc.perform(logoutRequest())
+                .andExpect(status().isUnauthorized());
+
+        then(authApplication).should(never()).logout(any(), any());
+    }
+
+    @DisplayName("변조된 Access Token 요청은 401과 INVALID_TOKEN으로 거부된다")
+    @Test
+    void logoutWithTamperedAccessToken() throws Exception {
+        mockMvc.perform(logoutRequest().with(tamperedAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string(containsString("AUTH-001")));
+
+        then(authApplication).should(never()).logout(any(), any());
+    }
+
+    @DisplayName("Refresh Token으로 인증을 시도하면 401과 WRONG_TOKEN_TYPE으로 거부된다")
+    @Test
+    void logoutWithRefreshToken() throws Exception {
+        mockMvc.perform(logoutRequest().with(refreshToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string(containsString("AUTH-003")));
+
+        then(authApplication).should(never()).logout(any(), any());
+    }
+
+    private MockHttpServletRequestBuilder logoutRequest() throws Exception {
+        return post("/auth/logout")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(LOGOUT_REQUEST));
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/support/ControllerTestApplication.java
+++ b/src/test/java/org/websoso/WSSServer/support/ControllerTestApplication.java
@@ -1,0 +1,26 @@
+package org.websoso.WSSServer.support;
+
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.TypeExcludeFilter;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+
+/**
+ * Controller 슬라이스 테스트 전용 구성 진입점.
+ * 프로덕션 진입점({@code WssServerApplication})은 JPA/Redis Repository 등록과 스케줄링을 함께 켜기 때문에
+ * 웹 계층 테스트에서도 Redis 인프라 빈을 요구한다. 이 클래스는 컴포넌트 스캔 범위만 동일하게 유지하고
+ * 외부 연동(JPA, Redis, 스케줄링) 활성화는 제외해, 슬라이스 테스트가 실제 Redis/DB 없이 뜨게 한다.
+ */
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@ComponentScan(
+        basePackages = {"org.websoso.WSSServer", "org.websoso.support", "org.websoso.common"},
+        excludeFilters = {
+                @Filter(type = FilterType.CUSTOM, classes = TypeExcludeFilter.class),
+                @Filter(type = FilterType.CUSTOM, classes = AutoConfigurationExcludeFilter.class)
+        })
+public class ControllerTestApplication {
+}

--- a/src/test/java/org/websoso/WSSServer/support/auth/AuthenticatedControllerTest.java
+++ b/src/test/java/org/websoso/WSSServer/support/auth/AuthenticatedControllerTest.java
@@ -1,0 +1,44 @@
+package org.websoso.WSSServer.support.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.websoso.WSSServer.auth.jwt.CustomAccessDeniedHandler;
+import org.websoso.WSSServer.auth.jwt.CustomJwtAuthenticationEntryPoint;
+import org.websoso.WSSServer.config.SecurityConfig;
+import org.websoso.WSSServer.support.ControllerTestApplication;
+
+/**
+ * 실제 {@code JwtAuthenticationFilter}, {@code JWTUtil}, {@code JwtKeyProvider},
+ * {@code CustomUserArgumentResolver}를 통과하는 MockMvc Controller 테스트용 애너테이션.
+ * 테스트 대상 Controller만 지정하면 되고, 토큰은 {@link TestBearerToken}으로 요청에 적용한다.
+ *
+ * <pre>
+ * &#64;AuthenticatedControllerTest(AuthController.class)
+ * class AuthControllerLogoutAuthenticationTest { ... }
+ * </pre>
+ *
+ * 사용자 조회({@code UserService})와 Controller가 의존하는 Application/Service는
+ * 테스트에서 {@code @MockBean}으로 격리한다. JWT Secret과 만료 시간은
+ * {@link ControllerAuthTestConfig}가 제공하므로 application-*.yml이 필요 없다.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@WebMvcTest
+@ContextConfiguration(classes = ControllerTestApplication.class)
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, CustomJwtAuthenticationEntryPoint.class, CustomAccessDeniedHandler.class,
+        ControllerAuthTestConfig.class})
+public @interface AuthenticatedControllerTest {
+
+    @AliasFor(annotation = WebMvcTest.class, attribute = "controllers")
+    Class<?>[] value() default {};
+}

--- a/src/test/java/org/websoso/WSSServer/support/auth/ControllerAuthTestConfig.java
+++ b/src/test/java/org/websoso/WSSServer/support/auth/ControllerAuthTestConfig.java
@@ -1,0 +1,27 @@
+package org.websoso.WSSServer.support.auth;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.websoso.WSSServer.auth.jwt.JWTUtil;
+import org.websoso.WSSServer.auth.jwt.JwtKeyProvider;
+import org.websoso.WSSServer.auth.jwt.TestTokenFactory;
+
+/**
+ * Controller 테스트에서 실제 JWT 검증 구성을 사용하기 위한 테스트 전용 구성.
+ * 프로덕션 {@code jwt.secret} 프로퍼티 대신 {@link TestTokenFactory#TEST_SECRET}으로
+ * {@link JwtKeyProvider}를 만들어, application-*.yml 없이도 실제 {@link JWTUtil}과
+ * {@code JwtAuthenticationFilter}가 동작하게 한다.
+ */
+@TestConfiguration
+public class ControllerAuthTestConfig {
+
+    @Bean
+    public JwtKeyProvider jwtKeyProvider() {
+        return new JwtKeyProvider(TestTokenFactory.TEST_SECRET);
+    }
+
+    @Bean
+    public JWTUtil jwtUtil(JwtKeyProvider jwtKeyProvider) {
+        return new JWTUtil(jwtKeyProvider);
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/support/auth/TestBearerToken.java
+++ b/src/test/java/org/websoso/WSSServer/support/auth/TestBearerToken.java
@@ -1,0 +1,41 @@
+package org.websoso.WSSServer.support.auth;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.websoso.WSSServer.auth.jwt.TestTokenFactory;
+
+/**
+ * MockMvc 요청에 {@link TestTokenFactory}가 발급한 실제 형식의 토큰을
+ * {@code Authorization: Bearer ...} 헤더로 적용하는 공통 도구.
+ *
+ * <pre>
+ * mockMvc.perform(post("/auth/logout").with(TestBearerToken.accessToken(USER_ID)))
+ * </pre>
+ */
+public final class TestBearerToken {
+
+    private static final String TOKEN_PREFIX = "Bearer ";
+    private static final TestTokenFactory TOKEN_FACTORY = new TestTokenFactory();
+
+    private TestBearerToken() {
+    }
+
+    public static RequestPostProcessor accessToken(Long userId) {
+        return bearer(TOKEN_FACTORY.createAccessToken(userId));
+    }
+
+    public static RequestPostProcessor refreshToken(Long userId) {
+        return bearer(TOKEN_FACTORY.createRefreshToken(userId));
+    }
+
+    public static RequestPostProcessor tamperedAccessToken(Long userId) {
+        return bearer(TOKEN_FACTORY.createAccessToken(userId) + "tampered");
+    }
+
+    public static RequestPostProcessor bearer(String token) {
+        return request -> {
+            request.addHeader(HttpHeaders.AUTHORIZATION, TOKEN_PREFIX + token);
+            return request;
+        };
+    }
+}


### PR DESCRIPTION
## Related Issue
- test/#574 -> dev
- Closes #574

## Key Changes
- 실제 `TestTokenFactory`, `JWTUtil`, `JwtAuthenticationFilter`를 사용하는 재사용 가능한 MockMvc 인증 테스트 구성을 추가했습니다.
- Access Token, Refresh Token, 변조 토큰을 Bearer 헤더에 적용하는 공통 요청 도구를 추가했습니다.
- `AuthController.logout`을 대표 대상으로 유효한 Access Token과 `CustomUserArgumentResolver`의 User 변환, 헤더 없음, 변조 토큰, Refresh Token 요청을 검증했습니다.

## To Reviewers
- 후속 Controller 테스트에서 `@AuthenticatedControllerTest`와 `TestBearerToken`을 재사용하는 구조가 적절한지 확인 부탁드립니다.

## References
- #554