### PR TITLE
[REFACTOR] Apple 외부 연동 책임 정리

### DIFF
--- a/src/main/java/org/websoso/WSSServer/auth/application/AuthApplication.java
+++ b/src/main/java/org/websoso/WSSServer/auth/application/AuthApplication.java
@@ -2,11 +2,9 @@ package org.websoso.WSSServer.auth.application;
 
 import static org.websoso.WSSServer.exception.error.CustomAuthError.INVALID_TOKEN;
 
-import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.websoso.WSSServer.auth.client.dto.AppleTokenResponse;
 import org.websoso.WSSServer.auth.controller.dto.AuthResponse;
 import org.websoso.WSSServer.auth.controller.dto.LogoutRequest;
 import org.websoso.WSSServer.auth.controller.dto.ReissueResponse;
@@ -15,12 +13,10 @@ import org.websoso.WSSServer.auth.jwt.CustomAuthenticationToken;
 import org.websoso.WSSServer.auth.jwt.JWTUtil;
 import org.websoso.WSSServer.auth.jwt.JwtProvider;
 import org.websoso.WSSServer.auth.jwt.JwtValidationType;
-import org.websoso.WSSServer.auth.client.AppleClient;
-import org.websoso.WSSServer.auth.client.AppleIdTokenVerifier;
-import org.websoso.WSSServer.auth.client.AppleKeyGenerator;
 import org.websoso.WSSServer.auth.service.AppleService;
 import org.websoso.WSSServer.auth.client.KakaoClient;
 import org.websoso.WSSServer.auth.service.TokenService;
+import org.websoso.WSSServer.auth.service.dto.AppleAuthResult;
 import org.websoso.WSSServer.auth.client.dto.KakaoUserInfo;
 import org.websoso.WSSServer.dto.user.LoginResponse;
 import org.websoso.WSSServer.exception.exception.CustomAuthException;
