### PR TITLE
[REFACTOR] GET /novels/taste 응답 지연 개선

### DIFF
--- a/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
+++ b/src/main/java/org/websoso/WSSServer/application/SearchNovelApplication.java
@@ -157,6 +157,7 @@ public class SearchNovelApplication {
         );
     }
 
+    // 선호 장르의 추천 작품과 집계 통계를 조회한다.
     @Transactional(readOnly = true)
     public TasteNovelsGetResponse getTasteNovels(User user) {
         // TODO: 선호하는 장르 리스트는 유저에서 가져오도록 해야함
@@ -166,9 +167,16 @@ public class SearchNovelApplication {
                 .toList();
 
         List<Novel> tasteNovels = libraryService.getTasteNovels(preferGenres);
+        List<Long> tasteNovelIds = tasteNovels.stream()
+                .map(Novel::getNovelId)
+                .toList();
+        Map<Long, Long> interestCounts = libraryService.getInterestCountsByNovelIds(tasteNovelIds);
 
         List<TasteNovelGetResponse> tasteNovelGetResponses = tasteNovels.stream()
-                .map(TasteNovelGetResponse::of)
+                .map(tasteNovel -> TasteNovelGetResponse.of(
+                        tasteNovel,
+                        interestCounts.getOrDefault(tasteNovel.getNovelId(), 0L)
+                ))
                 .toList();
 
         return TasteNovelsGetResponse.of(tasteNovelGetResponses);

--- a/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponse.java
@@ -1,7 +1,7 @@
 package org.websoso.WSSServer.dto.userNovel;
 
 import org.websoso.WSSServer.novel.domain.Novel;
-import org.websoso.WSSServer.library.domain.UserNovel;
+import org.websoso.WSSServer.novel.domain.NovelStatistics;
 
 public record TasteNovelGetResponse(
         Long novelId,
@@ -13,46 +13,24 @@ public record TasteNovelGetResponse(
         Long novelRatingCount
 ) {
 
-    public static TasteNovelGetResponse of(Novel tasteNovel) {
-        Long novelRatingCount = getNovelRatingCount(tasteNovel);
-        Float novelRating = getNovelRating(tasteNovel, novelRatingCount);
+    // 작품과 미리 집계한 관심 수로 취향 추천 응답을 생성한다.
+    public static TasteNovelGetResponse of(Novel tasteNovel, Long interestCount) {
+        NovelStatistics statistics = tasteNovel.getNovelStatistics();
+        Float novelRating = statistics == null
+                ? 0.0f
+                : statistics.getAverageRating().floatValue();
+        Long novelRatingCount = statistics == null
+                ? 0L
+                : statistics.getRatingCount();
 
         return new TasteNovelGetResponse(
                 tasteNovel.getNovelId(),
                 tasteNovel.getTitle(),
                 tasteNovel.getAuthor(),
                 tasteNovel.getNovelImage(),
-                getInterestCount(tasteNovel),
+                interestCount,
                 novelRating,
                 novelRatingCount
         );
-    }
-
-    private static Long getInterestCount(Novel tasteNovel) {
-        return tasteNovel.getUserNovels()
-                .stream()
-                .filter(UserNovel::getIsInterest)
-                .count();
-    }
-
-    private static Long getNovelRatingCount(Novel tasteNovel) {
-        return tasteNovel.getUserNovels()
-                .stream()
-                .filter(userNovel -> userNovel.getUserNovelRating() != 0.0f)
-                .count();
-    }
-
-    private static Float getNovelRatingSum(Novel tasteNovel) {
-        return (float) tasteNovel.getUserNovels()
-                .stream()
-                .filter(userNovel -> userNovel.getUserNovelRating() != 0.0f)
-                .mapToDouble(UserNovel::getUserNovelRating)
-                .sum();
-    }
-
-    private static float getNovelRating(Novel tasteNovel, Long novelRatingCount) {
-        return novelRatingCount > 0
-                ? getNovelRatingSum(tasteNovel) / novelRatingCount
-                : 0.0f;
     }
 }

--- a/src/main/java/org/websoso/WSSServer/library/repository/UserNovelCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/library/repository/UserNovelCustomRepositoryImpl.java
@@ -7,6 +7,7 @@ import static org.websoso.WSSServer.domain.common.UserNovelSortType.readDateExpr
 import static org.websoso.WSSServer.library.domain.QUserNovel.userNovel;
 import static org.websoso.WSSServer.novel.domain.QNovel.novel;
 import static org.websoso.WSSServer.novel.domain.QNovelGenre.novelGenre;
+import static org.websoso.WSSServer.novel.domain.QNovelStatistics.novelStatistics;
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -19,6 +20,7 @@ import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +41,7 @@ import org.websoso.WSSServer.user.domain.User;
 public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository {
 
     private static final long NO_CURSOR = 0L;
+    private static final long TASTE_NOVEL_LIMIT = 10L;
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
@@ -121,20 +124,34 @@ public class UserNovelCustomRepositoryImpl implements UserNovelCustomRepository 
                 .fetch();
     }
 
+    // 선호 장르의 최신 평가 작품 10건과 통계를 조회한다.
     @Override
     public List<Novel> findTasteNovels(List<Genre> preferGenres) {
-        return jpaQueryFactory
-                .select(userNovel.novel, userNovel.userNovelId)
+        List<Long> tasteNovelIds = jpaQueryFactory
+                .select(novel.novelId)
                 .from(userNovel)
                 .join(userNovel.novel, novel)
                 .join(novelGenre).on(novelGenre.novel.eq(novel))
                 .where(novelGenre.genre.in(preferGenres))
-                .orderBy(userNovel.userNovelId.desc())
+                .groupBy(novel.novelId)
+                .orderBy(userNovel.userNovelId.max().desc())
+                .limit(TASTE_NOVEL_LIMIT)
+                .fetch();
+
+        if (tasteNovelIds.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, Novel> tasteNovelsById = jpaQueryFactory
+                .selectFrom(novel)
+                .leftJoin(novel.novelStatistics, novelStatistics).fetchJoin()
+                .where(novel.novelId.in(tasteNovelIds))
                 .fetch()
                 .stream()
-                .map(tuple -> tuple.get(userNovel.novel))
-                .distinct()
-                .limit(10)
+                .collect(Collectors.toMap(Novel::getNovelId, tasteNovel -> tasteNovel));
+
+        return tasteNovelIds.stream()
+                .map(tasteNovelsById::get)
                 .toList();
     }
 

--- a/src/test/java/org/websoso/WSSServer/application/SearchNovelApplicationTest.java
+++ b/src/test/java/org/websoso/WSSServer/application/SearchNovelApplicationTest.java
@@ -1,0 +1,127 @@
+package org.websoso.WSSServer.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.websoso.WSSServer.domain.Genre;
+import org.websoso.WSSServer.domain.GenrePreference;
+import org.websoso.WSSServer.dto.userNovel.TasteNovelGetResponse;
+import org.websoso.WSSServer.dto.userNovel.TasteNovelsGetResponse;
+import org.websoso.WSSServer.feed.feed.repository.FeedRepository;
+import org.websoso.WSSServer.library.service.AttractivePointService;
+import org.websoso.WSSServer.library.service.KeywordService;
+import org.websoso.WSSServer.library.service.LibraryService;
+import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.novel.domain.NovelStatistics;
+import org.websoso.WSSServer.novel.service.GenreServiceImpl;
+import org.websoso.WSSServer.novel.service.KeywordServiceImpl;
+import org.websoso.WSSServer.novel.service.NovelServiceImpl;
+import org.websoso.WSSServer.novel.service.PopularNovelService;
+import org.websoso.WSSServer.repository.GenrePreferenceRepository;
+import org.websoso.WSSServer.user.domain.User;
+import org.websoso.WSSServer.user.repository.AvatarProfileRepository;
+import org.websoso.WSSServer.user.service.BlockService;
+
+/**
+ * 작품 검색 애플리케이션의 조회 조합 로직을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class SearchNovelApplicationTest {
+
+    @InjectMocks
+    private SearchNovelApplication searchNovelApplication;
+
+    @Mock
+    private NovelServiceImpl novelService;
+
+    @Mock
+    private PopularNovelService popularNovelService;
+
+    @Mock
+    private GenreServiceImpl genreService;
+
+    @Mock
+    private AttractivePointService attractivePointService;
+
+    @Mock
+    private KeywordService libraryKeywordService;
+
+    @Mock
+    private KeywordServiceImpl keywordService;
+
+    @Mock
+    private LibraryService libraryService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private BlockService blockService;
+
+    @Mock
+    private FeedRepository feedRepository;
+
+    @Mock
+    private GenrePreferenceRepository genrePreferenceRepository;
+
+    @Mock
+    private AvatarProfileRepository avatarProfileRepository;
+
+    @Mock
+    private User user;
+
+    @Mock
+    private GenrePreference genrePreference;
+
+    @Mock
+    private Genre genre;
+
+    @Mock
+    private Novel novel;
+
+    @Mock
+    private NovelStatistics novelStatistics;
+
+    // 추천 작품의 관심 수와 평점 통계를 컬렉션 로딩 없이 응답에 반영하는지 검증한다.
+    @DisplayName("취향 추천 작품의 통계를 일괄 조회 결과로 반환한다")
+    @Test
+    void getsTasteNovelsWithAggregatedStatistics() {
+        given(genrePreferenceRepository.findByUser(user)).willReturn(List.of(genrePreference));
+        given(genrePreference.getGenre()).willReturn(genre);
+        given(libraryService.getTasteNovels(List.of(genre))).willReturn(List.of(novel));
+        given(novel.getNovelId()).willReturn(1L);
+        given(novel.getTitle()).willReturn("작품명");
+        given(novel.getAuthor()).willReturn("작가명");
+        given(novel.getNovelImage()).willReturn("https://example.com/novel.png");
+        given(novel.getNovelStatistics()).willReturn(novelStatistics);
+        given(novelStatistics.getAverageRating()).willReturn(new BigDecimal("4.250"));
+        given(novelStatistics.getRatingCount()).willReturn(8L);
+        given(libraryService.getInterestCountsByNovelIds(List.of(1L))).willReturn(Map.of(1L, 3L));
+
+        TasteNovelsGetResponse response = searchNovelApplication.getTasteNovels(user);
+
+        assertThat(response.tasteNovels()).containsExactly(new TasteNovelGetResponse(
+                1L,
+                "작품명",
+                "작가명",
+                "https://example.com/novel.png",
+                3L,
+                4.25f,
+                8L
+        ));
+        then(libraryService).should().getInterestCountsByNovelIds(List.of(1L));
+        then(novel).should(never()).getUserNovels();
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponseTest.java
+++ b/src/test/java/org/websoso/WSSServer/dto/userNovel/TasteNovelGetResponseTest.java
@@ -1,0 +1,43 @@
+package org.websoso.WSSServer.dto.userNovel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.websoso.WSSServer.novel.domain.Novel;
+
+/**
+ * 취향 추천 작품 응답의 통계 기본값 매핑을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class TasteNovelGetResponseTest {
+
+    @Mock
+    private Novel novel;
+
+    // 작품 통계가 없을 때 평점과 평가 수를 0으로 반환하는지 검증한다.
+    @DisplayName("작품 통계가 없으면 평점 통계를 0으로 반환한다")
+    @Test
+    void returnsZeroRatingWhenStatisticsDoNotExist() {
+        given(novel.getNovelId()).willReturn(1L);
+        given(novel.getTitle()).willReturn("작품명");
+        given(novel.getAuthor()).willReturn("작가명");
+        given(novel.getNovelImage()).willReturn("https://example.com/novel.png");
+
+        TasteNovelGetResponse response = TasteNovelGetResponse.of(novel, 2L);
+
+        assertThat(response).isEqualTo(new TasteNovelGetResponse(
+                1L,
+                "작품명",
+                "작가명",
+                "https://example.com/novel.png",
+                2L,
+                0.0f,
+                0L
+        ));
+    }
+}


### PR DESCRIPTION
## Related Issue
- refactor/#591 -> dev
- close #591

## Key Changes
- 선호 장르 추천 후보를 애플리케이션에서 전체 조회한 뒤 중복 제거하던 로직을 DB의 `GROUP BY`와 `MAX(user_novel_id)` 기준 정렬, `LIMIT 10`으로 변경했습니다.
- 선별된 작품의 `novel_statistics`를 페치 조인해 후보 작품마다 발생하던 통계 조회 N+1을 제거했습니다.
- 관심 수는 기존 작품별 일괄 집계 쿼리를 재사용하고, 평점과 평가 수는 `novel_statistics`에서 조회해 `userNovels` 컬렉션 로딩을 제거했습니다.
- 추천 작품의 기존 최신순 의미를 유지하며 원본 로그 기준 125개였던 조회 쿼리를 구조상 약 5개로 줄였습니다.
- 일괄 집계 결과 매핑과 통계가 없는 작품의 기본값을 검증하는 테스트를 추가했습니다.

## To Reviewers
- 추천 순서는 작품별 가장 큰 `user_novel_id`를 기준으로 유지합니다.
- `novel_statistics`가 없는 작품은 기존 응답처럼 평점과 평가 수를 0으로 반환합니다.
- 관련 단위 테스트는 모두 통과했습니다.
- 전체 257개 테스트 중 12개는 로컬 테스트 데이터소스 드라이버 미설정, 1개는 기존 `RecentSearchServiceTest`의 null ID 문제로 실패했습니다.
- 개선 후 실제 API 응답 시간과 쿼리 수는 인증 가능한 실행 환경에서 재측정이 필요합니다.

## References
- #591
- 원본 측정: 총 응답 1,869ms, SQL 125개, SQL 실행시간 합계 619ms
