### PR TITLE
[HOTFIX] 인기 피드 소설 정보 null 반환 방지

### DIFF
--- a/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedCustomRepositoryImpl.java
@@ -13,6 +13,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import java.util.List;
@@ -291,13 +292,19 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
     @Override
     public List<Feed> findPopularRecommendedFeeds(Long userId, int size, List<Genre> genres,
                                                   List<Long> blockedUserIds) {
+        return popularRecommendedFeedsQuery(userId, size, genres, blockedUserIds).fetch();
+    }
+
+    // 소설과 장르가 모두 연결된 피드만 지금 뜨는 글 후보로 선정한다.
+    private JPAQuery<Feed> popularRecommendedFeedsQuery(Long userId, int size, List<Genre> genres,
+                                                        List<Long> blockedUserIds) {
         return jpaQueryFactory
                 .selectFrom(feed)
                 .distinct()
                 .join(feed.user).fetchJoin()
-                .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
-                .leftJoin(novelGenre).on(novel.eq(novelGenre.novel))
-                .leftJoin(genre).on(novelGenre.genre.eq(genre))
+                .join(novel).on(feed.novelId.eq(novel.novelId))
+                .join(novelGenre).on(novel.eq(novelGenre.novel))
+                .join(genre).on(novelGenre.genre.eq(genre))
                 .where(
                         recommendedFeedCondition(userId, genres),
                         excludeBlockedUsers(blockedUserIds),
@@ -305,8 +312,7 @@ public class FeedCustomRepositoryImpl implements FeedCustomRepository {
                         feed.isPublic.isTrue()
                 )
                 .orderBy(feed.feedId.desc())
-                .limit(size)
-                .fetch();
+                .limit(size);
     }
 
     private BooleanExpression checkPopularFeed() {

--- a/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedQueryRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/repository/FeedQueryRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import java.util.List;
@@ -130,6 +131,11 @@ public class FeedQueryRepositoryImpl implements FeedQueryRepository {
             return List.of();
         }
 
+        return popularFeedInfoRowsQuery(feedIds, userId).fetch();
+    }
+
+    // 소설과 장르가 모두 연결된 피드만 조회해 소설 제목, 이미지, 장르가 비지 않도록 한다.
+    private JPAQuery<PopularFeedInfoRow> popularFeedInfoRowsQuery(List<Long> feedIds, Long userId) {
         return jpaQueryFactory
                 .select(Projections.constructor(
                         PopularFeedInfoRow.class,
@@ -144,9 +150,24 @@ public class FeedQueryRepositoryImpl implements FeedQueryRepository {
                         firstGenreName()
                 ))
                 .from(feed)
-                .leftJoin(novel).on(feed.novelId.eq(novel.novelId))
-                .where(feed.feedId.in(feedIds))
-                .fetch();
+                .join(novel).on(feed.novelId.eq(novel.novelId))
+                .where(
+                        feed.feedId.in(feedIds),
+                        hasGenre()
+                );
+    }
+
+    // 장르가 연결되지 않은 소설의 피드를 제외한다.
+    private BooleanExpression hasGenre() {
+        QNovelGenre novelGenreSub = new QNovelGenre("genreExistsSub");
+        QGenre genreSub = new QGenre("genreExistsGenreSub");
+
+        return JPAExpressions
+                .selectOne()
+                .from(novelGenreSub)
+                .join(novelGenreSub.genre, genreSub)
+                .where(novelGenreSub.novel.eq(novel))
+                .exists();
     }
 
     private JPQLQuery<Long> likeCount() {

--- a/src/test/java/org/websoso/WSSServer/feed/feed/repository/FeedCustomRepositoryImplTest.java
+++ b/src/test/java/org/websoso/WSSServer/feed/feed/repository/FeedCustomRepositoryImplTest.java
@@ -1,0 +1,59 @@
+package org.websoso.WSSServer.feed.feed.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.querydsl.jpa.JPQLTemplates;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.websoso.WSSServer.feed.feed.domain.Feed;
+
+/**
+ * 지금 뜨는 글 후보 선정 쿼리가 소설과 장르가 연결된 피드만 고르는지 검증한다.
+ */
+class FeedCustomRepositoryImplTest {
+
+    private final FeedCustomRepositoryImpl repository =
+            new FeedCustomRepositoryImpl(new JPAQueryFactory(JPQLTemplates.DEFAULT, (EntityManager) null));
+
+    // 소설이 연결되지 않은 피드는 좋아요가 임계치를 넘어도 후보에서 빠져야 하므로 소설 조인이 내부 조인이어야 한다.
+    @DisplayName("지금 뜨는 글 후보는 소설이 연결된 피드만 선택한다")
+    @Test
+    void selectsOnlyFeedsJoinedWithNovel() {
+        String query = popularRecommendedFeedsQuery().toString();
+
+        assertThat(query).contains("inner join Novel novel on feed.novelId = novel.novelId");
+    }
+
+    // 장르가 연결되지 않은 소설의 피드는 장르 값을 채울 수 없으므로 장르 조인도 내부 조인이어야 한다.
+    @DisplayName("지금 뜨는 글 후보는 장르가 연결된 소설의 피드만 선택한다")
+    @Test
+    void selectsOnlyFeedsJoinedWithGenre() {
+        String query = popularRecommendedFeedsQuery().toString();
+
+        assertThat(query)
+                .contains("inner join NovelGenre novelGenre on novel = novelGenre.novel")
+                .contains("inner join Genre genre on novelGenre.genre = genre");
+    }
+
+    // 외부 조인이 하나라도 남으면 소설이나 장르가 없는 피드가 다시 후보로 들어온다.
+    @DisplayName("지금 뜨는 글 후보 선정에는 외부 조인을 사용하지 않는다")
+    @Test
+    void doesNotUseLeftJoinForPopularCandidates() {
+        String query = popularRecommendedFeedsQuery().toString();
+
+        assertThat(query).doesNotContain("left join");
+    }
+
+    private JPAQuery<Feed> popularRecommendedFeedsQuery() {
+        JPAQuery<Feed> query = ReflectionTestUtils.invokeMethod(
+                repository, "popularRecommendedFeedsQuery", null, 20, List.of(), List.of());
+
+        assertThat(query).isNotNull();
+        return query;
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/feed/feed/repository/FeedQueryRepositoryImplTest.java
+++ b/src/test/java/org/websoso/WSSServer/feed/feed/repository/FeedQueryRepositoryImplTest.java
@@ -3,13 +3,22 @@ package org.websoso.WSSServer.feed.feed.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.JPQLTemplates;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.websoso.WSSServer.feed.feed.repository.projection.PopularFeedInfoRow;
 
 class FeedQueryRepositoryImplTest {
 
     private final FeedQueryRepositoryImpl repository = new FeedQueryRepositoryImpl(null);
+
+    private final FeedQueryRepositoryImpl queryingRepository =
+            new FeedQueryRepositoryImpl(new JPAQueryFactory(JPQLTemplates.DEFAULT, (EntityManager) null));
 
     @DisplayName("피드 댓글 수에서 사용자의 양방향 차단 관계 댓글을 제외한다")
     @Test
@@ -29,5 +38,41 @@ class FeedQueryRepositoryImplTest {
         assertThat(query).isNotNull();
         assertThat(query.toString())
                 .doesNotContain("commentCountBlockingRelation", "commentCountBlockedRelation");
+    }
+
+    // 소설이 없는 피드가 조회되면 소설 제목과 이미지가 비어서 응답에 나가므로 내부 조인으로 막는다.
+    @DisplayName("지금 뜨는 글 조회는 소설이 연결된 피드만 대상으로 한다")
+    @Test
+    void selectsPopularFeedRowsJoinedWithNovel() {
+        String query = popularFeedInfoRowsQuery();
+
+        assertThat(query).contains("inner join");
+        assertThat(query).doesNotContain("left join");
+    }
+
+    // 장르가 없는 소설의 피드가 조회되면 장르가 비어서 응답에 나가므로 존재 조건으로 막는다.
+    @DisplayName("지금 뜨는 글 조회는 장르가 연결된 소설의 피드만 대상으로 한다")
+    @Test
+    void selectsPopularFeedRowsHavingGenre() {
+        String query = popularFeedInfoRowsQuery();
+
+        assertThat(query).contains("genreExistsSub", "genreExistsGenreSub", "exists");
+    }
+
+    // 응답의 소설 제목, 이미지, 장르는 모두 실제 조회 값으로 채워져야 한다.
+    @DisplayName("지금 뜨는 글 조회는 소설 제목, 이미지, 장르를 실제 값으로 조회한다")
+    @Test
+    void selectsNovelTitleImageAndGenre() {
+        String query = popularFeedInfoRowsQuery();
+
+        assertThat(query).contains("novel.title", "novel.novelImage", "genreSub.genreName");
+    }
+
+    private String popularFeedInfoRowsQuery() {
+        JPAQuery<PopularFeedInfoRow> query = ReflectionTestUtils.invokeMethod(
+                queryingRepository, "popularFeedInfoRowsQuery", List.of(1L), 1L);
+
+        assertThat(query).isNotNull();
+        return query.toString();
     }
 }

--- a/src/test/java/org/websoso/WSSServer/feed/feed/repository/projection/PopularFeedInfoRowTest.java
+++ b/src/test/java/org/websoso/WSSServer/feed/feed/repository/projection/PopularFeedInfoRowTest.java
@@ -1,0 +1,68 @@
+package org.websoso.WSSServer.feed.feed.repository.projection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.websoso.WSSServer.feed.feed.controller.dto.PopularFeedGetResponse;
+
+/**
+ * 지금 뜨는 글 조회 결과가 응답으로 변환될 때 소설 정보가 그대로 전달되는지 검증한다.
+ */
+class PopularFeedInfoRowTest {
+
+    private static final String NOVEL_TITLE = "재혼 황후";
+    private static final String NOVEL_IMAGE = "https://image.websoso.kr/novel/1.png";
+    private static final String NOVEL_GENRE = "romance";
+
+    // 조회한 소설 제목, 이미지, 장르가 응답까지 값 그대로 전달되어야 한다.
+    @DisplayName("지금 뜨는 글 응답의 소설 제목, 이미지, 장르는 조회 값을 그대로 매핑한다")
+    @Test
+    void mapsNovelTitleImageAndGenreAsIs() {
+        PopularFeedGetResponse response = createRow().toResponse();
+
+        assertThat(response.novelTitle()).isEqualTo(NOVEL_TITLE);
+        assertThat(response.novelImage()).isEqualTo(NOVEL_IMAGE);
+        assertThat(response.novelGenre()).isEqualTo(NOVEL_GENRE);
+    }
+
+    // 소설 정보를 빈 문자열이나 기본값으로 대체하지 않고 non-null 값으로 응답해야 한다.
+    @DisplayName("지금 뜨는 글 응답의 소설 제목, 이미지, 장르는 비어 있지 않다")
+    @Test
+    void mapsNovelInfoWithoutNullOrBlank() {
+        PopularFeedGetResponse response = createRow().toResponse();
+
+        assertThat(response.novelTitle()).isNotNull().isNotBlank();
+        assertThat(response.novelImage()).isNotNull().isNotBlank();
+        assertThat(response.novelGenre()).isNotNull().isNotBlank();
+    }
+
+    // 소설 정보 외 나머지 필드도 함께 전달되는지 확인한다.
+    @DisplayName("지금 뜨는 글 응답은 피드 정보와 좋아요, 댓글 수를 함께 전달한다")
+    @Test
+    void mapsFeedInfoWithCounts() {
+        PopularFeedGetResponse response = createRow().toResponse();
+
+        assertThat(response.feedId()).isEqualTo(1L);
+        assertThat(response.feedContent()).isEqualTo("피드 내용");
+        assertThat(response.likeCount()).isEqualTo(7);
+        assertThat(response.commentCount()).isEqualTo(3);
+        assertThat(response.isSpoiler()).isFalse();
+        assertThat(response.isPublic()).isTrue();
+    }
+
+    // 소설과 장르가 연결된 피드에서 조회되는 정상 결과를 만든다.
+    private PopularFeedInfoRow createRow() {
+        return new PopularFeedInfoRow(
+                1L,
+                "피드 내용",
+                7L,
+                3L,
+                false,
+                true,
+                NOVEL_TITLE,
+                NOVEL_IMAGE,
+                NOVEL_GENRE
+        );
+    }
+}


### PR DESCRIPTION
## Related Issue

- hotfix/#586 → main
- Closes #586

## Key Changes

- `GET /feeds/popular` 후보 조회에서 소설과 장르를 내부 조인하여 소설 또는 장르 정보가 없는 피드를 추천 결과에서 제외했습니다.
- 응답 상세 조회에서도 유효한 소설 연결과 장르 존재 여부를 다시 검증하여 `novelTitle`, `novelImage`, `novelGenre`가 null로 반환되는 경로를 차단했습니다.

## To Reviewers

- 운영 `main`의 v1.4.8 커밋에서 분기한 단일 핫픽스로, 현재 `dev`의 다른 변경은 포함하지 않습니다.
- 좋아요 임계치, 개인화 조건, 후보 수, 랜덤 선택 정책과 API 응답 구조는 변경하지 않았습니다.
- DB 스키마 및 데이터 변경이 없어 별도 DDL은 필요하지 않습니다.

## References

- 개발 서버용 backport: #588
- 원인 변경: [a74afe61](https://github.com/Team-WSS/WSS-Server/commit/a74afe61268d901988dd6650a02649fe021cc9fe)
