### PR TITLE
[FIX] Refresh Token 재발급 동시성 제어

### DIFF
--- a/src/main/java/org/websoso/WSSServer/auth/application/AuthApplication.java
+++ b/src/main/java/org/websoso/WSSServer/auth/application/AuthApplication.java
@@ -2,6 +2,7 @@ package org.websoso.WSSServer.auth.application;
 
 import static org.websoso.WSSServer.exception.error.CustomAuthError.INVALID_TOKEN;
 
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ import org.websoso.WSSServer.auth.jwt.JwtProvider;
 import org.websoso.WSSServer.auth.jwt.JwtValidationType;
 import org.websoso.WSSServer.auth.service.AppleService;
 import org.websoso.WSSServer.auth.client.KakaoClient;
+import org.websoso.WSSServer.auth.service.RefreshTokenLockService;
 import org.websoso.WSSServer.auth.service.TokenService;
 import org.websoso.WSSServer.auth.service.dto.AppleAuthResult;
 import org.websoso.WSSServer.auth.client.dto.KakaoUserInfo;
@@ -29,6 +31,7 @@ import org.websoso.WSSServer.user.service.UserService;
 public class AuthApplication {
 
     private final TokenService tokenService;
+    private final RefreshTokenLockService refreshTokenLockService;
     private final JwtProvider jwtProvider;
     private final JWTUtil jwtUtil;
     private final UserDeviceService userDeviceService;
@@ -45,17 +48,31 @@ public class AuthApplication {
             throw new CustomAuthException(INVALID_TOKEN, "given token is invalid token for reissue");
         }
 
-        // 2. 저장된 토큰 조회
+        // 2. 동일 리프레시 토큰의 동시 재발급 차단
+        String lockOwner = UUID.randomUUID().toString();
+        if (!refreshTokenLockService.tryLock(refreshToken, lockOwner)) {
+            throw new CustomAuthException(INVALID_TOKEN, "given token is already being reissued");
+        }
+
+        try {
+            return rotateTokens(refreshToken);
+        } finally {
+            refreshTokenLockService.unlock(refreshToken, lockOwner);
+        }
+    }
+
+    private ReissueResponse rotateTokens(String refreshToken) {
+        // 1. 잠금 획득 후 저장된 토큰 재조회 (먼저 회전한 요청이 이미 삭제했다면 여기서 거부된다)
         RefreshToken storedRefreshToken = tokenService.findRefreshTokenOrThrow(refreshToken);
 
-        // 3. 새로운 토큰 생성
+        // 2. 새로운 토큰 생성
         Long userId = jwtUtil.getUserIdFromJwt(refreshToken);
         CustomAuthenticationToken customAuthenticationToken = new CustomAuthenticationToken(userId, null, null);
 
         String newAccessToken = jwtProvider.generateAccessToken(customAuthenticationToken);
         String newRefreshToken = jwtProvider.generateRefreshToken(customAuthenticationToken);
 
-        // 4. 리프레시 토큰 교체
+        // 3. 리프레시 토큰 교체
         tokenService.rotateRefreshToken(storedRefreshToken, newRefreshToken, userId);
 
         return ReissueResponse.of(newAccessToken, newRefreshToken);

--- a/src/main/java/org/websoso/WSSServer/auth/service/RefreshTokenLockService.java
+++ b/src/main/java/org/websoso/WSSServer/auth/service/RefreshTokenLockService.java
@@ -1,0 +1,23 @@
+package org.websoso.WSSServer.auth.service;
+
+/**
+ * 동일한 Refresh Token으로 들어온 재발급 요청을 토큰 단위로 직렬화하기 위한 잠금이다.
+ * 서로 다른 Refresh Token은 서로 다른 잠금을 사용하므로 병렬로 처리된다.
+ */
+public interface RefreshTokenLockService {
+
+    /**
+     * 해당 Refresh Token의 잠금을 획득한다. 이미 다른 요청이 잠금을 보유하고 있으면 대기하지 않고 즉시 실패한다.
+     *
+     * @param owner 요청별로 생성한 소유자 값
+     * @return 잠금을 획득했으면 true
+     */
+    boolean tryLock(String refreshToken, String owner);
+
+    /**
+     * 잠금을 해제한다. 소유자가 일치할 때만 해제되며, 비교와 삭제는 원자적으로 수행된다.
+     *
+     * @return 자신이 보유한 잠금을 해제했으면 true
+     */
+    boolean unlock(String refreshToken, String owner);
+}

--- a/src/main/java/org/websoso/WSSServer/auth/service/RefreshTokenLockServiceImpl.java
+++ b/src/main/java/org/websoso/WSSServer/auth/service/RefreshTokenLockServiceImpl.java
@@ -1,0 +1,59 @@
+package org.websoso.WSSServer.auth.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenLockServiceImpl implements RefreshTokenLockService {
+
+    // 잠금 키에는 raw Refresh Token 대신 해시를 사용해 민감한 토큰 값이 Redis에 남지 않도록 한다.
+    private static final String LOCK_KEY_PREFIX = "refreshTokenLock:";
+    private static final String HASH_ALGORITHM = "SHA-256";
+
+    // 잠금 보유 중 프로세스가 죽어도 잠금이 남지 않도록 만료 시간을 둔다.
+    private static final Duration LOCK_TIME_TO_LIVE = Duration.ofSeconds(5);
+
+    // 소유자가 일치할 때만 삭제해, 만료 후 다른 요청이 획득한 잠금을 해제하지 않는다.
+    private static final RedisScript<Long> UNLOCK_SCRIPT = new DefaultRedisScript<>(
+            "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+            Long.class);
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public boolean tryLock(String refreshToken, String owner) {
+        Boolean acquired = stringRedisTemplate.opsForValue()
+                .setIfAbsent(toLockKey(refreshToken), owner, LOCK_TIME_TO_LIVE);
+        return Boolean.TRUE.equals(acquired);
+    }
+
+    @Override
+    public boolean unlock(String refreshToken, String owner) {
+        Long deletedCount = stringRedisTemplate.execute(UNLOCK_SCRIPT, List.of(toLockKey(refreshToken)), owner);
+        return deletedCount != null && deletedCount > 0;
+    }
+
+    private String toLockKey(String refreshToken) {
+        return LOCK_KEY_PREFIX + hash(refreshToken);
+    }
+
+    private String hash(String refreshToken) {
+        try {
+            byte[] digest = MessageDigest.getInstance(HASH_ALGORITHM)
+                    .digest(refreshToken.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(HASH_ALGORITHM + " is not available", e);
+        }
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationAppleLoginTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationAppleLoginTest.java
@@ -19,6 +19,7 @@ import org.websoso.WSSServer.auth.controller.dto.AuthResponse;
 import org.websoso.WSSServer.auth.jwt.JWTUtil;
 import org.websoso.WSSServer.auth.jwt.JwtProvider;
 import org.websoso.WSSServer.auth.service.AppleService;
+import org.websoso.WSSServer.auth.service.RefreshTokenLockService;
 import org.websoso.WSSServer.auth.service.TokenService;
 import org.websoso.WSSServer.auth.service.dto.AppleAuthResult;
 import org.websoso.WSSServer.exception.exception.CustomAppleLoginException;
@@ -41,6 +42,9 @@ class AuthApplicationAppleLoginTest {
 
     @Mock
     private TokenService tokenService;
+
+    @Mock
+    private RefreshTokenLockService refreshTokenLockService;
 
     @Mock
     private JwtProvider jwtProvider;
@@ -67,8 +71,8 @@ class AuthApplicationAppleLoginTest {
 
     @BeforeEach
     void setUp() {
-        authApplication = new AuthApplication(tokenService, jwtProvider, jwtUtil, userDeviceService,
-                userService, kakaoClient, appleService);
+        authApplication = new AuthApplication(tokenService, refreshTokenLockService, jwtProvider, jwtUtil,
+                userDeviceService, userService, kakaoClient, appleService);
     }
 
     @DisplayName("애플 로그인에 성공하면 Apple 인증 결과로 유저를 조회·생성하고 토큰을 발급한다")

--- a/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationLogoutTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationLogoutTest.java
@@ -14,6 +14,7 @@ import org.websoso.WSSServer.auth.controller.dto.LogoutRequest;
 import org.websoso.WSSServer.auth.jwt.JWTUtil;
 import org.websoso.WSSServer.auth.jwt.JwtProvider;
 import org.websoso.WSSServer.auth.service.AppleService;
+import org.websoso.WSSServer.auth.service.RefreshTokenLockService;
 import org.websoso.WSSServer.auth.service.TokenService;
 import org.websoso.WSSServer.notification.service.UserDeviceService;
 import org.websoso.WSSServer.user.domain.User;
@@ -27,6 +28,9 @@ class AuthApplicationLogoutTest {
 
     @Mock
     private TokenService tokenService;
+
+    @Mock
+    private RefreshTokenLockService refreshTokenLockService;
 
     @Mock
     private JwtProvider jwtProvider;
@@ -53,8 +57,8 @@ class AuthApplicationLogoutTest {
 
     @BeforeEach
     void setUp() {
-        authApplication = new AuthApplication(tokenService, jwtProvider, jwtUtil, userDeviceService,
-                userService, kakaoClient, appleService);
+        authApplication = new AuthApplication(tokenService, refreshTokenLockService, jwtProvider, jwtUtil,
+                userDeviceService, userService, kakaoClient, appleService);
     }
 
     @DisplayName("로그아웃하면 요청에 담긴 리프레시 토큰을 삭제하고 UserDeviceService로 디바이스 식별자를 삭제한다")

--- a/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationReissueConcurrencyTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationReissueConcurrencyTest.java
@@ -1,0 +1,217 @@
+package org.websoso.WSSServer.auth.application;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.websoso.WSSServer.auth.client.KakaoClient;
+import org.websoso.WSSServer.auth.controller.dto.ReissueResponse;
+import org.websoso.WSSServer.auth.domain.RefreshToken;
+import org.websoso.WSSServer.auth.jwt.CustomAuthenticationToken;
+import org.websoso.WSSServer.auth.jwt.JWTUtil;
+import org.websoso.WSSServer.auth.jwt.JwtKeyProvider;
+import org.websoso.WSSServer.auth.jwt.JwtProvider;
+import org.websoso.WSSServer.auth.jwt.TestTokenFactory;
+import org.websoso.WSSServer.auth.repository.RefreshTokenRepository;
+import org.websoso.WSSServer.auth.service.AppleService;
+import org.websoso.WSSServer.auth.service.InMemoryRefreshTokenLockService;
+import org.websoso.WSSServer.auth.service.TokenService;
+import org.websoso.WSSServer.exception.exception.CustomAuthException;
+import org.websoso.WSSServer.notification.service.UserDeviceService;
+import org.websoso.WSSServer.user.service.UserService;
+
+/**
+ * 저장소를 토큰 문자열 키 기반 맵으로 흉내 내고, 저장된 토큰을 조회하는 시점에 지연이나 동기화를 끼워 넣어
+ * 동일 Refresh Token에 대한 동시 재발급 경합을 재현한다. 잠금이 없으면 여러 요청이 같은 토큰을 함께 조회해
+ * 모두 회전에 성공하므로, 잠금 도입 전에는 "정확히 하나만 성공" 검증이 실패한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthApplicationReissueConcurrencyTest {
+
+    private static final Long USER_ID = 42L;
+    private static final Long OTHER_USER_ID = 77L;
+    private static final int CONCURRENT_REQUESTS = 8;
+    private static final long LOOKUP_DELAY_MILLIS = 50L;
+    private static final long AWAIT_TIMEOUT_SECONDS = 5L;
+
+    private final JwtKeyProvider jwtKeyProvider = new JwtKeyProvider(TestTokenFactory.TEST_SECRET);
+    private final JwtProvider jwtProvider = new JwtProvider(jwtKeyProvider,
+            TestTokenFactory.ACCESS_TOKEN_EXPIRATION, TestTokenFactory.REFRESH_TOKEN_EXPIRATION);
+    private final JWTUtil jwtUtil = new JWTUtil(jwtKeyProvider);
+    private final Map<String, RefreshToken> refreshTokenStore = new ConcurrentHashMap<>();
+    private final InMemoryRefreshTokenLockService refreshTokenLockService = new InMemoryRefreshTokenLockService();
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private UserDeviceService userDeviceService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private KakaoClient kakaoClient;
+
+    @Mock
+    private AppleService appleService;
+
+    private AuthApplication authApplication;
+    private ExecutorService executor;
+
+    // 저장된 토큰을 조회한 직후 실행되어 경합 구간을 넓히거나 두 요청의 동시 진입을 확인한다.
+    private volatile ThrowingRunnable afterLookup = () -> {
+    };
+
+    @BeforeEach
+    void setUp() {
+        given(refreshTokenRepository.findByRefreshToken(anyString()))
+                .willAnswer(invocation -> {
+                    Optional<RefreshToken> found = Optional.ofNullable(
+                            refreshTokenStore.get(invocation.<String>getArgument(0)));
+                    afterLookup.run();
+                    return found;
+                });
+        given(refreshTokenRepository.save(any(RefreshToken.class)))
+                .willAnswer(invocation -> {
+                    RefreshToken saved = invocation.getArgument(0);
+                    refreshTokenStore.put(saved.getRefreshToken(), saved);
+                    return saved;
+                });
+        willAnswer(invocation -> refreshTokenStore.remove(
+                invocation.<RefreshToken>getArgument(0).getRefreshToken()))
+                .given(refreshTokenRepository).delete(any(RefreshToken.class));
+
+        TokenService tokenService = new TokenService(refreshTokenRepository);
+        authApplication = new AuthApplication(tokenService, refreshTokenLockService, jwtProvider, jwtUtil,
+                userDeviceService, userService, kakaoClient, appleService);
+        executor = Executors.newFixedThreadPool(CONCURRENT_REQUESTS);
+    }
+
+    @AfterEach
+    void tearDown() {
+        executor.shutdownNow();
+    }
+
+    @DisplayName("동일한 리프레시 토큰으로 동시에 재발급을 요청하면 정확히 하나만 성공한다")
+    @Test
+    void reissue_concurrentRequestsWithSameToken_succeedExactlyOnce() throws Exception {
+        String refreshToken = storeRefreshToken(USER_ID);
+        afterLookup = () -> Thread.sleep(LOOKUP_DELAY_MILLIS);
+
+        List<Future<ReissueResponse>> futures = submitConcurrentReissues(refreshToken, CONCURRENT_REQUESTS);
+
+        List<ReissueResponse> succeeded = new ArrayList<>();
+        int rejectedCount = 0;
+        for (Future<ReissueResponse> future : futures) {
+            try {
+                succeeded.add(future.get(AWAIT_TIMEOUT_SECONDS, SECONDS));
+            } catch (ExecutionException e) {
+                assertThat(e.getCause()).isInstanceOf(CustomAuthException.class);
+                rejectedCount++;
+            }
+        }
+
+        assertThat(succeeded).hasSize(1);
+        assertThat(rejectedCount).isEqualTo(CONCURRENT_REQUESTS - 1);
+    }
+
+    @DisplayName("동시 재발급 이후 저장소에는 성공한 요청이 발급한 리프레시 토큰만 남는다")
+    @Test
+    void reissue_concurrentRequestsWithSameToken_leaveOnlyTheWinningToken() throws Exception {
+        String refreshToken = storeRefreshToken(USER_ID);
+        afterLookup = () -> Thread.sleep(LOOKUP_DELAY_MILLIS);
+
+        List<Future<ReissueResponse>> futures = submitConcurrentReissues(refreshToken, CONCURRENT_REQUESTS);
+        List<ReissueResponse> succeeded = collectSucceeded(futures);
+
+        assertThat(succeeded).hasSize(1);
+        assertThat(refreshTokenStore).containsOnlyKeys(succeeded.get(0).refreshToken());
+    }
+
+    @DisplayName("동시 재발급이 끝나면 해당 토큰의 잠금은 남아 있지 않다")
+    @Test
+    void reissue_concurrentRequestsWithSameToken_releaseLockAfterCompletion() throws Exception {
+        String refreshToken = storeRefreshToken(USER_ID);
+        afterLookup = () -> Thread.sleep(LOOKUP_DELAY_MILLIS);
+
+        collectSucceeded(submitConcurrentReissues(refreshToken, CONCURRENT_REQUESTS));
+
+        assertThat(refreshTokenLockService.isLocked(refreshToken)).isFalse();
+    }
+
+    @DisplayName("서로 다른 리프레시 토큰의 재발급 요청은 서로를 막지 않고 동시에 진행된다")
+    @Test
+    void reissue_concurrentRequestsWithDifferentTokens_runInParallel() throws Exception {
+        String refreshToken = storeRefreshToken(USER_ID);
+        String otherRefreshToken = storeRefreshToken(OTHER_USER_ID);
+        // 두 요청이 각자의 잠금을 잡은 채 동시에 조회 구간에 들어와야만 통과한다.
+        CyclicBarrier bothInsideLock = new CyclicBarrier(2);
+        afterLookup = () -> bothInsideLock.await(AWAIT_TIMEOUT_SECONDS, SECONDS);
+
+        Future<ReissueResponse> first = executor.submit(() -> authApplication.reissue(refreshToken));
+        Future<ReissueResponse> second = executor.submit(() -> authApplication.reissue(otherRefreshToken));
+
+        ReissueResponse firstResponse = first.get(AWAIT_TIMEOUT_SECONDS, SECONDS);
+        ReissueResponse secondResponse = second.get(AWAIT_TIMEOUT_SECONDS, SECONDS);
+        assertThat(jwtUtil.getUserIdFromJwt(firstResponse.refreshToken())).isEqualTo(USER_ID);
+        assertThat(jwtUtil.getUserIdFromJwt(secondResponse.refreshToken())).isEqualTo(OTHER_USER_ID);
+        assertThat(refreshTokenStore).containsOnlyKeys(firstResponse.refreshToken(), secondResponse.refreshToken());
+    }
+
+    private String storeRefreshToken(Long userId) {
+        String refreshToken = jwtProvider.generateRefreshToken(CustomAuthenticationToken.create(userId));
+        refreshTokenStore.put(refreshToken, new RefreshToken(refreshToken, userId));
+        return refreshToken;
+    }
+
+    private List<Future<ReissueResponse>> submitConcurrentReissues(String refreshToken, int count) {
+        CyclicBarrier startLine = new CyclicBarrier(count);
+        List<Future<ReissueResponse>> futures = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            futures.add(executor.submit(() -> {
+                startLine.await(AWAIT_TIMEOUT_SECONDS, SECONDS);
+                return authApplication.reissue(refreshToken);
+            }));
+        }
+        return futures;
+    }
+
+    private List<ReissueResponse> collectSucceeded(List<Future<ReissueResponse>> futures) throws Exception {
+        List<ReissueResponse> succeeded = new ArrayList<>();
+        for (Future<ReissueResponse> future : futures) {
+            try {
+                succeeded.add(future.get(AWAIT_TIMEOUT_SECONDS, SECONDS));
+            } catch (ExecutionException e) {
+                assertThat(e.getCause()).isInstanceOf(CustomAuthException.class);
+            }
+        }
+        return succeeded;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+
+        void run() throws Exception;
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationReissueLockTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationReissueLockTest.java
@@ -1,0 +1,164 @@
+package org.websoso.WSSServer.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.INVALID_TOKEN;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.websoso.WSSServer.auth.client.KakaoClient;
+import org.websoso.WSSServer.auth.domain.RefreshToken;
+import org.websoso.WSSServer.auth.jwt.JWTUtil;
+import org.websoso.WSSServer.auth.jwt.JwtKeyProvider;
+import org.websoso.WSSServer.auth.jwt.JwtProvider;
+import org.websoso.WSSServer.auth.jwt.TestTokenFactory;
+import org.websoso.WSSServer.auth.service.AppleService;
+import org.websoso.WSSServer.auth.service.RefreshTokenLockService;
+import org.websoso.WSSServer.auth.service.TokenService;
+import org.websoso.WSSServer.exception.exception.CustomAuthException;
+import org.websoso.WSSServer.notification.service.UserDeviceService;
+import org.websoso.WSSServer.user.service.UserService;
+
+/**
+ * 재발급 유스케이스가 잠금을 어떤 순서로 사용하는지 검증한다.
+ * 잠금 자체의 동시성 동작은 {@link AuthApplicationReissueConcurrencyTest}에서 확인한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthApplicationReissueLockTest {
+
+    private static final Long USER_ID = 42L;
+
+    private final TestTokenFactory testTokenFactory = new TestTokenFactory();
+    private final JwtKeyProvider jwtKeyProvider = new JwtKeyProvider(TestTokenFactory.TEST_SECRET);
+    private final JwtProvider jwtProvider = new JwtProvider(jwtKeyProvider,
+            TestTokenFactory.ACCESS_TOKEN_EXPIRATION, TestTokenFactory.REFRESH_TOKEN_EXPIRATION);
+    private final JWTUtil jwtUtil = new JWTUtil(jwtKeyProvider);
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private RefreshTokenLockService refreshTokenLockService;
+
+    @Mock
+    private UserDeviceService userDeviceService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private KakaoClient kakaoClient;
+
+    @Mock
+    private AppleService appleService;
+
+    private AuthApplication authApplication;
+
+    @BeforeEach
+    void setUp() {
+        authApplication = new AuthApplication(tokenService, refreshTokenLockService, jwtProvider, jwtUtil,
+                userDeviceService, userService, kakaoClient, appleService);
+    }
+
+    @DisplayName("잠금을 획득하지 못하면 저장된 토큰을 조회하지 않고 기존 INVALID_TOKEN 계약으로 거부한다")
+    @Test
+    void reissue_whenLockNotAcquired_throwsInvalidTokenWithoutRotating() {
+        String refreshToken = testTokenFactory.createRefreshToken(USER_ID);
+        given(refreshTokenLockService.tryLock(eq(refreshToken), anyString())).willReturn(false);
+
+        assertThatThrownBy(() -> authApplication.reissue(refreshToken))
+                .isInstanceOf(CustomAuthException.class)
+                .extracting(throwable -> ((CustomAuthException) throwable).getICustomError())
+                .isEqualTo(INVALID_TOKEN);
+
+        then(tokenService).shouldHaveNoInteractions();
+        then(refreshTokenLockService).should(never()).unlock(anyString(), anyString());
+    }
+
+    @DisplayName("잠금을 획득한 뒤에 저장된 토큰 존재 여부를 다시 확인하고 회전한다")
+    @Test
+    void reissue_verifiesStoredTokenAfterAcquiringLock() {
+        String refreshToken = testTokenFactory.createRefreshToken(USER_ID);
+        given(refreshTokenLockService.tryLock(eq(refreshToken), anyString())).willReturn(true);
+        given(tokenService.findRefreshTokenOrThrow(refreshToken))
+                .willReturn(new RefreshToken(refreshToken, USER_ID));
+
+        authApplication.reissue(refreshToken);
+
+        InOrder inOrder = Mockito.inOrder(refreshTokenLockService, tokenService);
+        inOrder.verify(refreshTokenLockService).tryLock(eq(refreshToken), anyString());
+        inOrder.verify(tokenService).findRefreshTokenOrThrow(refreshToken);
+        inOrder.verify(tokenService).rotateRefreshToken(Mockito.any(), anyString(), eq(USER_ID));
+        inOrder.verify(refreshTokenLockService).unlock(eq(refreshToken), anyString());
+    }
+
+    @DisplayName("잠금은 획득할 때 사용한 요청별 소유자 값으로 해제한다")
+    @Test
+    void reissue_releasesLockWithTheSameRequestOwner() {
+        String refreshToken = testTokenFactory.createRefreshToken(USER_ID);
+        ArgumentCaptor<String> lockOwnerCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> unlockOwnerCaptor = ArgumentCaptor.forClass(String.class);
+        given(refreshTokenLockService.tryLock(eq(refreshToken), anyString())).willReturn(true);
+        given(tokenService.findRefreshTokenOrThrow(refreshToken))
+                .willReturn(new RefreshToken(refreshToken, USER_ID));
+
+        authApplication.reissue(refreshToken);
+
+        then(refreshTokenLockService).should().tryLock(eq(refreshToken), lockOwnerCaptor.capture());
+        then(refreshTokenLockService).should().unlock(eq(refreshToken), unlockOwnerCaptor.capture());
+        assertThat(unlockOwnerCaptor.getValue()).isEqualTo(lockOwnerCaptor.getValue());
+    }
+
+    @DisplayName("요청마다 서로 다른 잠금 소유자 값을 사용한다")
+    @Test
+    void reissue_usesDifferentLockOwnerPerRequest() {
+        String refreshToken = testTokenFactory.createRefreshToken(USER_ID);
+        ArgumentCaptor<String> lockOwnerCaptor = ArgumentCaptor.forClass(String.class);
+        given(refreshTokenLockService.tryLock(eq(refreshToken), anyString())).willReturn(true);
+        given(tokenService.findRefreshTokenOrThrow(refreshToken))
+                .willReturn(new RefreshToken(refreshToken, USER_ID));
+
+        authApplication.reissue(refreshToken);
+        authApplication.reissue(refreshToken);
+
+        then(refreshTokenLockService).should(Mockito.times(2)).tryLock(eq(refreshToken), lockOwnerCaptor.capture());
+        assertThat(lockOwnerCaptor.getAllValues()).doesNotHaveDuplicates();
+    }
+
+    @DisplayName("회전 도중 예외가 발생해도 잠금을 해제한다")
+    @Test
+    void reissue_whenRotationFails_stillReleasesLock() {
+        String refreshToken = testTokenFactory.createRefreshToken(USER_ID);
+        given(refreshTokenLockService.tryLock(eq(refreshToken), anyString())).willReturn(true);
+        given(tokenService.findRefreshTokenOrThrow(refreshToken))
+                .willThrow(new CustomAuthException(INVALID_TOKEN, "given token is invalid token for reissue"));
+
+        assertThatThrownBy(() -> authApplication.reissue(refreshToken))
+                .isInstanceOf(CustomAuthException.class);
+
+        then(refreshTokenLockService).should().unlock(eq(refreshToken), anyString());
+    }
+
+    @DisplayName("서명 검증에 실패한 토큰은 잠금을 시도하지 않는다")
+    @Test
+    void reissue_whenTokenIsInvalid_doesNotTouchLock() {
+        String expiredRefreshToken = testTokenFactory.createExpiredRefreshToken(USER_ID);
+
+        assertThatThrownBy(() -> authApplication.reissue(expiredRefreshToken))
+                .isInstanceOf(CustomAuthException.class);
+
+        then(refreshTokenLockService).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationReissueRotationTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationReissueRotationTest.java
@@ -27,6 +27,8 @@ import org.websoso.WSSServer.auth.jwt.JwtProvider;
 import org.websoso.WSSServer.auth.jwt.TestTokenFactory;
 import org.websoso.WSSServer.auth.repository.RefreshTokenRepository;
 import org.websoso.WSSServer.auth.service.AppleService;
+import org.websoso.WSSServer.auth.service.InMemoryRefreshTokenLockService;
+import org.websoso.WSSServer.auth.service.RefreshTokenLockService;
 import org.websoso.WSSServer.auth.service.TokenService;
 import org.websoso.WSSServer.exception.exception.CustomAuthException;
 import org.websoso.WSSServer.notification.service.UserDeviceService;
@@ -47,6 +49,7 @@ class AuthApplicationReissueRotationTest {
             TestTokenFactory.ACCESS_TOKEN_EXPIRATION, TestTokenFactory.REFRESH_TOKEN_EXPIRATION);
     private final JWTUtil jwtUtil = new JWTUtil(jwtKeyProvider);
     private final Map<String, RefreshToken> refreshTokenStore = new HashMap<>();
+    private final RefreshTokenLockService refreshTokenLockService = new InMemoryRefreshTokenLockService();
 
     @Mock
     private RefreshTokenRepository refreshTokenRepository;
@@ -85,8 +88,8 @@ class AuthApplicationReissueRotationTest {
                 .given(refreshTokenRepository).delete(any(RefreshToken.class));
 
         tokenService = new TokenService(refreshTokenRepository);
-        authApplication = new AuthApplication(tokenService, jwtProvider, jwtUtil, userDeviceService,
-                userService, kakaoClient, appleService);
+        authApplication = new AuthApplication(tokenService, refreshTokenLockService, jwtProvider, jwtUtil,
+                userDeviceService, userService, kakaoClient, appleService);
     }
 
     @DisplayName("재발급에 성공하면 기존 리프레시 토큰은 저장소에서 사라져 다시 재발급에 사용할 수 없다")

--- a/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationReissueTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/application/AuthApplicationReissueTest.java
@@ -24,6 +24,8 @@ import org.websoso.WSSServer.auth.jwt.JwtKeyProvider;
 import org.websoso.WSSServer.auth.jwt.JwtProvider;
 import org.websoso.WSSServer.auth.jwt.TestTokenFactory;
 import org.websoso.WSSServer.auth.service.AppleService;
+import org.websoso.WSSServer.auth.service.InMemoryRefreshTokenLockService;
+import org.websoso.WSSServer.auth.service.RefreshTokenLockService;
 import org.websoso.WSSServer.auth.service.TokenService;
 import org.websoso.WSSServer.exception.exception.CustomAuthException;
 import org.websoso.WSSServer.notification.service.UserDeviceService;
@@ -39,6 +41,7 @@ class AuthApplicationReissueTest {
     private final JwtProvider jwtProvider = new JwtProvider(jwtKeyProvider,
             TestTokenFactory.ACCESS_TOKEN_EXPIRATION, TestTokenFactory.REFRESH_TOKEN_EXPIRATION);
     private final JWTUtil jwtUtil = new JWTUtil(jwtKeyProvider);
+    private final RefreshTokenLockService refreshTokenLockService = new InMemoryRefreshTokenLockService();
 
     @Mock
     private TokenService tokenService;
@@ -59,8 +62,8 @@ class AuthApplicationReissueTest {
 
     @BeforeEach
     void setUp() {
-        authApplication = new AuthApplication(tokenService, jwtProvider, jwtUtil, userDeviceService,
-                userService, kakaoClient, appleService);
+        authApplication = new AuthApplication(tokenService, refreshTokenLockService, jwtProvider, jwtUtil,
+                userDeviceService, userService, kakaoClient, appleService);
     }
 
     @DisplayName("유효한 리프레시 토큰이면 Access/Refresh Token을 모두 재발급하고 기존 토큰을 회전한다")

--- a/src/test/java/org/websoso/WSSServer/auth/service/InMemoryRefreshTokenLockService.java
+++ b/src/test/java/org/websoso/WSSServer/auth/service/InMemoryRefreshTokenLockService.java
@@ -1,0 +1,57 @@
+package org.websoso.WSSServer.auth.service;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Redis 없이 {@link RefreshTokenLockService} 계약을 그대로 흉내 내는 테스트 대역이다.
+ * 토큰 단위 잠금, 요청별 소유자, 만료 시간, 소유자 비교 후 삭제라는 동작을 실제 구현과 동일하게 제공한다.
+ */
+public class InMemoryRefreshTokenLockService implements RefreshTokenLockService {
+
+    private final Map<String, Holder> locks = new ConcurrentHashMap<>();
+    private final Duration timeToLive;
+
+    public InMemoryRefreshTokenLockService() {
+        this(Duration.ofSeconds(5));
+    }
+
+    public InMemoryRefreshTokenLockService(Duration timeToLive) {
+        this.timeToLive = timeToLive;
+    }
+
+    @Override
+    public boolean tryLock(String refreshToken, String owner) {
+        long now = System.nanoTime();
+        Holder holder = locks.compute(refreshToken, (key, current) -> {
+            if (current != null && current.expiresAtNanos() - now > 0) {
+                return current;
+            }
+            return new Holder(owner, now + timeToLive.toNanos());
+        });
+        return holder.owner().equals(owner);
+    }
+
+    @Override
+    public boolean unlock(String refreshToken, String owner) {
+        AtomicBoolean unlocked = new AtomicBoolean(false);
+        locks.computeIfPresent(refreshToken, (key, current) -> {
+            if (!current.owner().equals(owner)) {
+                return current;
+            }
+            unlocked.set(true);
+            return null;
+        });
+        return unlocked.get();
+    }
+
+    public boolean isLocked(String refreshToken) {
+        Holder holder = locks.get(refreshToken);
+        return holder != null && holder.expiresAtNanos() - System.nanoTime() > 0;
+    }
+
+    private record Holder(String owner, long expiresAtNanos) {
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/auth/service/RefreshTokenLockServiceImplTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/service/RefreshTokenLockServiceImplTest.java
@@ -1,0 +1,199 @@
+package org.websoso.WSSServer.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+class RefreshTokenLockServiceImplTest {
+
+    private static final String REFRESH_TOKEN = "header.payload.signature";
+    private static final String OTHER_REFRESH_TOKEN = "header.other-payload.other-signature";
+    private static final String OWNER = "owner-of-this-request";
+    private static final String OTHER_OWNER = "owner-of-another-request";
+
+    @ExtendWith(MockitoExtension.class)
+    @Nested
+    class TryLock {
+
+        @Mock
+        private StringRedisTemplate stringRedisTemplate;
+
+        @Mock
+        private ValueOperations<String, String> valueOperations;
+
+        private RefreshTokenLockServiceImpl refreshTokenLockService;
+
+        @BeforeEach
+        void setUp() {
+            given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+            refreshTokenLockService = new RefreshTokenLockServiceImpl(stringRedisTemplate);
+        }
+
+        @DisplayName("잠금은 아직 없을 때만 만료 시간과 함께 요청별 소유자 값으로 설정한다")
+        @Test
+        void tryLock_setsOwnerOnlyIfAbsentWithExpiration() {
+            ArgumentCaptor<Duration> timeToLiveCaptor = ArgumentCaptor.forClass(Duration.class);
+            given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+
+            boolean acquired = refreshTokenLockService.tryLock(REFRESH_TOKEN, OWNER);
+
+            assertThat(acquired).isTrue();
+            then(valueOperations).should().setIfAbsent(anyString(), eq(OWNER), timeToLiveCaptor.capture());
+            assertThat(timeToLiveCaptor.getValue()).isPositive();
+        }
+
+        @DisplayName("잠금 키에는 raw 리프레시 토큰 대신 해시를 사용한다")
+        @Test
+        void tryLock_doesNotExposeRawRefreshTokenInKey() {
+            ArgumentCaptor<String> lockKeyCaptor = ArgumentCaptor.forClass(String.class);
+            given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+
+            refreshTokenLockService.tryLock(REFRESH_TOKEN, OWNER);
+
+            then(valueOperations).should().setIfAbsent(lockKeyCaptor.capture(), anyString(), any(Duration.class));
+            assertThat(lockKeyCaptor.getValue()).doesNotContain(REFRESH_TOKEN);
+            assertThat(lockKeyCaptor.getValue()).startsWith("refreshTokenLock:");
+        }
+
+        @DisplayName("같은 토큰은 같은 잠금 키를, 다른 토큰은 다른 잠금 키를 사용한다")
+        @Test
+        void tryLock_usesTokenScopedKey() {
+            ArgumentCaptor<String> lockKeyCaptor = ArgumentCaptor.forClass(String.class);
+            given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(true);
+
+            refreshTokenLockService.tryLock(REFRESH_TOKEN, OWNER);
+            refreshTokenLockService.tryLock(REFRESH_TOKEN, OTHER_OWNER);
+            refreshTokenLockService.tryLock(OTHER_REFRESH_TOKEN, OWNER);
+
+            then(valueOperations).should(org.mockito.Mockito.times(3))
+                    .setIfAbsent(lockKeyCaptor.capture(), anyString(), any(Duration.class));
+            List<String> lockKeys = lockKeyCaptor.getAllValues();
+            assertThat(lockKeys.get(0)).isEqualTo(lockKeys.get(1));
+            assertThat(lockKeys.get(2)).isNotEqualTo(lockKeys.get(0));
+        }
+
+        @DisplayName("이미 다른 요청이 잠금을 보유하고 있으면 대기하지 않고 실패한다")
+        @Test
+        void tryLock_returnsFalseWhenAlreadyHeld() {
+            given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(false);
+
+            assertThat(refreshTokenLockService.tryLock(REFRESH_TOKEN, OWNER)).isFalse();
+        }
+
+        @DisplayName("설정 결과를 알 수 없으면 잠금을 획득하지 않은 것으로 본다")
+        @Test
+        void tryLock_returnsFalseWhenResultIsNull() {
+            given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).willReturn(null);
+
+            assertThat(refreshTokenLockService.tryLock(REFRESH_TOKEN, OWNER)).isFalse();
+        }
+    }
+
+    /**
+     * 해제 스크립트가 실제 Redis에서 하는 일을 그대로 흉내 내어, 서비스가 넘기는 KEYS/ARGV 조합만으로
+     * 소유자 비교 후 삭제가 성립하는지 확인한다. 스크립트 본문 자체는 별도로 검증한다.
+     */
+    @ExtendWith(MockitoExtension.class)
+    @Nested
+    class Unlock {
+
+        private final Map<String, String> redis = new HashMap<>();
+
+        @Mock
+        private StringRedisTemplate stringRedisTemplate;
+
+        private RefreshTokenLockServiceImpl refreshTokenLockService;
+
+        @BeforeEach
+        void setUp() {
+            given(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+                    .willAnswer(invocation -> {
+                        String lockKey = invocation.<List<String>>getArgument(1).get(0);
+                        String owner = invocation.getArgument(2);
+                        if (!owner.equals(redis.get(lockKey))) {
+                            return 0L;
+                        }
+                        redis.remove(lockKey);
+                        return 1L;
+                    });
+            refreshTokenLockService = new RefreshTokenLockServiceImpl(stringRedisTemplate);
+        }
+
+        @DisplayName("해제 스크립트는 소유자가 일치할 때만 삭제하도록 작성되어 있다")
+        @Test
+        void unlock_scriptComparesOwnerBeforeDeleting() {
+            ArgumentCaptor<RedisScript<Long>> scriptCaptor = ArgumentCaptor.forClass(RedisScript.class);
+
+            refreshTokenLockService.unlock(REFRESH_TOKEN, OWNER);
+
+            then(stringRedisTemplate).should().execute(scriptCaptor.capture(), anyList(), anyString());
+            String script = scriptCaptor.getValue().getScriptAsString().replace(" ", "");
+            assertThat(script).contains("redis.call('get',KEYS[1])==ARGV[1]");
+            assertThat(script).contains("redis.call('del',KEYS[1])");
+            assertThat(scriptCaptor.getValue().getResultType()).isEqualTo(Long.class);
+        }
+
+        @DisplayName("자신이 보유한 잠금은 해제한다")
+        @Test
+        void unlock_releasesOwnLock() {
+            holdLock(REFRESH_TOKEN, OWNER);
+
+            assertThat(refreshTokenLockService.unlock(REFRESH_TOKEN, OWNER)).isTrue();
+            assertThat(redis).isEmpty();
+        }
+
+        @DisplayName("만료 등으로 다른 요청이 획득한 잠금은 해제하지 못하고 그대로 남긴다")
+        @Test
+        void unlock_doesNotReleaseLockHeldByAnotherOwner() {
+            holdLock(REFRESH_TOKEN, OTHER_OWNER);
+
+            assertThat(refreshTokenLockService.unlock(REFRESH_TOKEN, OWNER)).isFalse();
+            assertThat(redis).containsEntry(lockKeyOf(REFRESH_TOKEN), OTHER_OWNER);
+        }
+
+        @DisplayName("이미 만료되어 사라진 잠금을 해제하면 해제하지 않은 것으로 본다")
+        @Test
+        void unlock_returnsFalseWhenLockAlreadyExpired() {
+            assertThat(refreshTokenLockService.unlock(REFRESH_TOKEN, OWNER)).isFalse();
+        }
+
+        private void holdLock(String refreshToken, String owner) {
+            redis.put(lockKeyOf(refreshToken), owner);
+        }
+    }
+
+    // 서비스와 동일한 규칙(prefix + SHA-256 hex)으로 잠금 키를 계산한다.
+    private static String lockKeyOf(String refreshToken) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(refreshToken.getBytes(StandardCharsets.UTF_8));
+            return "refreshTokenLock:" + HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue
- fix/#572 -> dev
- Closes #572

## Key Changes
- 동일 Refresh Token 단위로 Redis 잠금을 획득하고, 잠금 안에서 저장된 토큰을 다시 확인한 뒤 Token Pair를 회전하도록 재발급 흐름을 보호했습니다.
- 잠금 키에는 raw 토큰 대신 SHA-256 해시를 사용하고 요청별 UUID 소유자와 5초 TTL을 적용했으며, Lua 스크립트로 소유자 비교와 삭제를 원자적으로 수행합니다.
- 동일 토큰 동시 요청은 정확히 하나만 성공하고 서로 다른 토큰은 병렬 처리되는지, 비소유자 해제와 만료 처리가 안전한지 회귀 테스트로 검증했습니다.

## To Reviewers
- 동일 토큰으로 동시에 재발급하면 하나만 성공하고 나머지는 기존 `INVALID_TOKEN`(`AUTH-001`, 401) 계약으로 처리됩니다. API 경로·요청·응답 구조는 변경하지 않았습니다.
- 운영 Redis에 `refreshTokenLock:<sha256>` 키가 최대 5초간 생성되며 잠금 해제에 Lua `EVAL`을 사용합니다. 신규 의존성이나 별도 설정은 없습니다.
- Java 17 기준 `./gradlew build -x test`와 잠금·동시성 관련 테스트는 성공했습니다. 전체 테스트의 13개 실패는 clean `origin/dev` baseline과 동일합니다.
- 클라이언트 계약, DB DDL·제약조건, 배포 설정 변경은 없습니다.
- PR #589와 `AuthApplication` 생성자 테스트 파일이 겹치므로 이 PR을 먼저 merge한 뒤 #589를 최신 `dev`에 맞추는 순서를 권장합니다.

## References
- Follow-up to #557
- Related to #554