@@ -39,11 +35,8 @@ public class AuthApplication {
     private final UserService userService;
     private final KakaoClient kakaoClient;
     private final AppleService appleService;
-    private final AppleClient appleClient;
     private static final String KAKAO_PREFIX = "kakao";
     private static final String APPLE_PREFIX = "apple";
-    private final AppleKeyGenerator appleKeyGenerator;
-    private final AppleIdTokenVerifier appleIdTokenVerifier;
 
     @Transactional
     public ReissueResponse reissue(String refreshToken) {
@@ -90,31 +83,26 @@ public class AuthApplication {
 
     @Transactional
     public AuthResponse loginApple(String authorizationCode, String appleToken) {
-        // 1. Apple ID Token 검증 (헤더 파싱 + 공개키 조회 + 서명 검증)
-        Claims claims = appleIdTokenVerifier.verify(appleToken);
+        // 1. Apple 인증 (ID Token 검증 + Authorization Code 교환)
+        AppleAuthResult appleAuthResult = appleService.authenticate(authorizationCode, appleToken);
 
-        // 2. 애플 서버에서 Refresh Token 받아오기
-        String clientSecret = appleKeyGenerator.createClientSecret();
-        AppleTokenResponse appleTokenResponse = appleClient.requestAppleToken(authorizationCode, clientSecret);
-
-        // 3. 유저 정보 추출
-        String email = claims.get("email", String.class);
-        String userIdentifier = claims.get("sub", String.class);
+        // 2. 유저 정보 추출
+        String userIdentifier = appleAuthResult.userIdentifier();
         String customSocialId = APPLE_PREFIX + "_" + userIdentifier;
         String defaultNickname = APPLE_PREFIX.charAt(0) + "*" + userIdentifier.substring(7, 15);
 
-        // 4. 유저 처리
-        User user = userService.getOrCreateAppleUser(customSocialId, email, defaultNickname);
+        // 3. 유저 처리
+        User user = userService.getOrCreateAppleUser(customSocialId, appleAuthResult.email(), defaultNickname);
 
-        // 5. 애플 Refresh Token 저장
-        appleService.upsertRefreshToken(user, appleTokenResponse.getRefreshToken());
+        // 4. 애플 Refresh Token 저장
+        appleService.upsertRefreshToken(user, appleAuthResult.appleRefreshToken());
 
-        // 6. Access / Refresh Token 생성
+        // 5. Access / Refresh Token 생성
         CustomAuthenticationToken customAuthenticationToken = CustomAuthenticationToken.create(user.getUserId());
         String accessToken = jwtProvider.generateAccessToken(customAuthenticationToken);
         String refreshToken = jwtProvider.generateRefreshToken(customAuthenticationToken);
 
-        // 7. Refresh Token 저장
+        // 6. Refresh Token 저장
         tokenService.saveRefreshToken(user, refreshToken);
 
         boolean isRegister = !user.isTemporaryNickname();

--- a/src/main/java/org/websoso/WSSServer/auth/client/AppleClient.java
+++ b/src/main/java/org/websoso/WSSServer/auth/client/AppleClient.java
@@ -1,20 +1,50 @@
 package org.websoso.WSSServer.auth.client;
 
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.PUBLIC_KEY_REQUEST_FAILED;
 import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.TOKEN_REQUEST_FAILED;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.TOKEN_REVOKE_FAILED;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
-import org.websoso.WSSServer.auth.client.dto.AppleTokenResponse;
+import org.springframework.web.client.RestClientException;
 import org.websoso.WSSServer.auth.client.dto.ApplePublicKeys;
+import org.websoso.WSSServer.auth.client.dto.AppleTokenResponse;
+import org.websoso.WSSServer.exception.error.CustomAppleLoginError;
 import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AppleClient {
+
+    private static final String TOKEN_PATH = "/auth/token";
+    private static final String REVOKE_PATH = "/auth/revoke";
+    private static final String GRANT_TYPE = "grant_type";
+    private static final String GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code";
+    private static final String GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
+    private static final String CLIENT_ID = "client_id";
+    private static final String CLIENT_SECRET = "client_secret";
+    private static final String CODE = "code";
+    private static final String REDIRECT_URI = "redirect_uri";
+    private static final String TOKEN = "token";
+    private static final String TOKEN_TYPE_HINT = "token_type_hint";
+
+    private static final String PUBLIC_KEY_REQUEST = "public key request";
+    private static final String TOKEN_REQUEST = "token request";
+    private static final String TOKEN_REVOKE = "token revoke";
+
+    private final RestClient appleRestClient;
 
     @Value("${apple.public-keys-url}")
     private String applePublicKeysUrl;
@@ -25,42 +55,90 @@ public class AppleClient {
     @Value("${apple.redirect-url}")
     private String appleRedirectUrl;
 
-
     @Value("${apple.iss}")
     private String appleAuthUrl;
 
     // 애플 공개키 목록 가져오기
     public ApplePublicKeys getApplePublicKeys() {
-        return RestClient.create()
-                .get()
-                .uri(applePublicKeysUrl)
-                .retrieve()
-                .body(ApplePublicKeys.class);
+        try {
+            return appleRestClient
+                    .get()
+                    .uri(applePublicKeysUrl)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (request, response) ->
+                            handleErrorResponse(PUBLIC_KEY_REQUEST_FAILED, PUBLIC_KEY_REQUEST, response))
+                    .body(ApplePublicKeys.class);
+        } catch (RestClientException e) {
+            throw convert(PUBLIC_KEY_REQUEST_FAILED, PUBLIC_KEY_REQUEST, e);
+        }
     }
 
     // Authorization Code로 토큰 발급 요청
     public AppleTokenResponse requestAppleToken(String authorizationCode, String clientSecret) {
         try {
-            return RestClient.create()
+            return appleRestClient
                     .post()
-                    .uri(appleAuthUrl + "/auth/token")
-                    .headers(headers -> headers.add("Content-Type", "application/x-www-form-urlencoded"))
+                    .uri(appleAuthUrl + TOKEN_PATH)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                     .body(createTokenRequestParams(authorizationCode, clientSecret))
                     .retrieve()
+                    .onStatus(HttpStatusCode::isError, (request, response) ->
+                            handleErrorResponse(TOKEN_REQUEST_FAILED, TOKEN_REQUEST, response))
                     .body(AppleTokenResponse.class);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new CustomAppleLoginException(TOKEN_REQUEST_FAILED, "failed to get token from Apple server");
+        } catch (RestClientException e) {
+            throw convert(TOKEN_REQUEST_FAILED, TOKEN_REQUEST, e);
+        }
+    }
+
+    // Apple Refresh Token 폐기 요청
+    public void revokeAppleToken(String clientSecret, String appleRefreshToken) {
+        try {
+            appleRestClient
+                    .post()
+                    .uri(appleAuthUrl + REVOKE_PATH)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                    .body(createRevokeRequestParams(clientSecret, appleRefreshToken))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, (request, response) ->
+                            handleErrorResponse(TOKEN_REVOKE_FAILED, TOKEN_REVOKE, response))
+                    .toBodilessEntity();
+        } catch (RestClientException e) {
+            throw convert(TOKEN_REVOKE_FAILED, TOKEN_REVOKE, e);
         }
     }
 
     private MultiValueMap<String, String> createTokenRequestParams(String authorizationCode, String clientSecret) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", appleClientId);
-        params.add("client_secret", clientSecret);
-        params.add("code", authorizationCode);
-        params.add("redirect_uri", appleRedirectUrl);
+        params.add(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE);
+        params.add(CLIENT_ID, appleClientId);
+        params.add(CLIENT_SECRET, clientSecret);
+        params.add(CODE, authorizationCode);
+        params.add(REDIRECT_URI, appleRedirectUrl);
         return params;
+    }
+
+    private MultiValueMap<String, String> createRevokeRequestParams(String clientSecret, String appleRefreshToken) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add(GRANT_TYPE, GRANT_TYPE_REFRESH_TOKEN);
+        params.add(CLIENT_ID, appleClientId);
+        params.add(CLIENT_SECRET, clientSecret);
+        params.add(TOKEN, appleRefreshToken);
+        params.add(TOKEN_TYPE_HINT, GRANT_TYPE_REFRESH_TOKEN);
+        return params;
+    }
+
+    private void handleErrorResponse(CustomAppleLoginError error, String operation, ClientHttpResponse response)
+            throws IOException {
+        log.error("apple {} failed: status={}, body={}", operation, response.getStatusCode(), readBody(response));
+        throw new CustomAppleLoginException(error, "apple " + operation + " failed");
+    }
+
+    private String readBody(ClientHttpResponse response) throws IOException {
+        return new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    private CustomAppleLoginException convert(CustomAppleLoginError error, String operation, RestClientException e) {
+        log.error("apple {} failed: error={}", operation, e.getMessage(), e);
+        return new CustomAppleLoginException(error, "apple " + operation + " failed");
     }
 }

--- a/src/main/java/org/websoso/WSSServer/auth/client/AppleKeyGenerator.java
+++ b/src/main/java/org/websoso/WSSServer/auth/client/AppleKeyGenerator.java
@@ -4,6 +4,7 @@ import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.CLIENT
 import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.INVALID_APPLE_KEY;
 import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.PRIVATE_KEY_READ_FAILED;
 
+import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
@@ -24,6 +25,7 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.util.io.pem.PemReader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
@@ -33,6 +35,7 @@ import org.websoso.WSSServer.auth.client.dto.ApplePublicKey;
 import org.websoso.WSSServer.auth.client.dto.ApplePublicKeys;
 import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AppleKeyGenerator {
@@ -93,7 +96,8 @@ public class AppleKeyGenerator {
             signJwt(jwt);
 
             return jwt.serialize();
-        } catch (Exception e) {
+        } catch (IllegalStateException e) {
+            log.error("apple client secret creation failed: error={}", e.getMessage(), e);
             throw new CustomAppleLoginException(CLIENT_SECRET_CREATION_FAILED, "failed to generate client secret");
         }
     }
@@ -111,6 +115,7 @@ public class AppleKeyGenerator {
         return claimsSet;
     }
 
+    // 프라이빗 키 읽기 실패(PRIVATE_KEY_READ_FAILED)도 기존 계약대로 클라이언트 시크릿 생성 실패로 응답한다.
     private void signJwt(SignedJWT jwt) {
         try {
             PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(readPrivateKey(appleKeyPath));
@@ -118,7 +123,9 @@ public class AppleKeyGenerator {
             ECPrivateKey ecPrivateKey = (ECPrivateKey) keyFactory.generatePrivate(spec);
             JWSSigner signer = new ECDSASigner(ecPrivateKey.getS());
             jwt.sign(signer);
-        } catch (Exception e) {
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException | JOSEException | ClassCastException
+                 | CustomAppleLoginException e) {
+            log.error("apple client secret signing failed: error={}", e.getMessage(), e);
             throw new CustomAppleLoginException(CLIENT_SECRET_CREATION_FAILED, "failed to create client secret");
         }
     }

--- a/src/main/java/org/websoso/WSSServer/auth/service/AppleService.java
+++ b/src/main/java/org/websoso/WSSServer/auth/service/AppleService.java
@@ -4,12 +4,8 @@ import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.USER_A
 
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClient;
 import org.websoso.WSSServer.auth.client.AppleClient;
 import org.websoso.WSSServer.auth.client.AppleIdTokenVerifier;
 import org.websoso.WSSServer.auth.client.AppleKeyGenerator;
@@ -17,28 +13,44 @@ import org.websoso.WSSServer.auth.client.dto.AppleTokenResponse;
 import org.websoso.WSSServer.auth.controller.dto.AppleIdUpdateRequest;
 import org.websoso.WSSServer.auth.domain.UserAppleToken;
 import org.websoso.WSSServer.auth.repository.UserAppleTokenRepository;
+import org.websoso.WSSServer.auth.service.dto.AppleAuthResult;
 import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
 import org.websoso.WSSServer.user.domain.User;
 
-@Transactional
 @Service
 @RequiredArgsConstructor
 public class AppleService {
 
     private static final String APPLE_PREFIX = "apple";
     private static final String CLAIM_SUB = "sub";
+    private static final String CLAIM_EMAIL = "email";
 
     private final UserAppleTokenRepository userAppleTokenRepository;
     private final AppleClient appleClient;
     private final AppleKeyGenerator appleKeyGenerator;
     private final AppleIdTokenVerifier appleIdTokenVerifier;
 
-    @Value("${apple.client-id}")
-    private String appleClientId;
+    /**
+     * Apple ID Token을 검증하고 Authorization Code를 Apple Refresh Token으로 교환한다.
+     *
+     * @param authorizationCode Apple Authorization Code
+     * @param appleIdToken      Apple ID Token
+     * @return Apple 인증 결과
+     */
+    public AppleAuthResult authenticate(String authorizationCode, String appleIdToken) {
+        Claims claims = appleIdTokenVerifier.verify(appleIdToken);
 
-    @Value("${apple.iss}")
-    private String appleAuthUrl;
+        String clientSecret = appleKeyGenerator.createClientSecret();
+        AppleTokenResponse appleTokenResponse = appleClient.requestAppleToken(authorizationCode, clientSecret);
 
+        return AppleAuthResult.of(
+                claims.get(CLAIM_SUB, String.class),
+                claims.get(CLAIM_EMAIL, String.class),
+                appleTokenResponse.getRefreshToken()
+        );
+    }
+
+    @Transactional
     public void upsertRefreshToken(User user, String appleRefreshToken) {
         userAppleTokenRepository.findByUser(user)
                 .ifPresentOrElse(
@@ -47,18 +59,13 @@ public class AppleService {
                 );
     }
 
+    @Transactional
     public void unlinkFromApple(User user) {
         UserAppleToken userAppleToken = userAppleTokenRepository.findByUser(user).orElseThrow(
                 () -> new CustomAppleLoginException(USER_APPLE_REFRESH_TOKEN_NOT_FOUND,
                         "cannot find the user Apple refresh token"));
 
-        RestClient restClient = RestClient.create();
-        restClient.post()
-                .uri(appleAuthUrl + "/auth/revoke")
-                .headers(headers -> headers.add("Content-Type", "application/x-www-form-urlencoded"))
-                .body(createUserRevokeParams(appleKeyGenerator.createClientSecret(), userAppleToken.getAppleRefreshToken()))
-                .retrieve()
-                .body(String.class);
+        appleClient.revokeAppleToken(appleKeyGenerator.createClientSecret(), userAppleToken.getAppleRefreshToken());
 
         userAppleTokenRepository.delete(userAppleToken);
     }
@@ -69,6 +76,7 @@ public class AppleService {
      * @param user    User
      * @param request AppleIdUpdateRequest
      */
+    @Transactional
     public void syncSocialId(User user, AppleIdUpdateRequest request) {
 
         UserAppleToken userAppleToken = userAppleTokenRepository.findByUser(user)
@@ -78,26 +86,11 @@ public class AppleService {
             return;
         }
 
-        String appleToken = request.idToken();
-        Claims claims = appleIdTokenVerifier.verify(appleToken);
+        AppleAuthResult appleAuthResult = authenticate(request.authorizationCode(), request.idToken());
 
-        AppleTokenResponse appleTokenResponse = appleClient.requestAppleToken(request.authorizationCode(),
-                appleKeyGenerator.createClientSecret());
-
-        String userIdentifier = claims.get(CLAIM_SUB, String.class);
-        String customSocialId = APPLE_PREFIX + "_" + userIdentifier;
+        String customSocialId = APPLE_PREFIX + "_" + appleAuthResult.userIdentifier();
 
         user.syncSocialId(customSocialId);
-        userAppleToken.syncRefreshToken(appleTokenResponse.getRefreshToken());
-    }
-
-    private MultiValueMap<String, String> createUserRevokeParams(String clientSecret, String appleRefreshToken) {
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "refresh_token");
-        params.add("client_id", appleClientId);
-        params.add("client_secret", clientSecret);
-        params.add("token", appleRefreshToken);
-        params.add("token_type_hint", "refresh_token");
-        return params;
+        userAppleToken.syncRefreshToken(appleAuthResult.appleRefreshToken());
     }
 }

--- a/src/main/java/org/websoso/WSSServer/auth/service/dto/AppleAuthResult.java
+++ b/src/main/java/org/websoso/WSSServer/auth/service/dto/AppleAuthResult.java
@@ -1,0 +1,15 @@
+package org.websoso.WSSServer.auth.service.dto;
+
+/**
+ * Apple 인증(ID Token 검증 + Authorization Code 교환) 결과를 Application 계층에 전달하는 내부 DTO이다.
+ */
+public record AppleAuthResult(
+        String userIdentifier,
+        String email,
+        String appleRefreshToken
+) {
+
+    public static AppleAuthResult of(String userIdentifier, String email, String appleRefreshToken) {
+        return new AppleAuthResult(userIdentifier, email, appleRefreshToken);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/config/AppleRestClientConfig.java
+++ b/src/main/java/org/websoso/WSSServer/config/AppleRestClientConfig.java
@@ -1,0 +1,25 @@
+package org.websoso.WSSServer.config;
+
+import java.time.Duration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class AppleRestClientConfig {
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(5);
+
+    @Bean
+    public RestClient appleRestClient() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(CONNECT_TIMEOUT);
+        factory.setReadTimeout(READ_TIMEOUT);
+
+        return RestClient.builder()
+                .requestFactory(factory)
+                .build();
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/exception/error/CustomAppleLoginError.java
+++ b/src/main/java/org/websoso/WSSServer/exception/error/CustomAppleLoginError.java
@@ -22,7 +22,9 @@ public enum CustomAppleLoginError implements ICustomError {
     EMPTY_JWT("APPLE-007", "비어있는 jwt입니다.", BAD_REQUEST),
     JWT_VERIFICATION_FAILED("APPLE-008", "jwt 검증 또는 분석에 실패했습니다.", INTERNAL_SERVER_ERROR),
     INVALID_APPLE_KEY("APPLE-009", "잘못된 애플 키입니다.", INTERNAL_SERVER_ERROR),
-    USER_APPLE_REFRESH_TOKEN_NOT_FOUND("APPLE-010", "유저의 애플 리프레시 토큰을 찾을 수 없습니다.", NOT_FOUND);
+    USER_APPLE_REFRESH_TOKEN_NOT_FOUND("APPLE-010", "유저의 애플 리프레시 토큰을 찾을 수 없습니다.", NOT_FOUND),
+    PUBLIC_KEY_REQUEST_FAILED("APPLE-011", "Apple 서버로부터 공개키를 받아오지 못했습니다.", INTERNAL_SERVER_ERROR),
+    TOKEN_REVOKE_FAILED("APPLE-012", "Apple 서버의 토큰 폐기에 실패했습니다.", INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String description;

--- a/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationAppleLoginTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationAppleLoginTest.java
@@ -1,0 +1,109 @@
+package org.websoso.WSSServer.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.TOKEN_REQUEST_FAILED;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.websoso.WSSServer.auth.client.KakaoClient;
+import org.websoso.WSSServer.auth.controller.dto.AuthResponse;
+import org.websoso.WSSServer.auth.jwt.JWTUtil;
+import org.websoso.WSSServer.auth.jwt.JwtProvider;
+import org.websoso.WSSServer.auth.service.AppleService;
+import org.websoso.WSSServer.auth.service.TokenService;
+import org.websoso.WSSServer.auth.service.dto.AppleAuthResult;
+import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
+import org.websoso.WSSServer.notification.service.UserDeviceService;
+import org.websoso.WSSServer.user.domain.User;
+import org.websoso.WSSServer.user.service.UserService;
+
+@ExtendWith(MockitoExtension.class)
+class AuthApplicationAppleLoginTest {
+
+    private static final String AUTHORIZATION_CODE = "apple-authorization-code";
+    private static final String ID_TOKEN = "apple-id-token";
+    private static final String APPLE_REFRESH_TOKEN = "apple-refresh-token";
+    private static final String USER_IDENTIFIER = "001234.abcdefghijklmn.1234";
+    private static final String EMAIL = "websoso@websoso.org";
+    private static final String EXPECTED_SOCIAL_ID = "apple_" + USER_IDENTIFIER;
+    private static final String EXPECTED_DEFAULT_NICKNAME = "a*" + "abcdefgh";
+    private static final String ACCESS_TOKEN = "access-token-value";
+    private static final String REFRESH_TOKEN = "refresh-token-value";
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private JWTUtil jwtUtil;
+
+    @Mock
+    private UserDeviceService userDeviceService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private KakaoClient kakaoClient;
+
+    @Mock
+    private AppleService appleService;
+
+    @Mock
+    private User user;
+
+    private AuthApplication authApplication;
+
+    @BeforeEach
+    void setUp() {
+        authApplication = new AuthApplication(tokenService, jwtProvider, jwtUtil, userDeviceService,
+                userService, kakaoClient, appleService);
+    }
+
+    @DisplayName("애플 로그인에 성공하면 Apple 인증 결과로 유저를 조회·생성하고 토큰을 발급한다")
+    @Test
+    void loginApple_success() {
+        given(appleService.authenticate(AUTHORIZATION_CODE, ID_TOKEN))
+                .willReturn(AppleAuthResult.of(USER_IDENTIFIER, EMAIL, APPLE_REFRESH_TOKEN));
+        given(userService.getOrCreateAppleUser(EXPECTED_SOCIAL_ID, EMAIL, EXPECTED_DEFAULT_NICKNAME))
+                .willReturn(user);
+        given(jwtProvider.generateAccessToken(any())).willReturn(ACCESS_TOKEN);
+        given(jwtProvider.generateRefreshToken(any())).willReturn(REFRESH_TOKEN);
+        given(user.isTemporaryNickname()).willReturn(false);
+
+        AuthResponse response = authApplication.loginApple(AUTHORIZATION_CODE, ID_TOKEN);
+
+        assertThat(response.Authorization()).isEqualTo(ACCESS_TOKEN);
+        assertThat(response.refreshToken()).isEqualTo(REFRESH_TOKEN);
+        assertThat(response.isRegister()).isTrue();
+        then(appleService).should().upsertRefreshToken(user, APPLE_REFRESH_TOKEN);
+        then(tokenService).should().saveRefreshToken(user, REFRESH_TOKEN);
+    }
+
+    @DisplayName("Apple 인증이 실패하면 유저 처리와 토큰 저장을 수행하지 않고 예외를 전파한다")
+    @Test
+    void loginApple_authenticationFailed() {
+        given(appleService.authenticate(AUTHORIZATION_CODE, ID_TOKEN))
+                .willThrow(new CustomAppleLoginException(TOKEN_REQUEST_FAILED, "apple token request failed"));
+
+        assertThatThrownBy(() -> authApplication.loginApple(AUTHORIZATION_CODE, ID_TOKEN))
+                .isInstanceOf(CustomAppleLoginException.class)
+                .extracting(throwable -> ((CustomAppleLoginException) throwable).getICustomError())
+                .isEqualTo(TOKEN_REQUEST_FAILED);
+
+        then(userService).should(never())
+                .getOrCreateAppleUser(EXPECTED_SOCIAL_ID, EMAIL, EXPECTED_DEFAULT_NICKNAME);
+        then(tokenService).should(never()).saveRefreshToken(user, REFRESH_TOKEN);
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationLogoutTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationLogoutTest.java
@@ -9,9 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.websoso.WSSServer.auth.client.AppleClient;
-import org.websoso.WSSServer.auth.client.AppleIdTokenVerifier;
-import org.websoso.WSSServer.auth.client.AppleKeyGenerator;
 import org.websoso.WSSServer.auth.client.KakaoClient;
 import org.websoso.WSSServer.auth.controller.dto.LogoutRequest;
 import org.websoso.WSSServer.auth.jwt.JWTUtil;
@@ -50,15 +47,6 @@ class AuthApplicationLogoutTest {
     private AppleService appleService;
 
     @Mock
-    private AppleClient appleClient;
-
-    @Mock
-    private AppleKeyGenerator appleKeyGenerator;
-
-    @Mock
-    private AppleIdTokenVerifier appleIdTokenVerifier;
-
-    @Mock
     private User user;
 
     private AuthApplication authApplication;
@@ -66,7 +54,7 @@ class AuthApplicationLogoutTest {
     @BeforeEach
     void setUp() {
         authApplication = new AuthApplication(tokenService, jwtProvider, jwtUtil, userDeviceService,
-                userService, kakaoClient, appleService, appleClient, appleKeyGenerator, appleIdTokenVerifier);
+                userService, kakaoClient, appleService);
     }
 
     @DisplayName("로그아웃하면 요청에 담긴 리프레시 토큰을 삭제하고 UserDeviceService로 디바이스 식별자를 삭제한다")

--- a/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationReissueRotationTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationReissueRotationTest.java
@@ -17,9 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.websoso.WSSServer.auth.client.AppleClient;
-import org.websoso.WSSServer.auth.client.AppleIdTokenVerifier;
-import org.websoso.WSSServer.auth.client.AppleKeyGenerator;
 import org.websoso.WSSServer.auth.client.KakaoClient;
 import org.websoso.WSSServer.auth.controller.dto.ReissueResponse;
 import org.websoso.WSSServer.auth.domain.RefreshToken;
@@ -67,15 +64,6 @@ class AuthApplicationReissueRotationTest {
     private AppleService appleService;
 
     @Mock
-    private AppleClient appleClient;
-
-    @Mock
-    private AppleKeyGenerator appleKeyGenerator;
-
-    @Mock
-    private AppleIdTokenVerifier appleIdTokenVerifier;
-
-    @Mock
     private User user;
 
     private TokenService tokenService;
@@ -98,7 +86,7 @@ class AuthApplicationReissueRotationTest {
 
         tokenService = new TokenService(refreshTokenRepository);
         authApplication = new AuthApplication(tokenService, jwtProvider, jwtUtil, userDeviceService,
-                userService, kakaoClient, appleService, appleClient, appleKeyGenerator, appleIdTokenVerifier);
+                userService, kakaoClient, appleService);
     }
 
     @DisplayName("재발급에 성공하면 기존 리프레시 토큰은 저장소에서 사라져 다시 재발급에 사용할 수 없다")

--- a/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationReissueTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationReissueTest.java
@@ -16,9 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.websoso.WSSServer.auth.client.AppleClient;
-import org.websoso.WSSServer.auth.client.AppleIdTokenVerifier;
-import org.websoso.WSSServer.auth.client.AppleKeyGenerator;
 import org.websoso.WSSServer.auth.client.KakaoClient;
 import org.websoso.WSSServer.auth.controller.dto.ReissueResponse;
 import org.websoso.WSSServer.auth.domain.RefreshToken;
@@ -58,21 +55,12 @@ class AuthApplicationReissueTest {
     @Mock
     private AppleService appleService;
 
-    @Mock
-    private AppleClient appleClient;
-
-    @Mock
-    private AppleKeyGenerator appleKeyGenerator;
-
-    @Mock
-    private AppleIdTokenVerifier appleIdTokenVerifier;
-
     private AuthApplication authApplication;
 
     @BeforeEach
     void setUp() {
         authApplication = new AuthApplication(tokenService, jwtProvider, jwtUtil, userDeviceService,
-                userService, kakaoClient, appleService, appleClient, appleKeyGenerator, appleIdTokenVerifier);
+                userService, kakaoClient, appleService);
     }
 
     @DisplayName("유효한 리프레시 토큰이면 Access/Refresh Token을 모두 재발급하고 기존 토큰을 회전한다")

--- a/src/test/java/org/websoso/WSSServer/auth/client/AppleClientTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/client/AppleClientTest.java
@@ -1,0 +1,190 @@
+package org.websoso.WSSServer.auth.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.PUBLIC_KEY_REQUEST_FAILED;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.TOKEN_REQUEST_FAILED;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.TOKEN_REVOKE_FAILED;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+import org.websoso.WSSServer.auth.client.dto.ApplePublicKeys;
+import org.websoso.WSSServer.auth.client.dto.AppleTokenResponse;
+import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
+
+class AppleClientTest {
+
+    private static final String PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
+    private static final String APPLE_AUTH_URL = "https://appleid.apple.com";
+    private static final String TOKEN_URL = APPLE_AUTH_URL + "/auth/token";
+    private static final String REVOKE_URL = APPLE_AUTH_URL + "/auth/revoke";
+    private static final String CLIENT_ID = "org.websoso.app";
+    private static final String REDIRECT_URL = "https://websoso.org/apple/callback";
+    private static final String AUTHORIZATION_CODE = "apple-authorization-code";
+    private static final String CLIENT_SECRET = "apple-client-secret";
+    private static final String APPLE_REFRESH_TOKEN = "apple-refresh-token";
+
+    private MockRestServiceServer mockServer;
+    private AppleClient appleClient;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+
+        appleClient = new AppleClient(builder.build());
+        ReflectionTestUtils.setField(appleClient, "applePublicKeysUrl", PUBLIC_KEYS_URL);
+        ReflectionTestUtils.setField(appleClient, "appleAuthUrl", APPLE_AUTH_URL);
+        ReflectionTestUtils.setField(appleClient, "appleClientId", CLIENT_ID);
+        ReflectionTestUtils.setField(appleClient, "appleRedirectUrl", REDIRECT_URL);
+    }
+
+    @DisplayName("공개키 조회에 성공하면 애플 공개키 목록을 반환한다")
+    @Test
+    void getApplePublicKeys_success() {
+        mockServer.expect(requestTo(PUBLIC_KEYS_URL))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("""
+                        {
+                          "keys": [
+                            {"kty": "RSA", "kid": "test-kid", "alg": "RS256", "n": "test-n", "e": "AQAB"}
+                          ]
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
+
+        assertThat(applePublicKeys.keys()).hasSize(1);
+        assertThat(applePublicKeys.getMatchingKey("RS256", "test-kid").n()).isEqualTo("test-n");
+        mockServer.verify();
+    }
+
+    @DisplayName("공개키 조회가 5xx로 실패하면 공개키 요청 실패 예외가 발생한다")
+    @Test
+    void getApplePublicKeys_serverError() {
+        mockServer.expect(requestTo(PUBLIC_KEYS_URL))
+                .andRespond(withServerError());
+
+        assertThatThrownBy(() -> appleClient.getApplePublicKeys())
+                .isInstanceOf(CustomAppleLoginException.class)
+                .hasMessage("apple public key request failed")
+                .extracting(throwable -> ((CustomAppleLoginException) throwable).getICustomError())
+                .isEqualTo(PUBLIC_KEY_REQUEST_FAILED);
+        mockServer.verify();
+    }
+
+    @DisplayName("토큰 교환에 성공하면 애플 토큰 응답을 반환한다")
+    @Test
+    void requestAppleToken_success() {
+        mockServer.expect(requestTo(TOKEN_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_FORM_URLENCODED))
+                .andExpect(content().string("grant_type=authorization_code"
+                        + "&client_id=" + CLIENT_ID
+                        + "&client_secret=" + CLIENT_SECRET
+                        + "&code=" + AUTHORIZATION_CODE
+                        + "&redirect_uri=https%3A%2F%2Fwebsoso.org%2Fapple%2Fcallback"))
+                .andRespond(withSuccess("""
+                        {
+                          "access_token": "apple-access-token",
+                          "expires_in": "3600",
+                          "id_token": "apple-id-token",
+                          "refresh_token": "apple-refresh-token",
+                          "token_type": "bearer"
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        AppleTokenResponse response = appleClient.requestAppleToken(AUTHORIZATION_CODE, CLIENT_SECRET);
+
+        assertThat(response.getRefreshToken()).isEqualTo(APPLE_REFRESH_TOKEN);
+        assertThat(response.getIdToken()).isEqualTo("apple-id-token");
+        mockServer.verify();
+    }
+
+    @DisplayName("토큰 교환이 4xx로 실패하면 토큰 요청 실패 예외가 발생한다")
+    @Test
+    void requestAppleToken_clientError() {
+        mockServer.expect(requestTo(TOKEN_URL))
+                .andRespond(withStatus(HttpStatus.BAD_REQUEST)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"error\": \"invalid_grant\"}"));
+
+        assertThatThrownBy(() -> appleClient.requestAppleToken(AUTHORIZATION_CODE, CLIENT_SECRET))
+                .isInstanceOf(CustomAppleLoginException.class)
+                .hasMessage("apple token request failed")
+                .extracting(throwable -> ((CustomAppleLoginException) throwable).getICustomError())
+                .isEqualTo(TOKEN_REQUEST_FAILED);
+        mockServer.verify();
+    }
+
+    @DisplayName("토큰 교환이 5xx로 실패하면 토큰 요청 실패 예외가 발생한다")
+    @Test
+    void requestAppleToken_serverError() {
+        mockServer.expect(requestTo(TOKEN_URL))
+                .andRespond(withServerError());
+
+        assertThatThrownBy(() -> appleClient.requestAppleToken(AUTHORIZATION_CODE, CLIENT_SECRET))
+                .isInstanceOf(CustomAppleLoginException.class)
+                .extracting(throwable -> ((CustomAppleLoginException) throwable).getICustomError())
+                .isEqualTo(TOKEN_REQUEST_FAILED);
+        mockServer.verify();
+    }
+
+    @DisplayName("토큰 폐기 요청은 form body를 담아 전송한다")
+    @Test
+    void revokeAppleToken_success() {
+        mockServer.expect(requestTo(REVOKE_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_FORM_URLENCODED))
+                .andExpect(content().string("grant_type=refresh_token"
+                        + "&client_id=" + CLIENT_ID
+                        + "&client_secret=" + CLIENT_SECRET
+                        + "&token=" + APPLE_REFRESH_TOKEN
+                        + "&token_type_hint=refresh_token"))
+                .andRespond(withSuccess());
+
+        appleClient.revokeAppleToken(CLIENT_SECRET, APPLE_REFRESH_TOKEN);
+
+        mockServer.verify();
+    }
+
+    @DisplayName("토큰 폐기가 4xx로 실패하면 토큰 폐기 실패 예외가 발생한다")
+    @Test
+    void revokeAppleToken_clientError() {
+        mockServer.expect(requestTo(REVOKE_URL))
+                .andRespond(withStatus(HttpStatus.BAD_REQUEST));
+
+        assertThatThrownBy(() -> appleClient.revokeAppleToken(CLIENT_SECRET, APPLE_REFRESH_TOKEN))
+                .isInstanceOf(CustomAppleLoginException.class)
+                .hasMessage("apple token revoke failed")
+                .extracting(throwable -> ((CustomAppleLoginException) throwable).getICustomError())
+                .isEqualTo(TOKEN_REVOKE_FAILED);
+        mockServer.verify();
+    }
+
+    @DisplayName("토큰 폐기가 5xx로 실패하면 토큰 폐기 실패 예외가 발생한다")
+    @Test
+    void revokeAppleToken_serverError() {
+        mockServer.expect(requestTo(REVOKE_URL))
+                .andRespond(withServerError());
+
+        assertThatThrownBy(() -> appleClient.revokeAppleToken(CLIENT_SECRET, APPLE_REFRESH_TOKEN))
+                .isInstanceOf(CustomAppleLoginException.class)
+                .extracting(throwable -> ((CustomAppleLoginException) throwable).getICustomError())
+                .isEqualTo(TOKEN_REVOKE_FAILED);
+        mockServer.verify();
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/auth/client/AppleKeyGeneratorTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/client/AppleKeyGeneratorTest.java
@@ -1,0 +1,101 @@
+package org.websoso.WSSServer.auth.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.CLIENT_SECRET_CREATION_FAILED;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Base64;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
+
+class AppleKeyGeneratorTest {
+
+    private static final String APPLE_LOGIN_KEY = "test-key-id";
+    private static final String APPLE_TEAM_ID = "test-team-id";
+    private static final String APPLE_CLIENT_ID = "org.websoso.app";
+    private static final String APPLE_AUTH_URL = "https://appleid.apple.com";
+    private static final long EXPIRATION_TIME = 3600000L;
+
+    @TempDir
+    Path tempDir;
+
+    private AppleKeyGenerator appleKeyGenerator;
+
+    @BeforeEach
+    void setUp() {
+        appleKeyGenerator = new AppleKeyGenerator(new DefaultResourceLoader());
+        ReflectionTestUtils.setField(appleKeyGenerator, "appleLoginKey", APPLE_LOGIN_KEY);
+        ReflectionTestUtils.setField(appleKeyGenerator, "tokenExpirationTime", EXPIRATION_TIME);
+        ReflectionTestUtils.setField(appleKeyGenerator, "appleTeamId", APPLE_TEAM_ID);
+        ReflectionTestUtils.setField(appleKeyGenerator, "appleClientId", APPLE_CLIENT_ID);
+        ReflectionTestUtils.setField(appleKeyGenerator, "appleAuthUrl", APPLE_AUTH_URL);
+    }
+
+    @DisplayName("프라이빗 키 파일을 읽을 수 없으면 클라이언트 시크릿 생성 실패 예외로 변환된다")
+    @Test
+    void createClientSecret_privateKeyReadFailed() {
+        ReflectionTestUtils.setField(appleKeyGenerator, "appleKeyPath",
+                tempDir.resolve("not-exist.p8").toString());
+
+        assertThatThrownBy(() -> appleKeyGenerator.createClientSecret())
+                .isInstanceOf(CustomAppleLoginException.class)
+                .extracting(throwable -> ((CustomAppleLoginException) throwable).getICustomError())
+                .isEqualTo(CLIENT_SECRET_CREATION_FAILED);
+    }
+
+    @DisplayName("프라이빗 키 형식이 잘못되면 클라이언트 시크릿 생성 실패 예외로 변환된다")
+    @Test
+    void createClientSecret_invalidPrivateKeyFormat() throws IOException {
+        Path invalidKey = tempDir.resolve("invalid.p8");
+        Files.writeString(invalidKey, """
+                -----BEGIN PRIVATE KEY-----
+                bm90LWEtdmFsaWQtcHJpdmF0ZS1rZXk=
+                -----END PRIVATE KEY-----
+                """);
+        ReflectionTestUtils.setField(appleKeyGenerator, "appleKeyPath", invalidKey.toString());
+
+        assertThatThrownBy(() -> appleKeyGenerator.createClientSecret())
+                .isInstanceOf(CustomAppleLoginException.class)
+                .extracting(throwable -> ((CustomAppleLoginException) throwable).getICustomError())
+                .isEqualTo(CLIENT_SECRET_CREATION_FAILED);
+    }
+
+    @DisplayName("유효한 프라이빗 키로 서명된 클라이언트 시크릿을 생성한다")
+    @Test
+    void createClientSecret_success() throws IOException, NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+        Path validKey = tempDir.resolve("valid.p8");
+        Files.writeString(validKey, toPrivateKeyPem(generateEcKeyPair()));
+        ReflectionTestUtils.setField(appleKeyGenerator, "appleKeyPath", validKey.toString());
+
+        String clientSecret = appleKeyGenerator.createClientSecret();
+
+        assertThat(clientSecret.split("\\.")).hasSize(3);
+    }
+
+    private KeyPair generateEcKeyPair() throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC");
+        keyPairGenerator.initialize(new ECGenParameterSpec("secp256r1"));
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private String toPrivateKeyPem(KeyPair keyPair) {
+        String encoded = Base64.getMimeEncoder(64, System.lineSeparator().getBytes())
+                .encodeToString(keyPair.getPrivate().getEncoded());
+        return "-----BEGIN PRIVATE KEY-----" + System.lineSeparator()
+                + encoded + System.lineSeparator()
+                + "-----END PRIVATE KEY-----" + System.lineSeparator();
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/auth/service/AppleServiceTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/service/AppleServiceTest.java
@@ -1,0 +1,191 @@
+package org.websoso.WSSServer.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.TOKEN_REQUEST_FAILED;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.TOKEN_REVOKE_FAILED;
+import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.USER_APPLE_REFRESH_TOKEN_NOT_FOUND;
+
+import io.jsonwebtoken.Claims;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.websoso.WSSServer.auth.client.AppleClient;
+import org.websoso.WSSServer.auth.client.AppleIdTokenVerifier;
+import org.websoso.WSSServer.auth.client.AppleKeyGenerator;
+import org.websoso.WSSServer.auth.client.dto.AppleTokenResponse;
+import org.websoso.WSSServer.auth.controller.dto.AppleIdUpdateRequest;
+import org.websoso.WSSServer.auth.domain.UserAppleToken;
+import org.websoso.WSSServer.auth.repository.UserAppleTokenRepository;
+import org.websoso.WSSServer.auth.service.dto.AppleAuthResult;
+import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
+import org.websoso.WSSServer.user.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+class AppleServiceTest {
+
+    private static final String AUTHORIZATION_CODE = "apple-authorization-code";
+    private static final String ID_TOKEN = "apple-id-token";
+    private static final String CLIENT_SECRET = "apple-client-secret";
+    private static final String APPLE_REFRESH_TOKEN = "apple-refresh-token";
+    private static final String USER_IDENTIFIER = "001234.abcdefghijklmn.1234";
+    private static final String EMAIL = "websoso@websoso.org";
+
+    @Mock
+    private UserAppleTokenRepository userAppleTokenRepository;
+
+    @Mock
+    private AppleClient appleClient;
+
+    @Mock
+    private AppleKeyGenerator appleKeyGenerator;
+
+    @Mock
+    private AppleIdTokenVerifier appleIdTokenVerifier;
+
+    @Mock
+    private Claims claims;
+
+    @Mock
+    private User user;
+
+    @InjectMocks
+    private AppleService appleService;
+
+    @DisplayName("Apple 인증에 성공하면 ID Token 검증 결과와 Apple Refresh Token을 담아 반환한다")
+    @Test
+    void authenticate_success() {
+        given(appleIdTokenVerifier.verify(ID_TOKEN)).willReturn(claims);
+        given(claims.get("sub", String.class)).willReturn(USER_IDENTIFIER);
+        given(claims.get("email", String.class)).willReturn(EMAIL);
+        given(appleKeyGenerator.createClientSecret()).willReturn(CLIENT_SECRET);
+        given(appleClient.requestAppleToken(AUTHORIZATION_CODE, CLIENT_SECRET))
+                .willReturn(appleTokenResponse());
+
+        AppleAuthResult result = appleService.authenticate(AUTHORIZATION_CODE, ID_TOKEN);
+
+        assertThat(result.userIdentifier()).isEqualTo(USER_IDENTIFIER);
+        assertThat(result.email()).isEqualTo(EMAIL);
+        assertThat(result.appleRefreshToken()).isEqualTo(APPLE_REFRESH_TOKEN);
+    }
+
+    @DisplayName("Apple 인증 중 토큰 교환이 실패하면 예외가 그대로 전파된다")
+    @Test
+    void authenticate_tokenRequestFailed() {
+        given(appleIdTokenVerifier.verify(ID_TOKEN)).willReturn(claims);
+        given(appleKeyGenerator.createClientSecret()).willReturn(CLIENT_SECRET);
+        given(appleClient.requestAppleToken(AUTHORIZATION_CODE, CLIENT_SECRET))
+                .willThrow(new CustomAppleLoginException(TOKEN_REQUEST_FAILED, "apple token request failed"));
+
+        assertThatThrownBy(() -> appleService.authenticate(AUTHORIZATION_CODE, ID_TOKEN))
+                .isInstanceOf(CustomAppleLoginException.class)
+                .extracting(throwable -> ((CustomAppleLoginException) throwable).getICustomError())
+                .isEqualTo(TOKEN_REQUEST_FAILED);
+    }
+
+    @DisplayName("Apple 연결 해제에 성공하면 토큰 폐기를 요청하고 저장된 Apple Refresh Token을 삭제한다")
+    @Test
+    void unlinkFromApple_success() {
+        UserAppleToken userAppleToken = UserAppleToken.create(user, APPLE_REFRESH_TOKEN);
+        given(userAppleTokenRepository.findByUser(user)).willReturn(Optional.of(userAppleToken));
+        given(appleKeyGenerator.createClientSecret()).willReturn(CLIENT_SECRET);
+
+        appleService.unlinkFromApple(user);
+
+        then(appleClient).should().revokeAppleToken(CLIENT_SECRET, APPLE_REFRESH_TOKEN);
+        then(userAppleTokenRepository).should().delete(userAppleToken);
+    }
+
+    @DisplayName("저장된 Apple Refresh Token이 없으면 연결 해제 시 예외가 발생한다")
+    @Test
+    void unlinkFromApple_tokenNotFound() {
+        given(userAppleTokenRepository.findByUser(user)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> appleService.unlinkFromApple(user))
+                .isInstanceOf(CustomAppleLoginException.class)
+                .extracting(throwable -> ((CustomAppleLoginException) throwable).getICustomError())
+                .isEqualTo(USER_APPLE_REFRESH_TOKEN_NOT_FOUND);
+
+        then(appleClient).should(never()).revokeAppleToken(CLIENT_SECRET, APPLE_REFRESH_TOKEN);
+    }
+
+    @DisplayName("토큰 폐기 요청이 실패하면 저장된 Apple Refresh Token을 삭제하지 않는다")
+    @Test
+    void unlinkFromApple_revokeFailed() {
+        UserAppleToken userAppleToken = UserAppleToken.create(user, APPLE_REFRESH_TOKEN);
+        given(userAppleTokenRepository.findByUser(user)).willReturn(Optional.of(userAppleToken));
+        given(appleKeyGenerator.createClientSecret()).willReturn(CLIENT_SECRET);
+        doThrow(new CustomAppleLoginException(TOKEN_REVOKE_FAILED, "apple token revoke failed"))
+                .when(appleClient).revokeAppleToken(CLIENT_SECRET, APPLE_REFRESH_TOKEN);
+
+        assertThatThrownBy(() -> appleService.unlinkFromApple(user))
+                .isInstanceOf(CustomAppleLoginException.class)
+                .extracting(throwable -> ((CustomAppleLoginException) throwable).getICustomError())
+                .isEqualTo(TOKEN_REVOKE_FAILED);
+
+        then(userAppleTokenRepository).should(never()).delete(userAppleToken);
+    }
+
+    @DisplayName("저장된 Apple Refresh Token이 없으면 새로 저장한다")
+    @Test
+    void upsertRefreshToken_saveWhenAbsent() {
+        given(userAppleTokenRepository.findByUser(user)).willReturn(Optional.empty());
+
+        appleService.upsertRefreshToken(user, APPLE_REFRESH_TOKEN);
+
+        then(userAppleTokenRepository).should().save(any(UserAppleToken.class));
+    }
+
+    @DisplayName("저장된 Apple Refresh Token이 있으면 값을 갱신한다")
+    @Test
+    void upsertRefreshToken_updateWhenPresent() {
+        UserAppleToken userAppleToken = UserAppleToken.create(user, "old-refresh-token");
+        given(userAppleTokenRepository.findByUser(user)).willReturn(Optional.of(userAppleToken));
+
+        appleService.upsertRefreshToken(user, APPLE_REFRESH_TOKEN);
+
+        assertThat(userAppleToken.getAppleRefreshToken()).isEqualTo(APPLE_REFRESH_TOKEN);
+        then(userAppleTokenRepository).should(never()).save(any(UserAppleToken.class));
+    }
+
+    @DisplayName("socialId 동기화는 Apple 인증 결과로 socialId와 Apple Refresh Token을 갱신한다")
+    @Test
+    void syncSocialId_updatesSocialIdAndRefreshToken() {
+        UserAppleToken userAppleToken = UserAppleToken.create(user, "old-refresh-token");
+        given(userAppleTokenRepository.findByUser(user)).willReturn(Optional.of(userAppleToken));
+        given(appleIdTokenVerifier.verify(ID_TOKEN)).willReturn(claims);
+        given(claims.get("sub", String.class)).willReturn(USER_IDENTIFIER);
+        given(appleKeyGenerator.createClientSecret()).willReturn(CLIENT_SECRET);
+        given(appleClient.requestAppleToken(AUTHORIZATION_CODE, CLIENT_SECRET))
+                .willReturn(appleTokenResponse());
+
+        appleService.syncSocialId(user, new AppleIdUpdateRequest(AUTHORIZATION_CODE, ID_TOKEN));
+
+        then(user).should().syncSocialId("apple_" + USER_IDENTIFIER);
+        assertThat(userAppleToken.getAppleRefreshToken()).isEqualTo(APPLE_REFRESH_TOKEN);
+    }
+
+    @DisplayName("저장된 Apple Refresh Token이 없으면 socialId 동기화는 아무것도 하지 않는다")
+    @Test
+    void syncSocialId_doesNothingWhenTokenNotFound() {
+        given(userAppleTokenRepository.findByUser(user)).willReturn(Optional.empty());
+
+        appleService.syncSocialId(user, new AppleIdUpdateRequest(AUTHORIZATION_CODE, ID_TOKEN));
+
+        then(appleIdTokenVerifier).should(never()).verify(ID_TOKEN);
+        then(appleClient).should(never()).requestAppleToken(AUTHORIZATION_CODE, CLIENT_SECRET);
+    }
+
+    private AppleTokenResponse appleTokenResponse() {
+        return new AppleTokenResponse("apple-access-token", "3600", ID_TOKEN, APPLE_REFRESH_TOKEN, "bearer", null);
+    }
+}


### PR DESCRIPTION
## Related Issue
- refactor/#569 -> dev
- Closes #569

## Key Changes
- `AppleClient`가 Apple 공개 키 조회, 토큰 교환, 토큰 폐기 HTTP 호출과 외부 오류 매핑을 전담하도록 정리했습니다. 전용 `RestClient`의 연결·응답 제한 시간을 5초로 설정하고 Apple 키 생성 오류 처리를 보완했습니다. ([`115d5c49`](https://github.com/Team-WSS/WSS-Server/pull/583/changes/115d5c49914155800124f88d3989c7a014387291))
- `AppleService`가 Apple 인증 절차와 Refresh Token 저장·폐기·소셜 ID 동기화를 담당하도록 통합했습니다. 트랜잭션은 DB 변경 메서드에만 메서드 단위로 적용하고, `AuthApplication`의 Apple 구현체 직접 의존을 제거했습니다. ([`f419de10`](https://github.com/Team-WSS/WSS-Server/pull/583/changes/f419de1063e7967e22a7de1928cf13c1e5e02b94))

## To Reviewers
- 기존 Apple 로그인·탈퇴 API 계약과 Kakao 코드, 공통 소셜 인터페이스, 재시도 정책은 변경하지 않았습니다.
- DB 스키마 및 배포 설정 변경은 없습니다.

## References
- #554