### PR TITLE
[TEST] 소셜 로그인 및 로그아웃 인증 흐름 보완

### DIFF
--- a/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationAppleLoginTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationAppleLoginTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.websoso.WSSServer.exception.error.CustomAppleLoginError.TOKEN_REQUEST_FAILED;
 
@@ -12,10 +13,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.websoso.WSSServer.auth.client.KakaoClient;
 import org.websoso.WSSServer.auth.controller.dto.AuthResponse;
+import org.websoso.WSSServer.auth.jwt.CustomAuthenticationToken;
 import org.websoso.WSSServer.auth.jwt.JWTUtil;
 import org.websoso.WSSServer.auth.jwt.JwtProvider;
 import org.websoso.WSSServer.auth.service.AppleService;
@@ -38,6 +43,7 @@ class AuthApplicationAppleLoginTest {
     private static final String EXPECTED_DEFAULT_NICKNAME = "a*" + "abcdefgh";
     private static final String ACCESS_TOKEN = "access-token-value";
     private static final String REFRESH_TOKEN = "refresh-token-value";
+    private static final Long USER_ID = 42L;
 
     @Mock
     private TokenService tokenService;
@@ -62,6 +68,9 @@ class AuthApplicationAppleLoginTest {
 
     @Mock
     private User user;
+
+    @Captor
+    private ArgumentCaptor<CustomAuthenticationToken> authenticationTokenCaptor;
 
     private AuthApplication authApplication;
 
@@ -89,6 +98,48 @@ class AuthApplicationAppleLoginTest {
         assertThat(response.isRegister()).isTrue();
         then(appleService).should().upsertRefreshToken(user, APPLE_REFRESH_TOKEN);
         then(tokenService).should().saveRefreshToken(user, REFRESH_TOKEN);
+    }
+
+    @DisplayName("임시 닉네임인 신규 애플 사용자는 isRegister가 false인 토큰 쌍을 받는다")
+    @Test
+    void loginApple_newUserWithTemporaryNickname_returnsIsRegisterFalse() {
+        given(appleService.authenticate(AUTHORIZATION_CODE, ID_TOKEN))
+                .willReturn(AppleAuthResult.of(USER_IDENTIFIER, EMAIL, APPLE_REFRESH_TOKEN));
+        given(userService.getOrCreateAppleUser(EXPECTED_SOCIAL_ID, EMAIL, EXPECTED_DEFAULT_NICKNAME))
+                .willReturn(user);
+        given(jwtProvider.generateAccessToken(any())).willReturn(ACCESS_TOKEN);
+        given(jwtProvider.generateRefreshToken(any())).willReturn(REFRESH_TOKEN);
+        given(user.isTemporaryNickname()).willReturn(true);
+
+        AuthResponse response = authApplication.loginApple(AUTHORIZATION_CODE, ID_TOKEN);
+
+        assertThat(response.isRegister()).isFalse();
+        then(appleService).should().upsertRefreshToken(user, APPLE_REFRESH_TOKEN);
+        then(tokenService).should().saveRefreshToken(user, REFRESH_TOKEN);
+    }
+
+    @DisplayName("애플 로그인은 애플 Refresh Token을 저장한 뒤 조회·생성한 사용자 식별자로 서비스 토큰 쌍을 발급한다")
+    @Test
+    void loginApple_storesAppleRefreshTokenBeforeIssuingServiceTokenPair() {
+        given(appleService.authenticate(AUTHORIZATION_CODE, ID_TOKEN))
+                .willReturn(AppleAuthResult.of(USER_IDENTIFIER, EMAIL, APPLE_REFRESH_TOKEN));
+        given(userService.getOrCreateAppleUser(EXPECTED_SOCIAL_ID, EMAIL, EXPECTED_DEFAULT_NICKNAME))
+                .willReturn(user);
+        given(user.getUserId()).willReturn(USER_ID);
+        given(jwtProvider.generateAccessToken(any())).willReturn(ACCESS_TOKEN);
+        given(jwtProvider.generateRefreshToken(any())).willReturn(REFRESH_TOKEN);
+
+        authApplication.loginApple(AUTHORIZATION_CODE, ID_TOKEN);
+
+        InOrder inOrder = inOrder(appleService, jwtProvider, tokenService);
+        inOrder.verify(appleService).authenticate(AUTHORIZATION_CODE, ID_TOKEN);
+        inOrder.verify(appleService).upsertRefreshToken(user, APPLE_REFRESH_TOKEN);
+        inOrder.verify(jwtProvider).generateAccessToken(authenticationTokenCaptor.capture());
+        inOrder.verify(jwtProvider).generateRefreshToken(authenticationTokenCaptor.capture());
+        inOrder.verify(tokenService).saveRefreshToken(user, REFRESH_TOKEN);
+        assertThat(authenticationTokenCaptor.getAllValues())
+                .extracting(CustomAuthenticationToken::getPrincipal)
+                .containsExactly(USER_ID, USER_ID);
     }
 
     @DisplayName("Apple 인증이 실패하면 유저 처리와 토큰 저장을 수행하지 않고 예외를 전파한다")

--- a/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationKakaoLoginTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationKakaoLoginTest.java
@@ -1,0 +1,151 @@
+package org.websoso.WSSServer.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.websoso.WSSServer.exception.error.CustomKakaoError.INVALID_KAKAO_ACCESS_TOKEN;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.websoso.WSSServer.auth.client.KakaoClient;
+import org.websoso.WSSServer.auth.client.dto.KakaoUserInfo;
+import org.websoso.WSSServer.auth.controller.dto.AuthResponse;
+import org.websoso.WSSServer.auth.jwt.CustomAuthenticationToken;
+import org.websoso.WSSServer.auth.jwt.JWTUtil;
+import org.websoso.WSSServer.auth.jwt.JwtProvider;
+import org.websoso.WSSServer.auth.service.AppleService;
+import org.websoso.WSSServer.auth.service.TokenService;
+import org.websoso.WSSServer.exception.exception.CustomKakaoException;
+import org.websoso.WSSServer.notification.service.UserDeviceService;
+import org.websoso.WSSServer.user.domain.User;
+import org.websoso.WSSServer.user.service.UserService;
+
+@ExtendWith(MockitoExtension.class)
+class AuthApplicationKakaoLoginTest {
+
+    private static final String KAKAO_ACCESS_TOKEN = "kakao-access-token";
+    private static final Long USER_ID = 42L;
+    private static final String ACCESS_TOKEN = "access-token-value";
+    private static final String REFRESH_TOKEN = "refresh-token-value";
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private JWTUtil jwtUtil;
+
+    @Mock
+    private UserDeviceService userDeviceService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private KakaoClient kakaoClient;
+
+    @Mock
+    private AppleService appleService;
+
+    @Mock
+    private User user;
+
+    @Captor
+    private ArgumentCaptor<CustomAuthenticationToken> authenticationTokenCaptor;
+
+    private AuthApplication authApplication;
+
+    @BeforeEach
+    void setUp() {
+        authApplication = new AuthApplication(tokenService, jwtProvider, jwtUtil, userDeviceService,
+                userService, kakaoClient, appleService);
+    }
+
+    @DisplayName("이미 닉네임을 등록한 기존 사용자가 카카오 로그인하면 isRegister가 true인 토큰 쌍을 발급한다")
+    @Test
+    void loginKakao_registeredUser_returnsIsRegisterTrue() {
+        KakaoUserInfo kakaoUserInfo = kakaoUserInfo();
+        given(kakaoClient.getUserInfo(KAKAO_ACCESS_TOKEN)).willReturn(kakaoUserInfo);
+        given(userService.getOrCreateKakaoUser(kakaoUserInfo)).willReturn(user);
+        given(jwtProvider.generateAccessToken(any())).willReturn(ACCESS_TOKEN);
+        given(jwtProvider.generateRefreshToken(any())).willReturn(REFRESH_TOKEN);
+        given(user.isTemporaryNickname()).willReturn(false);
+
+        AuthResponse response = authApplication.loginKakao(KAKAO_ACCESS_TOKEN);
+
+        assertThat(response.Authorization()).isEqualTo(ACCESS_TOKEN);
+        assertThat(response.refreshToken()).isEqualTo(REFRESH_TOKEN);
+        assertThat(response.isRegister()).isTrue();
+        then(tokenService).should().saveRefreshToken(user, REFRESH_TOKEN);
+    }
+
+    @DisplayName("임시 닉네임인 신규 사용자가 카카오 로그인하면 isRegister가 false인 토큰 쌍을 발급한다")
+    @Test
+    void loginKakao_newUserWithTemporaryNickname_returnsIsRegisterFalse() {
+        KakaoUserInfo kakaoUserInfo = kakaoUserInfo();
+        given(kakaoClient.getUserInfo(KAKAO_ACCESS_TOKEN)).willReturn(kakaoUserInfo);
+        given(userService.getOrCreateKakaoUser(kakaoUserInfo)).willReturn(user);
+        given(jwtProvider.generateAccessToken(any())).willReturn(ACCESS_TOKEN);
+        given(jwtProvider.generateRefreshToken(any())).willReturn(REFRESH_TOKEN);
+        given(user.isTemporaryNickname()).willReturn(true);
+
+        AuthResponse response = authApplication.loginKakao(KAKAO_ACCESS_TOKEN);
+
+        assertThat(response.isRegister()).isFalse();
+        then(tokenService).should().saveRefreshToken(user, REFRESH_TOKEN);
+    }
+
+    @DisplayName("카카오 로그인은 조회하거나 생성한 사용자의 식별자로 Access / Refresh Token을 발급한다")
+    @Test
+    void loginKakao_issuesTokenPairForResolvedUser() {
+        KakaoUserInfo kakaoUserInfo = kakaoUserInfo();
+        given(kakaoClient.getUserInfo(KAKAO_ACCESS_TOKEN)).willReturn(kakaoUserInfo);
+        given(userService.getOrCreateKakaoUser(kakaoUserInfo)).willReturn(user);
+        given(user.getUserId()).willReturn(USER_ID);
+        given(jwtProvider.generateAccessToken(any())).willReturn(ACCESS_TOKEN);
+        given(jwtProvider.generateRefreshToken(any())).willReturn(REFRESH_TOKEN);
+
+        authApplication.loginKakao(KAKAO_ACCESS_TOKEN);
+
+        then(jwtProvider).should().generateAccessToken(authenticationTokenCaptor.capture());
+        then(jwtProvider).should().generateRefreshToken(authenticationTokenCaptor.capture());
+        assertThat(authenticationTokenCaptor.getAllValues())
+                .extracting(CustomAuthenticationToken::getPrincipal)
+                .containsExactly(USER_ID, USER_ID);
+    }
+
+    @DisplayName("카카오 사용자 정보 조회가 실패하면 사용자 조회·생성과 토큰 저장을 수행하지 않고 예외를 전파한다")
+    @Test
+    void loginKakao_userInfoRequestFailed() {
+        given(kakaoClient.getUserInfo(KAKAO_ACCESS_TOKEN))
+                .willThrow(new CustomKakaoException(INVALID_KAKAO_ACCESS_TOKEN, "invalid kakao access token"));
+
+        assertThatThrownBy(() -> authApplication.loginKakao(KAKAO_ACCESS_TOKEN))
+                .isInstanceOf(CustomKakaoException.class)
+                .extracting(throwable -> ((CustomKakaoException) throwable).getICustomError())
+                .isEqualTo(INVALID_KAKAO_ACCESS_TOKEN);
+
+        then(userService).shouldHaveNoInteractions();
+        then(jwtProvider).shouldHaveNoInteractions();
+        then(tokenService).should(never()).saveRefreshToken(any(), any());
+    }
+
+    private KakaoUserInfo kakaoUserInfo() {
+        return new KakaoUserInfo(
+                1234567890L,
+                new KakaoUserInfo.Properties("websoso"),
+                new KakaoUserInfo.KakaoAccount("websoso@websoso.org")
+        );
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationLogoutTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationLogoutTest.java
@@ -78,4 +78,14 @@ class AuthApplicationLogoutTest {
         then(userDeviceService).should().deleteDeviceIdentifier(user, DEVICE_IDENTIFIER);
         then(kakaoClient).should().logout("1234567890");
     }
+
+    @DisplayName("애플 사용자가 로그아웃하면 카카오 외부 로그아웃을 호출하지 않는다")
+    @Test
+    void logout_appleUser_doesNotCallKakaoLogout() {
+        given(user.getSocialId()).willReturn("apple_001234.abcdefghijklmn.1234");
+
+        authApplication.logout(user, new LogoutRequest(REFRESH_TOKEN, DEVICE_IDENTIFIER));
+
+        then(kakaoClient).shouldHaveNoInteractions();
+    }
 }

--- a/src/test/java/org/websoso/WSSServer/user/service/UserServiceSocialUserTest.java
+++ b/src/test/java/org/websoso/WSSServer/user/service/UserServiceSocialUserTest.java
@@ -1,0 +1,125 @@
+package org.websoso.WSSServer.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.websoso.WSSServer.auth.client.dto.KakaoUserInfo;
+import org.websoso.WSSServer.infrastructure.discord.DiscordMessageClient;
+import org.websoso.WSSServer.repository.GenrePreferenceRepository;
+import org.websoso.WSSServer.repository.GenreRepository;
+import org.websoso.WSSServer.user.domain.User;
+import org.websoso.WSSServer.user.repository.AvatarProfileRepository;
+import org.websoso.WSSServer.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceSocialUserTest {
+
+    private static final Long KAKAO_ID = 1234567890L;
+    private static final String KAKAO_SOCIAL_ID = "kakao_1234567890";
+    private static final String KAKAO_DEFAULT_NICKNAME = "k*34567890";
+    private static final String APPLE_SOCIAL_ID = "apple_001234.abcdefghijklmn.1234";
+    private static final String APPLE_DEFAULT_NICKNAME = "a*abcdefgh";
+    private static final String EMAIL = "websoso@websoso.org";
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AvatarProfileRepository avatarProfileRepository;
+
+    @Mock
+    private GenrePreferenceRepository genrePreferenceRepository;
+
+    @Mock
+    private GenreRepository genreRepository;
+
+    @Mock
+    private BlockService blockService;
+
+    @Mock
+    private DiscordMessageClient discordMessageClient;
+
+    @Mock
+    private User existingUser;
+
+    @Captor
+    private ArgumentCaptor<User> userCaptor;
+
+    @DisplayName("카카오 소셜 식별자로 가입된 사용자가 있으면 새로 저장하지 않고 기존 사용자를 반환한다")
+    @Test
+    void getOrCreateKakaoUser_existingUser_returnsWithoutSaving() {
+        given(userRepository.findBySocialId(KAKAO_SOCIAL_ID)).willReturn(existingUser);
+
+        User result = userService.getOrCreateKakaoUser(kakaoUserInfo());
+
+        assertThat(result).isSameAs(existingUser);
+        then(userRepository).should(never()).save(any(User.class));
+    }
+
+    @DisplayName("카카오 소셜 식별자로 가입된 사용자가 없으면 임시 닉네임을 가진 사용자를 생성해 저장한다")
+    @Test
+    void getOrCreateKakaoUser_newUser_savesWithTemporaryNickname() {
+        given(userRepository.findBySocialId(KAKAO_SOCIAL_ID)).willReturn(null);
+        given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        User result = userService.getOrCreateKakaoUser(kakaoUserInfo());
+
+        then(userRepository).should().save(userCaptor.capture());
+        User saved = userCaptor.getValue();
+        assertThat(result).isSameAs(saved);
+        assertThat(saved.getSocialId()).isEqualTo(KAKAO_SOCIAL_ID);
+        assertThat(saved.getNickname()).isEqualTo(KAKAO_DEFAULT_NICKNAME);
+        assertThat(saved.getEmail()).isEqualTo(EMAIL);
+        assertThat(saved.isTemporaryNickname()).isTrue();
+    }
+
+    @DisplayName("애플 소셜 식별자로 가입된 사용자가 있으면 새로 저장하지 않고 기존 사용자를 반환한다")
+    @Test
+    void getOrCreateAppleUser_existingUser_returnsWithoutSaving() {
+        given(userRepository.findBySocialId(APPLE_SOCIAL_ID)).willReturn(existingUser);
+
+        User result = userService.getOrCreateAppleUser(APPLE_SOCIAL_ID, EMAIL, APPLE_DEFAULT_NICKNAME);
+
+        assertThat(result).isSameAs(existingUser);
+        then(userRepository).should(never()).save(any(User.class));
+    }
+
+    @DisplayName("애플 소셜 식별자로 가입된 사용자가 없으면 전달받은 닉네임으로 사용자를 생성해 저장한다")
+    @Test
+    void getOrCreateAppleUser_newUser_savesWithGivenNickname() {
+        given(userRepository.findBySocialId(APPLE_SOCIAL_ID)).willReturn(null);
+        given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        User result = userService.getOrCreateAppleUser(APPLE_SOCIAL_ID, EMAIL, APPLE_DEFAULT_NICKNAME);
+
+        then(userRepository).should().save(userCaptor.capture());
+        User saved = userCaptor.getValue();
+        assertThat(result).isSameAs(saved);
+        assertThat(saved.getSocialId()).isEqualTo(APPLE_SOCIAL_ID);
+        assertThat(saved.getNickname()).isEqualTo(APPLE_DEFAULT_NICKNAME);
+        assertThat(saved.getEmail()).isEqualTo(EMAIL);
+        assertThat(saved.isTemporaryNickname()).isTrue();
+    }
+
+    private KakaoUserInfo kakaoUserInfo() {
+        return new KakaoUserInfo(
+                KAKAO_ID,
+                new KakaoUserInfo.Properties("websoso"),
+                new KakaoUserInfo.KakaoAccount(EMAIL)
+        );
+    }
+}


### PR DESCRIPTION
## Related Issue
- test/#575 -> dev
- Closes #575

## Key Changes
- Kakao 신규·기존 사용자 로그인 흐름에서 사용자 조회·생성, Access/Refresh Token 발급과 서비스 Refresh Token 저장, `isRegister` 분기를 단위 테스트로 검증했습니다.
- Apple ID Token 검증과 Authorization Code 교환부터 Apple Refresh Token 및 서비스 Token Pair 저장까지의 흐름과 `isRegister` 분기를 검증했습니다.
- 기존 로그아웃 상태 정리 회귀 테스트를 유지하면서 Kakao 사용자의 외부 로그아웃 호출과 Apple 사용자의 미호출 조건을 보완했습니다.

## To Reviewers
- 프로덕션 코드와 API 계약은 변경하지 않은 테스트 전용 PR입니다.
- 클라이언트, DB DDL·제약조건, 배포 설정 영향은 없습니다.

## References