### PR TITLE
[FEAT] 완결 / 휴재 알림 기능 구현

### DIFF
--- a/src/main/java/org/websoso/WSSServer/domain/common/NotificationTypeGroup.java
+++ b/src/main/java/org/websoso/WSSServer/domain/common/NotificationTypeGroup.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 public enum NotificationTypeGroup {
 
     NOTICE("공지사항", "이벤트"),
-    FEED("지금뜨는글", "댓글", "좋아요");
+    FEED("지금뜨는글", "댓글", "좋아요"),
+    NOVEL("완결 알림", "휴재 복귀 알림");
 
     private final Set<String> types;
 

--- a/src/main/java/org/websoso/WSSServer/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/websoso/WSSServer/exception/handler/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.websoso.WSSServer.exception.error.CustomUserError.DUPLICATED_NICKNAME;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
@@ -12,8 +14,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.websoso.common.exception.AbstractCustomException;
 import org.websoso.common.exception.ErrorResult;
@@ -33,6 +37,53 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(httpStatus)
                 .body(new ErrorResult(httpStatus.name(),
                         e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
+    }
+
+    /**
+     * {@code @Validated}가 붙은 Controller의 PathVariable, RequestParam 검증 실패를 처리한다.
+     * 이 핸들러가 없으면 예외가 처리되지 않은 채 ERROR 디스패치로 넘어가고, 그 재요청은
+     * SecurityContext가 비어 있어 인증에 실패한다. 그 결과 검증 실패가 401 AUTH-001로 둔갑해
+     * 제약 조건에 정의한 메시지가 클라이언트에 전달되지 않는다.
+     * RequestBody 검증({@link MethodArgumentNotValidException})과 같은 형식으로 응답한다.
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResult> ConstraintViolationExceptionHandler(ConstraintViolationException e) {
+        log.error("[ConstraintViolationException] exception ", e);
+        String message = e.getConstraintViolations().stream()
+                .findFirst()
+                .map(ConstraintViolation::getMessage)
+                .orElse(BAD_REQUEST.getReasonPhrase());
+        return ResponseEntity
+                .status(BAD_REQUEST)
+                .body(new ErrorResult(BAD_REQUEST.name(), message));
+    }
+
+    /**
+     * 필수 요청 파라미터가 없을 때를 처리한다.
+     * 처리하지 않으면 {@link ConstraintViolationException}과 같은 경로로 401 AUTH-001이 된다.
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResult> MissingServletRequestParameterExceptionHandler(
+            MissingServletRequestParameterException e) {
+        log.error("[MissingServletRequestParameterException] exception ", e);
+        return ResponseEntity
+                .status(BAD_REQUEST)
+                .body(new ErrorResult(BAD_REQUEST.name(),
+                        "필수 요청 파라미터가 없습니다: " + e.getParameterName()));
+    }
+
+    /**
+     * 요청 파라미터나 경로 변수를 선언한 타입으로 변환하지 못할 때를 처리한다.
+     * 정의되지 않은 Enum 값과 숫자 자리에 온 문자열이 여기에 해당한다.
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResult> MethodArgumentTypeMismatchExceptionHandler(
+            MethodArgumentTypeMismatchException e) {
+        log.error("[MethodArgumentTypeMismatchException] exception ", e);
+        return ResponseEntity
+                .status(BAD_REQUEST)
+                .body(new ErrorResult(BAD_REQUEST.name(),
+                        "요청 값의 형식이 올바르지 않습니다: " + e.getName()));
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/src/main/java/org/websoso/WSSServer/notification/application/NovelNotificationApplication.java
+++ b/src/main/java/org/websoso/WSSServer/notification/application/NovelNotificationApplication.java
@@ -1,0 +1,64 @@
+package org.websoso.WSSServer.notification.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.websoso.WSSServer.notification.controller.request.NovelNotificationDeleteRequest;
+import org.websoso.WSSServer.notification.controller.request.NovelNotificationUpdateRequest;
+import org.websoso.WSSServer.notification.controller.response.NovelNotificationPageResponse;
+import org.websoso.WSSServer.notification.controller.response.NovelNotificationResponse;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+import org.websoso.WSSServer.notification.service.NovelNotificationService;
+import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.novel.service.NovelServiceImpl;
+import org.websoso.WSSServer.user.domain.User;
+
+/** 작품 존재 검증과 사용자별 작품 알림 유스케이스를 조합한다. */
+@Service
+@RequiredArgsConstructor
+public class NovelNotificationApplication {
+
+    private final NovelServiceImpl novelService;
+    private final NovelNotificationService novelNotificationService;
+
+    /** 작품에 등록된 사용자의 두 알림 설정을 조회한다. */
+    public NovelNotificationResponse getSettings(User user, Long novelId) {
+        Novel novel = novelService.getNovelOrException(novelId);
+
+        return NovelNotificationResponse.from(
+                novelNotificationService.getEnabledTypes(user.getUserId(), novel.getNovelId())
+        );
+    }
+
+    /** 작품의 두 알림 설정을 요청 상태에 맞게 갱신한다. */
+    public void updateSettings(User user, Long novelId, NovelNotificationUpdateRequest request) {
+        Novel novel = novelService.getNovelOrException(novelId);
+
+        novelNotificationService.updateSettings(
+                user,
+                novel,
+                request.isCompletionNotificationEnabled(),
+                request.isHiatusReturnNotificationEnabled()
+        );
+    }
+
+    /** 사용자가 등록한 작품 알림을 유형별로 조회한다. */
+    public NovelNotificationPageResponse getSubscriptions(
+            User user,
+            NovelNotificationType notificationType,
+            Long lastSubscriptionId,
+            int size
+    ) {
+        return NovelNotificationPageResponse.from(
+                novelNotificationService.getSubscriptions(user.getUserId(), notificationType, lastSubscriptionId, size)
+        );
+    }
+
+    /** 사용자가 선택한 같은 유형의 작품 알림을 일괄 삭제한다. */
+    public void deleteSubscriptions(User user, NovelNotificationDeleteRequest request) {
+        novelNotificationService.deleteSubscriptions(
+                user.getUserId(),
+                request.notificationType(),
+                request.novelIds()
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/notification/controller/NovelNotificationController.java
+++ b/src/main/java/org/websoso/WSSServer/notification/controller/NovelNotificationController.java
@@ -1,0 +1,95 @@
+package org.websoso.WSSServer.notification.controller;
+
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.OK;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.LAST_SUBSCRIPTION_ID_POSITIVE_OR_ZERO;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.NOVEL_ID_POSITIVE;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.SIZE_MAX;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.SIZE_MIN;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.websoso.WSSServer.notification.application.NovelNotificationApplication;
+import org.websoso.WSSServer.notification.controller.request.NovelNotificationDeleteRequest;
+import org.websoso.WSSServer.notification.controller.request.NovelNotificationUpdateRequest;
+import org.websoso.WSSServer.notification.controller.response.NovelNotificationPageResponse;
+import org.websoso.WSSServer.notification.controller.response.NovelNotificationResponse;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+import org.websoso.WSSServer.user.domain.User;
+
+/** 작품별 알림 설정과 설정 화면의 구독 목록 API를 제공한다. */
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class NovelNotificationController {
+
+    private final NovelNotificationApplication novelNotificationApplication;
+
+    /** 작품에 등록된 사용자의 완결·휴재 복귀 알림 상태를 조회한다. */
+    @GetMapping("/novels/{novelId}/notification")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<NovelNotificationResponse> getSettings(
+            @AuthenticationPrincipal User user,
+            @PathVariable @Positive(message = NOVEL_ID_POSITIVE) Long novelId
+    ) {
+        return ResponseEntity
+                .status(OK)
+                .body(novelNotificationApplication.getSettings(user, novelId));
+    }
+
+    /** 작품의 완결·휴재 복귀 알림 상태를 한 번에 갱신한다. */
+    @PutMapping("/novels/{novelId}/notification")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> updateSettings(
+            @AuthenticationPrincipal User user,
+            @PathVariable @Positive(message = NOVEL_ID_POSITIVE) Long novelId,
+            @Valid @RequestBody NovelNotificationUpdateRequest request
+    ) {
+        novelNotificationApplication.updateSettings(user, novelId, request);
+
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
+
+    /** 설정 화면에서 알림 유형별 등록 작품을 조회한다. */
+    @GetMapping("/users/me/notification/novels")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<NovelNotificationPageResponse> getSubscriptions(
+            @AuthenticationPrincipal User user,
+            @RequestParam NovelNotificationType notificationType,
+            @RequestParam(defaultValue = "0")
+            @PositiveOrZero(message = LAST_SUBSCRIPTION_ID_POSITIVE_OR_ZERO) Long lastSubscriptionId,
+            @RequestParam(defaultValue = "10")
+            @Min(value = 1, message = SIZE_MIN) @Max(value = 50, message = SIZE_MAX) int size
+    ) {
+        return ResponseEntity
+                .status(OK)
+                .body(novelNotificationApplication.getSubscriptions(user, notificationType, lastSubscriptionId, size));
+    }
+
+    /** 설정 화면에서 선택한 같은 유형의 작품 알림을 일괄 삭제한다. */
+    @DeleteMapping("/users/me/notification/novels")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> deleteSubscriptions(
+            @AuthenticationPrincipal User user,
+            @Valid @RequestBody NovelNotificationDeleteRequest request
+    ) {
+        novelNotificationApplication.deleteSubscriptions(user, request);
+
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/notification/controller/NovelNotificationValidationMessage.java
+++ b/src/main/java/org/websoso/WSSServer/notification/controller/NovelNotificationValidationMessage.java
@@ -1,0 +1,20 @@
+package org.websoso.WSSServer.notification.controller;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/** 작품 알림 설정 API의 요청 검증 실패 시 클라이언트에 내려가는 에러 메시지를 모아둔다. */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class NovelNotificationValidationMessage {
+
+    public static final String NOTIFICATION_TYPE_NOT_NULL = "작품 알림 유형은 null일 수 없습니다.";
+    public static final String NOVEL_IDS_NOT_EMPTY = "삭제할 작품 ID는 한 개 이상이어야 합니다.";
+    public static final String NOVEL_IDS_MAX_SIZE = "한 번에 삭제할 작품은 100개를 초과할 수 없습니다.";
+    public static final String NOVEL_ID_NOT_NULL = "작품 ID는 null일 수 없습니다.";
+    public static final String NOVEL_ID_POSITIVE = "작품 ID는 양수여야 합니다.";
+    public static final String COMPLETION_NOTIFICATION_NOT_NULL = "완결 알림 설정 값은 null일 수 없습니다.";
+    public static final String HIATUS_RETURN_NOTIFICATION_NOT_NULL = "휴재 복귀 알림 설정 값은 null일 수 없습니다.";
+    public static final String LAST_SUBSCRIPTION_ID_POSITIVE_OR_ZERO = "마지막 구독 ID는 0 이상이어야 합니다.";
+    public static final String SIZE_MIN = "조회 개수는 1개 이상이어야 합니다.";
+    public static final String SIZE_MAX = "조회 개수는 50개를 초과할 수 없습니다.";
+}

--- a/src/main/java/org/websoso/WSSServer/notification/controller/request/NovelNotificationDeleteRequest.java
+++ b/src/main/java/org/websoso/WSSServer/notification/controller/request/NovelNotificationDeleteRequest.java
@@ -1,0 +1,27 @@
+package org.websoso.WSSServer.notification.controller.request;
+
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.NOTIFICATION_TYPE_NOT_NULL;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.NOVEL_IDS_MAX_SIZE;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.NOVEL_IDS_NOT_EMPTY;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.NOVEL_ID_NOT_NULL;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.NOVEL_ID_POSITIVE;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+
+/** 설정 화면에서 삭제할 작품 알림 유형과 작품 목록을 전달한다. */
+public record NovelNotificationDeleteRequest(
+        @NotNull(message = NOTIFICATION_TYPE_NOT_NULL)
+        NovelNotificationType notificationType,
+        @NotEmpty(message = NOVEL_IDS_NOT_EMPTY)
+        @Size(max = 100, message = NOVEL_IDS_MAX_SIZE)
+        List<
+                @NotNull(message = NOVEL_ID_NOT_NULL)
+                @Positive(message = NOVEL_ID_POSITIVE)
+                Long> novelIds
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/notification/controller/request/NovelNotificationUpdateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/notification/controller/request/NovelNotificationUpdateRequest.java
@@ -1,0 +1,15 @@
+package org.websoso.WSSServer.notification.controller.request;
+
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.COMPLETION_NOTIFICATION_NOT_NULL;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.HIATUS_RETURN_NOTIFICATION_NOT_NULL;
+
+import jakarta.validation.constraints.NotNull;
+
+/** 작품 상세에서 변경할 두 작품 알림의 목표 상태를 전달한다. */
+public record NovelNotificationUpdateRequest(
+        @NotNull(message = COMPLETION_NOTIFICATION_NOT_NULL)
+        Boolean isCompletionNotificationEnabled,
+        @NotNull(message = HIATUS_RETURN_NOTIFICATION_NOT_NULL)
+        Boolean isHiatusReturnNotificationEnabled
+) {
+}

--- a/src/main/java/org/websoso/WSSServer/notification/controller/response/NotificationPageResponse.java
+++ b/src/main/java/org/websoso/WSSServer/notification/controller/response/NotificationPageResponse.java
@@ -32,7 +32,8 @@ public record NotificationPageResponse(
             String createdDate,
             boolean isRead,
             boolean isNotice,
-            Long feedId
+            Long feedId,
+            Long novelId
     ) {
 
         public static NotificationItem from(ReadNotificationDto dto) {
@@ -46,7 +47,8 @@ public record NotificationPageResponse(
                     TimeFormatUtil.formatNotificationDate(notification.getCreatedDate()),
                     dto.isRead(),
                     NotificationTypeGroup.isTypeInGroup(notification.getNotificationType().getNotificationTypeName(), NOTICE),
-                    notification.getFeedId()
+                    notification.getFeedId(),
+                    notification.getNovelId()
             );
         }
 

--- a/src/main/java/org/websoso/WSSServer/notification/controller/response/NovelNotificationPageResponse.java
+++ b/src/main/java/org/websoso/WSSServer/notification/controller/response/NovelNotificationPageResponse.java
@@ -1,0 +1,57 @@
+package org.websoso.WSSServer.notification.controller.response;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.springframework.data.domain.Slice;
+import org.websoso.WSSServer.notification.domain.NovelNotificationSubscription;
+import org.websoso.WSSServer.novel.domain.Novel;
+
+/** 설정 화면의 작품 알림 구독 목록과 다음 페이지 정보를 반환한다. */
+public record NovelNotificationPageResponse(
+        boolean isLoadable,
+        Long nextSubscriptionId,
+        List<NovelNotificationItem> subscriptions
+) {
+
+    /** 구독 Slice를 설정 화면 응답으로 변환한다. */
+    public static NovelNotificationPageResponse from(Slice<NovelNotificationSubscription> subscriptionSlice) {
+        List<NovelNotificationItem> items = subscriptionSlice.getContent().stream()
+                .map(NovelNotificationItem::from)
+                .toList();
+        Long nextSubscriptionId = subscriptionSlice.hasNext() && !items.isEmpty()
+                ? items.get(items.size() - 1).subscriptionId()
+                : null;
+
+        return new NovelNotificationPageResponse(
+                subscriptionSlice.hasNext(),
+                nextSubscriptionId,
+                items
+        );
+    }
+
+    /** 설정 목록 한 항목에 필요한 작품 정보와 등록일을 반환한다. */
+    public record NovelNotificationItem(
+            Long subscriptionId,
+            Long novelId,
+            String novelImage,
+            String novelTitle,
+            String novelAuthor,
+            String registeredDate
+    ) {
+        private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+        /** 작품 알림 구독을 목록 항목으로 변환한다. */
+        public static NovelNotificationItem from(NovelNotificationSubscription subscription) {
+            Novel novel = subscription.getNovel();
+
+            return new NovelNotificationItem(
+                    subscription.getNovelNotificationSubscriptionId(),
+                    novel.getNovelId(),
+                    novel.getNovelImage(),
+                    novel.getTitle(),
+                    novel.getAuthor(),
+                    subscription.getCreatedDate().format(DATE_FORMATTER)
+            );
+        }
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/notification/controller/response/NovelNotificationResponse.java
+++ b/src/main/java/org/websoso/WSSServer/notification/controller/response/NovelNotificationResponse.java
@@ -1,0 +1,19 @@
+package org.websoso.WSSServer.notification.controller.response;
+
+import java.util.Set;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+
+/** 작품 상세에서 표시할 완결·휴재 복귀 알림의 현재 상태를 반환한다. */
+public record NovelNotificationResponse(
+        boolean isCompletionNotificationEnabled,
+        boolean isHiatusReturnNotificationEnabled
+) {
+
+    /** 등록된 알림 유형 집합을 두 토글 상태로 변환한다. */
+    public static NovelNotificationResponse from(Set<NovelNotificationType> notificationTypes) {
+        return new NovelNotificationResponse(
+                notificationTypes.contains(NovelNotificationType.COMPLETION),
+                notificationTypes.contains(NovelNotificationType.HIATUS_RETURN)
+        );
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/notification/domain/Notification.java
+++ b/src/main/java/org/websoso/WSSServer/notification/domain/Notification.java
@@ -46,37 +46,50 @@ public class Notification extends BaseEntity {
     @Comment("관련 피드 ID (댓글/좋아요 등 피드 이동 시 사용)")
     private Long feedId;
 
+    @Column
+    @Comment("관련 작품 ID (완결/휴재 복귀 알림에서 작품 이동 시 사용)")
+    private Long novelId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "notification_type_id", nullable = false)
     @Comment("알림 유형 (1:공지, 2:이벤트, 3:인기글, 4:댓글, 5:좋아요)")
     private NotificationType notificationType;
 
-    private Notification(String title, String body, String detail, Long userId, Long feedId, NotificationType type) {
+    private Notification(
+            String title,
+            String body,
+            String detail,
+            Long userId,
+            Long feedId,
+            Long novelId,
+            NotificationType type
+    ) {
         this.notificationTitle = title;
         this.notificationBody = body;
         this.notificationDetail = detail;
         this.userId = userId;
         this.feedId = feedId;
+        this.novelId = novelId;
         this.notificationType = type;
     }
 
     @Deprecated
     public static Notification create(String title, String body, String detail, Long userId, Long feedId, NotificationType type) {
-        return new Notification(title, body, detail, userId, feedId, type);
+        return new Notification(title, body, detail, userId, feedId, null, type);
     }
 
     /**
      * 피드 관련 알림 생성 (댓글, 좋아요 등)
      */
     public static Notification createFeedNotification(String title, String body, Long userId, Long feedId, NotificationType type) {
-        return new Notification(title, body, null, userId, feedId, type);
+        return new Notification(title, body, null, userId, feedId, null, type);
     }
 
     /**
      * 공지사항 알림 생성 (전체 또는 개인)
      */
     public static Notification createNoticeNotification(String title, String body, String detail, Long userId, NotificationType type) {
-        return new Notification(title, body, detail, userId, null, type);
+        return new Notification(title, body, detail, userId, null, null, type);
     }
 
 }

--- a/src/main/java/org/websoso/WSSServer/notification/domain/NovelNotificationSubscription.java
+++ b/src/main/java/org/websoso/WSSServer/notification/domain/NovelNotificationSubscription.java
@@ -1,0 +1,90 @@
+package org.websoso.WSSServer.notification.domain;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static org.hibernate.annotations.OnDeleteAction.CASCADE;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.user.domain.User;
+import org.websoso.common.entity.BaseEntity;
+
+/** 사용자가 작품별로 등록한 완결·휴재 복귀 알림을 저장한다. */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "novel_notification_subscription",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_novel_notification_subscription_user_novel_type",
+                columnNames = {"user_id", "novel_id", "notification_type"}
+        ),
+        indexes = {
+                @Index(
+                        name = "idx_novel_notification_subscription_user_type_sent_id",
+                        columnList = "user_id, notification_type, is_sent, novel_notification_subscription_id"
+                ),
+                @Index(
+                        name = "idx_novel_notification_subscription_novel_type",
+                        columnList = "novel_id, notification_type"
+                )
+        }
+)
+public class NovelNotificationSubscription extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long novelNotificationSubscriptionId;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = CASCADE)
+    private User user;
+
+    @ManyToOne(fetch = LAZY, optional = false)
+    @JoinColumn(name = "novel_id", nullable = false)
+    @OnDelete(action = CASCADE)
+    private Novel novel;
+
+    @Enumerated(STRING)
+    @Column(name = "notification_type", length = 30, nullable = false)
+    private NovelNotificationType notificationType;
+
+    /**
+     * 알림 발송 여부. 등록 시 false이고, 어드민이 발송을 마치면 true가 된다.
+     * 발송은 이 서버가 아니라 어드민에서 처리하므로 여기서는 값을 바꾸지 않는다.
+     */
+    @Column(name = "is_sent", nullable = false)
+    private boolean isSent;
+
+    /** 구독의 소유자와 대상 작품, 알림 유형을 초기화한다. 발송 여부는 미발송으로 시작한다. */
+    private NovelNotificationSubscription(User user, Novel novel, NovelNotificationType notificationType) {
+        this.user = user;
+        this.novel = novel;
+        this.notificationType = notificationType;
+        this.isSent = false;
+    }
+
+    /** 사용자와 작품, 알림 유형으로 새 구독을 생성한다. */
+    public static NovelNotificationSubscription create(
+            User user,
+            Novel novel,
+            NovelNotificationType notificationType
+    ) {
+        return new NovelNotificationSubscription(user, novel, notificationType);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/notification/domain/NovelNotificationType.java
+++ b/src/main/java/org/websoso/WSSServer/notification/domain/NovelNotificationType.java
@@ -1,0 +1,8 @@
+package org.websoso.WSSServer.notification.domain;
+
+/** 작품 상태 변경 알림의 구독 유형을 정의한다. */
+public enum NovelNotificationType {
+
+    COMPLETION,
+    HIATUS_RETURN
+}

--- a/src/main/java/org/websoso/WSSServer/notification/repository/NovelNotificationSubscriptionCustomRepository.java
+++ b/src/main/java/org/websoso/WSSServer/notification/repository/NovelNotificationSubscriptionCustomRepository.java
@@ -1,0 +1,22 @@
+package org.websoso.WSSServer.notification.repository;
+
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.websoso.WSSServer.notification.domain.NovelNotificationSubscription;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+
+/** 작품 알림 구독의 목록 조회와 삭제를 QueryDSL로 처리한다. */
+public interface NovelNotificationSubscriptionCustomRepository {
+
+    /** 알림 유형별로 아직 발송되지 않은 등록 작품을 최신 구독 ID 순으로 조회한다. */
+    Slice<NovelNotificationSubscription> findSubscriptions(
+            Long userId,
+            NovelNotificationType notificationType,
+            Long lastSubscriptionId,
+            Pageable pageable
+    );
+
+    /** 사용자가 선택한 같은 유형의 작품 알림을 한 번에 삭제한다. */
+    int deleteSubscriptions(Long userId, NovelNotificationType notificationType, List<Long> novelIds);
+}

--- a/src/main/java/org/websoso/WSSServer/notification/repository/NovelNotificationSubscriptionCustomRepositoryImpl.java
+++ b/src/main/java/org/websoso/WSSServer/notification/repository/NovelNotificationSubscriptionCustomRepositoryImpl.java
@@ -1,0 +1,87 @@
+package org.websoso.WSSServer.notification.repository;
+
+import static org.websoso.WSSServer.notification.domain.QNovelNotificationSubscription.novelNotificationSubscription;
+import static org.websoso.WSSServer.novel.domain.QNovel.novel;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+import org.websoso.WSSServer.notification.domain.NovelNotificationSubscription;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+
+/**
+ * 작품 알림 구독의 목록 조회와 삭제를 QueryDSL로 수행한다.
+ * QueryDSL에는 @Modifying의 flushAutomatically/clearAutomatically가 적용되지 않아,
+ * 벌크 삭제 전후로 영속성 컨텍스트를 직접 flush/clear 해 기존 동작을 유지한다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class NovelNotificationSubscriptionCustomRepositoryImpl implements NovelNotificationSubscriptionCustomRepository {
+
+    private static final long NO_CURSOR = 0L;
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final EntityManager entityManager;
+
+    @Override
+    public Slice<NovelNotificationSubscription> findSubscriptions(
+            Long userId,
+            NovelNotificationType notificationType,
+            Long lastSubscriptionId,
+            Pageable pageable
+    ) {
+        List<NovelNotificationSubscription> subscriptions = jpaQueryFactory
+                .selectFrom(novelNotificationSubscription)
+                .join(novelNotificationSubscription.novel, novel).fetchJoin()
+                .where(
+                        novelNotificationSubscription.user.userId.eq(userId),
+                        novelNotificationSubscription.notificationType.eq(notificationType),
+                        novelNotificationSubscription.isSent.isFalse(),
+                        ltSubscriptionId(lastSubscriptionId)
+                )
+                .orderBy(novelNotificationSubscription.novelNotificationSubscriptionId.desc())
+                .limit(pageable.getPageSize() + 1L)
+                .fetch();
+
+        boolean hasNext = subscriptions.size() > pageable.getPageSize();
+
+        if (hasNext) {
+            subscriptions.remove(subscriptions.size() - 1);
+        }
+
+        return new SliceImpl<>(subscriptions, pageable, hasNext);
+    }
+
+    /** 첫 페이지 요청(커서 0)에는 커서 조건을 붙이지 않는다. */
+    private BooleanExpression ltSubscriptionId(Long lastSubscriptionId) {
+        if (lastSubscriptionId == null || lastSubscriptionId == NO_CURSOR) {
+            return null;
+        }
+
+        return novelNotificationSubscription.novelNotificationSubscriptionId.lt(lastSubscriptionId);
+    }
+
+    @Override
+    public int deleteSubscriptions(Long userId, NovelNotificationType notificationType, List<Long> novelIds) {
+        entityManager.flush();
+
+        long deletedCount = jpaQueryFactory
+                .delete(novelNotificationSubscription)
+                .where(
+                        novelNotificationSubscription.user.userId.eq(userId),
+                        novelNotificationSubscription.notificationType.eq(notificationType),
+                        novelNotificationSubscription.novel.novelId.in(novelIds)
+                )
+                .execute();
+
+        entityManager.clear();
+
+        return Math.toIntExact(deletedCount);
+    }
+}

--- a/src/main/java/org/websoso/WSSServer/notification/repository/NovelNotificationSubscriptionRepository.java
+++ b/src/main/java/org/websoso/WSSServer/notification/repository/NovelNotificationSubscriptionRepository.java
@@ -1,0 +1,14 @@
+package org.websoso.WSSServer.notification.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.websoso.WSSServer.notification.domain.NovelNotificationSubscription;
+
+/** 작품 알림 구독의 사용자별 조회와 저장을 담당한다. */
+public interface NovelNotificationSubscriptionRepository
+        extends JpaRepository<NovelNotificationSubscription, Long>, NovelNotificationSubscriptionCustomRepository {
+
+    /** 한 작품에 등록된 사용자의 모든 알림 유형을 조회한다. */
+    List<NovelNotificationSubscription> findAllByUser_UserIdAndNovel_NovelId(Long userId, Long novelId);
+
+}

--- a/src/main/java/org/websoso/WSSServer/notification/service/NovelNotificationService.java
+++ b/src/main/java/org/websoso/WSSServer/notification/service/NovelNotificationService.java
@@ -1,0 +1,133 @@
+package org.websoso.WSSServer.notification.service;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.websoso.WSSServer.notification.domain.NovelNotificationSubscription;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+import org.websoso.WSSServer.notification.repository.NovelNotificationSubscriptionRepository;
+import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.user.domain.User;
+
+/** 작품 알림 구독의 멱등 등록, 상태 조회, 목록 조회와 삭제를 처리한다. */
+@Service
+@RequiredArgsConstructor
+public class NovelNotificationService {
+
+    private final NovelNotificationSubscriptionRepository subscriptionRepository;
+
+    /** 두 작품 알림을 요청된 활성화 상태와 동일하게 맞춘다. */
+    @Transactional
+    public void updateSettings(
+            User user,
+            Novel novel,
+            boolean isCompletionEnabled,
+            boolean isHiatusReturnEnabled
+    ) {
+        List<NovelNotificationSubscription> subscriptions = subscriptionRepository
+                .findAllByUser_UserIdAndNovel_NovelId(user.getUserId(), novel.getNovelId());
+
+        synchronizeSubscription(user, novel, NovelNotificationType.COMPLETION, isCompletionEnabled, subscriptions);
+        synchronizeSubscription(user, novel, NovelNotificationType.HIATUS_RETURN, isHiatusReturnEnabled,
+                subscriptions);
+    }
+
+    /**
+     * 작품에 현재 등록된 사용자의 알림 유형을 조회한다.
+     * 발송이 끝난 구독은 제외한다. 이미 알림을 받은 뒤에도 토글이 켜져 있으면
+     * 다시 알림을 받는 것으로 오해하기 때문이다.
+     */
+    @Transactional(readOnly = true)
+    public Set<NovelNotificationType> getEnabledTypes(Long userId, Long novelId) {
+        Set<NovelNotificationType> enabledTypes = subscriptionRepository
+                .findAllByUser_UserIdAndNovel_NovelId(userId, novelId)
+                .stream()
+                .filter(subscription -> !subscription.isSent())
+                .map(NovelNotificationSubscription::getNotificationType)
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(NovelNotificationType.class)));
+
+        return Set.copyOf(enabledTypes);
+    }
+
+    /** 사용자가 등록한 작품 알림 중 아직 발송되지 않은 것을 유형별 최신순으로 조회한다. */
+    @Transactional(readOnly = true)
+    public Slice<NovelNotificationSubscription> getSubscriptions(
+            Long userId,
+            NovelNotificationType notificationType,
+            Long lastSubscriptionId,
+            int size
+    ) {
+        return subscriptionRepository.findSubscriptions(
+                userId,
+                notificationType,
+                lastSubscriptionId,
+                PageRequest.of(0, size)
+        );
+    }
+
+    /** 사용자가 선택한 같은 유형의 작품 알림을 일괄 삭제한다. */
+    @Transactional
+    public void deleteSubscriptions(
+            Long userId,
+            NovelNotificationType notificationType,
+            List<Long> novelIds
+    ) {
+        subscriptionRepository.deleteSubscriptions(userId, notificationType, novelIds);
+    }
+
+    /**
+     * 단일 알림 유형을 요청 상태에 맞춘다.
+     * 이미 요청과 같은 상태면 아무것도 하지 않아, 같은 요청을 반복해도 결과가 같다.
+     */
+    private void synchronizeSubscription(
+            User user,
+            Novel novel,
+            NovelNotificationType notificationType,
+            boolean enabled,
+            List<NovelNotificationSubscription> subscriptions
+    ) {
+        NovelNotificationSubscription subscription = subscriptions.stream()
+                .filter(it -> it.getNotificationType() == notificationType)
+                .findFirst()
+                .orElse(null);
+
+        if (enabled) {
+            enableSubscription(user, novel, notificationType, subscription);
+            return;
+        }
+
+        if (subscription != null) {
+            subscriptionRepository.delete(subscription);
+        }
+    }
+
+    /**
+     * 알림을 켠다. 발송이 끝난 구독은 지우고 새로 등록해 등록일을 갱신한다.
+     * 사용자가 알림을 받은 뒤 다시 켠 것이므로 지난 등록일을 유지하면
+     * 어드민이 이전 발송 시점 기준으로 판단하게 된다.
+     * (user, novel, type) UNIQUE 제약이 있어 새로 저장하기 전에 삭제를 먼저 반영한다.
+     */
+    private void enableSubscription(
+            User user,
+            Novel novel,
+            NovelNotificationType notificationType,
+            NovelNotificationSubscription subscription
+    ) {
+        if (subscription != null && !subscription.isSent()) {
+            return;
+        }
+
+        if (subscription != null) {
+            subscriptionRepository.delete(subscription);
+            subscriptionRepository.flush();
+        }
+
+        subscriptionRepository.save(NovelNotificationSubscription.create(user, novel, notificationType));
+    }
+}

--- a/src/main/resources/db/ddl/567_novel_notification_subscription.sql
+++ b/src/main/resources/db/ddl/567_novel_notification_subscription.sql
@@ -1,0 +1,26 @@
+CREATE TABLE novel_notification_subscription (
+    novel_notification_subscription_id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    novel_id BIGINT NOT NULL,
+    notification_type VARCHAR(30) NOT NULL,
+    is_sent BOOLEAN NOT NULL DEFAULT FALSE,
+    created_date DATETIME NOT NULL,
+    modified_date DATETIME NOT NULL,
+    PRIMARY KEY (novel_notification_subscription_id),
+    CONSTRAINT uk_novel_notification_subscription_user_novel_type
+        UNIQUE (user_id, novel_id, notification_type),
+    CONSTRAINT fk_novel_notification_subscription_user
+        FOREIGN KEY (user_id) REFERENCES user (user_id) ON DELETE CASCADE,
+    CONSTRAINT fk_novel_notification_subscription_novel
+        FOREIGN KEY (novel_id) REFERENCES novel (novel_id) ON DELETE CASCADE,
+    INDEX idx_novel_notification_subscription_user_type_id
+        (user_id, notification_type, novel_notification_subscription_id),
+    INDEX idx_novel_notification_subscription_novel_type
+        (novel_id, notification_type)
+);
+
+ALTER TABLE notification
+    ADD COLUMN novel_id BIGINT NULL AFTER feed_id,
+    ADD INDEX idx_notification_novel_id (novel_id),
+    ADD CONSTRAINT fk_notification_novel
+        FOREIGN KEY (novel_id) REFERENCES novel (novel_id) ON DELETE SET NULL;

--- a/src/test/java/org/websoso/WSSServer/domain/common/NotificationTypeGroupTest.java
+++ b/src/test/java/org/websoso/WSSServer/domain/common/NotificationTypeGroupTest.java
@@ -1,0 +1,18 @@
+package org.websoso.WSSServer.domain.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** 완결·휴재 복귀 알림의 작품 알림 그룹 분류를 검증한다. */
+class NotificationTypeGroupTest {
+
+    /** 두 작품 알림 이름이 NOVEL 그룹에 포함되는지 검증한다. */
+    @Test
+    @DisplayName("완결과 휴재 복귀 알림은 작품 알림으로 분류한다")
+    void classifiesNovelNotificationTypes() {
+        assertThat(NotificationTypeGroup.isTypeInGroup("완결 알림", NotificationTypeGroup.NOVEL)).isTrue();
+        assertThat(NotificationTypeGroup.isTypeInGroup("휴재 복귀 알림", NotificationTypeGroup.NOVEL)).isTrue();
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/notification/application/NovelNotificationApplicationTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/application/NovelNotificationApplicationTest.java
@@ -1,0 +1,80 @@
+package org.websoso.WSSServer.notification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.websoso.WSSServer.notification.controller.request.NovelNotificationUpdateRequest;
+import org.websoso.WSSServer.notification.controller.response.NovelNotificationResponse;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+import org.websoso.WSSServer.notification.service.NovelNotificationService;
+import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.novel.service.NovelServiceImpl;
+import org.websoso.WSSServer.user.domain.User;
+
+/** 작품 검증과 알림 설정 서비스 조합을 검증한다. */
+@ExtendWith(MockitoExtension.class)
+class NovelNotificationApplicationTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long NOVEL_ID = 10L;
+
+    @InjectMocks
+    private NovelNotificationApplication novelNotificationApplication;
+
+    @Mock
+    private NovelServiceImpl novelService;
+
+    @Mock
+    private NovelNotificationService novelNotificationService;
+
+    /** 존재하는 작품의 두 알림 설정을 응답으로 변환하는지 검증한다. */
+    @Test
+    @DisplayName("작품별 알림 설정을 조회한다")
+    void getsSettings() {
+        User user = createUser();
+        Novel novel = createNovel();
+        given(novelService.getNovelOrException(NOVEL_ID)).willReturn(novel);
+        given(novelNotificationService.getEnabledTypes(USER_ID, NOVEL_ID))
+                .willReturn(Set.of(NovelNotificationType.COMPLETION));
+
+        NovelNotificationResponse result = novelNotificationApplication.getSettings(user, NOVEL_ID);
+
+        assertThat(result.isCompletionNotificationEnabled()).isTrue();
+        assertThat(result.isHiatusReturnNotificationEnabled()).isFalse();
+    }
+
+    /** 작품 검증 후 요청된 두 토글 상태를 서비스에 전달하는지 검증한다. */
+    @Test
+    @DisplayName("작품별 알림 설정을 갱신한다")
+    void updatesSettings() {
+        User user = createUser();
+        Novel novel = org.mockito.Mockito.mock(Novel.class);
+        NovelNotificationUpdateRequest request = new NovelNotificationUpdateRequest(true, false);
+        given(novelService.getNovelOrException(NOVEL_ID)).willReturn(novel);
+
+        novelNotificationApplication.updateSettings(user, NOVEL_ID, request);
+
+        verify(novelNotificationService).updateSettings(user, novel, true, false);
+    }
+
+    private User createUser() {
+        User user = User.createBySocial("social-id", "사용자", null);
+        ReflectionTestUtils.setField(user, "userId", USER_ID);
+        return user;
+    }
+
+    private Novel createNovel() {
+        Novel novel = org.mockito.Mockito.mock(Novel.class);
+        given(novel.getNovelId()).willReturn(NOVEL_ID);
+        return novel;
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/notification/controller/NovelNotificationControllerTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/NovelNotificationControllerTest.java
@@ -1,0 +1,53 @@
+package org.websoso.WSSServer.notification.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.websoso.WSSServer.notification.application.NovelNotificationApplication;
+import org.websoso.WSSServer.notification.controller.request.NovelNotificationDeleteRequest;
+import org.websoso.WSSServer.notification.controller.request.NovelNotificationUpdateRequest;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+import org.websoso.WSSServer.user.domain.User;
+
+/** 작품 알림 설정 Controller의 요청 위임과 상태 코드를 검증한다. */
+class NovelNotificationControllerTest {
+
+    private final NovelNotificationApplication novelNotificationApplication =
+            mock(NovelNotificationApplication.class);
+    private final NovelNotificationController controller =
+            new NovelNotificationController(novelNotificationApplication);
+    private final User user = mock(User.class);
+
+    /** 두 토글 갱신 요청을 위임하고 204를 반환하는지 검증한다. */
+    @Test
+    @DisplayName("작품 알림 설정을 갱신하면 204를 반환한다")
+    void updatesSettings() {
+        NovelNotificationUpdateRequest request = new NovelNotificationUpdateRequest(true, false);
+
+        ResponseEntity<Void> response = controller.updateSettings(user, 10L, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        verify(novelNotificationApplication).updateSettings(user, 10L, request);
+    }
+
+    /** 일괄 삭제 요청을 위임하고 204를 반환하는지 검증한다. */
+    @Test
+    @DisplayName("선택한 작품 알림을 삭제하면 204를 반환한다")
+    void deletesSubscriptions() {
+        NovelNotificationDeleteRequest request = new NovelNotificationDeleteRequest(
+                NovelNotificationType.COMPLETION,
+                List.of(10L, 20L)
+        );
+
+        ResponseEntity<Void> response = controller.deleteSubscriptions(user, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        verify(novelNotificationApplication).deleteSubscriptions(user, request);
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/notification/controller/novelnotification/DeleteMyNovelNotificationsDocsTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/novelnotification/DeleteMyNovelNotificationsDocsTest.java
@@ -1,0 +1,289 @@
+package org.websoso.WSSServer.notification.controller.novelnotification;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.ACCESS_TOKEN_EXPIRED;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.INVALID_TOKEN;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.WRONG_TOKEN_TYPE;
+import static org.websoso.WSSServer.exception.error.CustomUserError.USER_NOT_FOUND;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.NOTIFICATION_TYPE_NOT_NULL;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.NOVEL_IDS_MAX_SIZE;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.NOVEL_IDS_NOT_EMPTY;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.NOVEL_ID_POSITIVE;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.accessToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.expiredAccessToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.refreshToken;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.ERROR_RESULT_SCHEMA;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.errorLine;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.errorResultFields;
+import static org.websoso.WSSServer.support.docs.RequestPreprocessors.withoutRequestBody;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
+import com.epages.restdocs.apispec.Schema;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.websoso.WSSServer.exception.exception.CustomUserException;
+import org.websoso.WSSServer.notification.application.NovelNotificationApplication;
+import org.websoso.WSSServer.notification.controller.NovelNotificationController;
+import org.websoso.WSSServer.notification.controller.request.NovelNotificationDeleteRequest;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+import org.websoso.WSSServer.support.auth.AuthenticatedControllerTest;
+import org.websoso.WSSServer.user.domain.User;
+import org.websoso.WSSServer.user.service.UserService;
+
+/**
+ * {@code DELETE /users/me/notification/novels}의 실제 응답을 문서화하는 REST Docs 테스트.
+ * 설정 화면에서 선택한 같은 유형의 작품 알림을 한 번에 해제하는 API다.
+ *
+ * <p>등록되어 있지 않은 작품 ID가 섞여 있어도 성공으로 응답하는 멱등 API이므로,
+ * 클라이언트가 삭제 전에 등록 여부를 다시 확인할 필요가 없다.
+ */
+@AutoConfigureRestDocs
+@AuthenticatedControllerTest(NovelNotificationController.class)
+class DeleteMyNovelNotificationsDocsTest {
+
+    private static final Long USER_ID = 42L;
+    private static final int MAX_NOVEL_IDS = 100;
+    private static final NovelNotificationDeleteRequest DELETE_REQUEST =
+            new NovelNotificationDeleteRequest(NovelNotificationType.COMPLETION, List.of(1L, 2L));
+    private static final String TAG = "Novel Notification";
+    private static final String SUMMARY = "작품 알림 구독 일괄 삭제";
+    private static final Schema REQUEST_SCHEMA = Schema.schema("NovelNotificationDeleteRequest");
+    private static final String MALFORMED_JSON_MESSAGE = "잘못된 JSON 형식입니다.";
+
+    private static final String DESCRIPTION = String.join("\n",
+            "설정 화면에서 선택한 같은 유형의 작품 알림을 한 번에 해제합니다.",
+            "",
+            "한 번에 100개까지 보낼 수 있고, 알림 유형이 다른 작품은 함께 삭제할 수 없습니다.",
+            "등록되어 있지 않은 작품 ID가 섞여 있어도 성공하는 멱등 API입니다.",
+            "",
+            "Try it out으로 호출하려면 상단 Authorize에 실제 Access Token을 입력해야 합니다.",
+            "",
+            "이 API가 정의하는 응답은 다음과 같습니다.",
+            "",
+            "- 204 No Content — 성공. (응답 본문이 없습니다.)",
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), NOTIFICATION_TYPE_NOT_NULL),
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), NOVEL_IDS_NOT_EMPTY),
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), NOVEL_IDS_MAX_SIZE),
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), NOVEL_ID_POSITIVE),
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), MALFORMED_JSON_MESSAGE)
+                    + " (본문이 JSON으로 읽히지 않을 때 반환합니다.)",
+            errorLine(ACCESS_TOKEN_EXPIRED),
+            errorLine(INVALID_TOKEN) + " (헤더 형식 오류 또는 누락을 포함합니다.)",
+            errorLine(WRONG_TOKEN_TYPE),
+            errorLine(USER_NOT_FOUND) + " (토큰은 유효하지만, 해당 사용자 정보가 없을 때 반환합니다.)",
+            "",
+            "400과 401은 상태 코드만으로 원인을 구분할 수 없습니다. 각 응답의 Examples에서 본문 확인이 필요합니다.");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private NovelNotificationApplication novelNotificationApplication;
+
+    @BeforeEach
+    void setUp() {
+        given(userService.getUserOrException(USER_ID)).willReturn(mock(User.class));
+    }
+
+    @DisplayName("작품 알림 구독 일괄 삭제 성공(204, 본문 없음) 응답을 문서화한다")
+    @Test
+    void documentDeleteSubscriptionsSuccess() throws Exception {
+        mockMvc.perform(deleteRequest(DELETE_REQUEST).with(accessToken(USER_ID)))
+                .andExpect(status().isNoContent())
+                .andExpect(content().string(""))
+                .andDo(document("my-novel-notifications-delete",
+                        resource(deletion()
+                                .requestSchema(REQUEST_SCHEMA)
+                                .requestFields(deleteRequestFields())
+                                .build())));
+    }
+
+    @DisplayName("알림 유형이 없는 요청의 400 응답을 문서화한다")
+    @Test
+    void documentDeleteSubscriptionsWithoutNotificationType() throws Exception {
+        mockMvc.perform(deleteRequest(new NovelNotificationDeleteRequest(null, List.of(1L)))
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(NOTIFICATION_TYPE_NOT_NULL))
+                .andDo(document("my-novel-notifications-delete-notification-type-null",
+                        withoutRequestBody(),
+                        resource(deletionError().build())));
+    }
+
+    @DisplayName("삭제할 작품이 하나도 없는 요청의 400 응답을 문서화한다")
+    @Test
+    void documentDeleteSubscriptionsWithEmptyNovelIds() throws Exception {
+        mockMvc.perform(deleteRequest(
+                        new NovelNotificationDeleteRequest(NovelNotificationType.COMPLETION, List.of()))
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(NOVEL_IDS_NOT_EMPTY))
+                .andDo(document("my-novel-notifications-delete-novel-ids-empty",
+                        withoutRequestBody(),
+                        resource(deletionError().build())));
+    }
+
+    @DisplayName("삭제할 작품이 100개를 넘는 요청의 400 응답을 문서화한다")
+    @Test
+    void documentDeleteSubscriptionsWithTooManyNovelIds() throws Exception {
+        List<Long> tooManyNovelIds = LongStream.rangeClosed(1, MAX_NOVEL_IDS + 1).boxed().toList();
+
+        mockMvc.perform(deleteRequest(
+                        new NovelNotificationDeleteRequest(NovelNotificationType.COMPLETION, tooManyNovelIds))
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(NOVEL_IDS_MAX_SIZE))
+                .andDo(document("my-novel-notifications-delete-novel-ids-too-many",
+                        withoutRequestBody(),
+                        resource(deletionError().build())));
+    }
+
+    @DisplayName("양수가 아닌 작품 ID가 섞인 요청의 400 응답을 문서화한다")
+    @Test
+    void documentDeleteSubscriptionsWithNonPositiveNovelId() throws Exception {
+        mockMvc.perform(deleteRequest(
+                        new NovelNotificationDeleteRequest(NovelNotificationType.COMPLETION, List.of(-1L)))
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(NOVEL_ID_POSITIVE))
+                .andDo(document("my-novel-notifications-delete-novel-id-not-positive",
+                        withoutRequestBody(),
+                        resource(deletionError().build())));
+    }
+
+    @DisplayName("본문 JSON 형식이 잘못된 요청의 400 응답을 문서화한다")
+    @Test
+    void documentDeleteSubscriptionsWithMalformedJson() throws Exception {
+        mockMvc.perform(delete("/users/me/notification/novels")
+                        .contentType(APPLICATION_JSON)
+                        .content("{\"notificationType\":")
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(MALFORMED_JSON_MESSAGE))
+                .andDo(document("my-novel-notifications-delete-malformed-json",
+                        withoutRequestBody(),
+                        resource(deletionError().build())));
+    }
+
+    @DisplayName("만료된 Access Token 요청의 401 AUTH-000 응답을 문서화한다")
+    @Test
+    void documentDeleteSubscriptionsWithExpiredAccessToken() throws Exception {
+        mockMvc.perform(deleteRequest(DELETE_REQUEST).with(expiredAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(ACCESS_TOKEN_EXPIRED.getCode()))
+                .andExpect(jsonPath("$.message").value(ACCESS_TOKEN_EXPIRED.getDescription()))
+                .andDo(document("my-novel-notifications-delete-access-token-expired",
+                        withoutRequestBody(),
+                        resource(deletionError().build())));
+    }
+
+    @DisplayName("Authorization 헤더가 없는 요청의 401 AUTH-001 응답을 문서화한다")
+    @Test
+    void documentDeleteSubscriptionsWithInvalidToken() throws Exception {
+        mockMvc.perform(deleteRequest(DELETE_REQUEST))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(INVALID_TOKEN.getDescription()))
+                .andDo(document("my-novel-notifications-delete-invalid-token",
+                        withoutRequestBody(),
+                        resource(deletionError().build())));
+    }
+
+    @DisplayName("Refresh Token으로 인증한 요청의 401 AUTH-003 응답을 문서화한다")
+    @Test
+    void documentDeleteSubscriptionsWithWrongTokenType() throws Exception {
+        mockMvc.perform(deleteRequest(DELETE_REQUEST).with(refreshToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(WRONG_TOKEN_TYPE.getCode()))
+                .andExpect(jsonPath("$.message").value(WRONG_TOKEN_TYPE.getDescription()))
+                .andDo(document("my-novel-notifications-delete-wrong-token-type",
+                        withoutRequestBody(),
+                        resource(deletionError().build())));
+    }
+
+    @DisplayName("토큰은 유효하지만 사용자가 없는 요청의 404 USER-006 응답을 문서화한다")
+    @Test
+    void documentDeleteSubscriptionsWithUnknownUser() throws Exception {
+        given(userService.getUserOrException(USER_ID))
+                .willThrow(new CustomUserException(USER_NOT_FOUND, "user with the given id was not found"));
+
+        mockMvc.perform(deleteRequest(DELETE_REQUEST).with(accessToken(USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(USER_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(USER_NOT_FOUND.getDescription()))
+                .andDo(document("my-novel-notifications-delete-user-not-found",
+                        withoutRequestBody(),
+                        resource(deletionError().build())));
+    }
+
+    private ResourceSnippetParametersBuilder deletionError() {
+        return deletion()
+                .responseSchema(ERROR_RESULT_SCHEMA)
+                .responseFields(errorResultFields());
+    }
+
+    private ResourceSnippetParametersBuilder deletion() {
+        return ResourceSnippetParameters.builder()
+                .tag(TAG)
+                .summary(SUMMARY)
+                .description(DESCRIPTION);
+    }
+
+    private List<FieldDescriptor> deleteRequestFields() {
+        return List.of(
+                fieldWithPath("notificationType").type(STRING)
+                        .description("삭제할 알림 유형. COMPLETION 또는 HIATUS_RETURN."),
+                fieldWithPath("novelIds").type(ARRAY)
+                        .description("삭제할 작품 ID 목록. 1개 이상 100개 이하이며 각 값은 양수여야 한다."));
+    }
+
+    private MockHttpServletRequestBuilder deleteRequest(NovelNotificationDeleteRequest request)
+            throws Exception {
+        return delete("/users/me/notification/novels")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request));
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/notification/controller/novelnotification/GetMyNovelNotificationsDocsTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/novelnotification/GetMyNovelNotificationsDocsTest.java
@@ -1,6 +1,7 @@
 package org.websoso.WSSServer.notification.controller.novelnotification;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static org.springframework.restdocs.snippet.Attributes.key;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -35,6 +36,8 @@ import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.erro
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
 import com.epages.restdocs.apispec.Schema;
+import com.epages.restdocs.apispec.SimpleType;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -70,6 +73,8 @@ class GetMyNovelNotificationsDocsTest {
     private static final String TAG = "Novel Notification";
     private static final String SUMMARY = "작품 알림 구독 목록 조회";
     private static final Schema RESPONSE_SCHEMA = Schema.schema("NovelNotificationPageResponse");
+    private static final List<String> NOTIFICATION_TYPE_VALUES =
+            Arrays.stream(NovelNotificationType.values()).map(Enum::name).toList();
     private static final String NOTIFICATION_TYPE_REQUIRED_MESSAGE = "필수 요청 파라미터가 없습니다: notificationType";
     private static final String NOTIFICATION_TYPE_MISMATCH_MESSAGE = "요청 값의 형식이 올바르지 않습니다: notificationType";
 
@@ -280,15 +285,25 @@ class GetMyNovelNotificationsDocsTest {
                 .description(DESCRIPTION);
     }
 
+    /**
+     * enumValues 속성을 주면 생성 명세의 파라미터 스키마에 enum이 붙어
+     * Swagger UI가 자유 입력 대신 선택 상자를 띄운다.
+     */
     private ResourceSnippetParametersBuilder subscriptions() {
         return withoutQueryParameters()
                 .queryParameters(
                         parameterWithName("notificationType")
-                                .description("조회할 알림 유형. COMPLETION 또는 HIATUS_RETURN."),
+                                .type(SimpleType.STRING)
+                                .attributes(key("enumValues").value(NOTIFICATION_TYPE_VALUES))
+                                .description("조회할 알림 유형"),
                         parameterWithName("lastSubscriptionId").optional()
-                                .description("이전 페이지 마지막 구독 ID. 첫 페이지는 생략하거나 0을 보낸다. 기본값 0."),
+                                .type(SimpleType.INTEGER)
+                                .defaultValue(0)
+                                .description("이전 페이지 마지막 구독 ID. 첫 페이지는 생략하거나 0을 보낸다."),
                         parameterWithName("size").optional()
-                                .description("조회 개수. 1 이상 50 이하. 기본값 10."));
+                                .type(SimpleType.INTEGER)
+                                .defaultValue(10)
+                                .description("조회 개수. 1 이상 50 이하."));
     }
 
     private List<FieldDescriptor> subscriptionsResponseFields() {

--- a/src/test/java/org/websoso/WSSServer/notification/controller/novelnotification/GetMyNovelNotificationsDocsTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/novelnotification/GetMyNovelNotificationsDocsTest.java
@@ -1,0 +1,316 @@
+package org.websoso.WSSServer.notification.controller.novelnotification;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.ACCESS_TOKEN_EXPIRED;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.INVALID_TOKEN;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.WRONG_TOKEN_TYPE;
+import static org.websoso.WSSServer.exception.error.CustomUserError.USER_NOT_FOUND;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.LAST_SUBSCRIPTION_ID_POSITIVE_OR_ZERO;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.SIZE_MAX;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.SIZE_MIN;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.accessToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.expiredAccessToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.refreshToken;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.ERROR_RESULT_SCHEMA;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.errorLine;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.errorResultFields;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
+import com.epages.restdocs.apispec.Schema;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.websoso.WSSServer.exception.exception.CustomUserException;
+import org.websoso.WSSServer.notification.application.NovelNotificationApplication;
+import org.websoso.WSSServer.notification.controller.NovelNotificationController;
+import org.websoso.WSSServer.notification.controller.response.NovelNotificationPageResponse;
+import org.websoso.WSSServer.notification.controller.response.NovelNotificationPageResponse.NovelNotificationItem;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+import org.websoso.WSSServer.support.auth.AuthenticatedControllerTest;
+import org.websoso.WSSServer.user.domain.User;
+import org.websoso.WSSServer.user.service.UserService;
+
+/**
+ * {@code GET /users/me/notification/novels}의 실제 응답을 문서화하는 REST Docs 테스트.
+ * 설정 화면에서 알림 유형별로 등록한 작품을 커서 방식으로 조회하는 API다.
+ *
+ * <p>필수 파라미터 누락과 Enum 변환 실패도 이 API의 계약이므로 함께 문서화한다.
+ * 두 경우 모두 처리되지 않으면 401 AUTH-001로 둔갑해 원인을 알 수 없다.
+ */
+@AutoConfigureRestDocs
+@AuthenticatedControllerTest(NovelNotificationController.class)
+class GetMyNovelNotificationsDocsTest {
+
+    private static final Long USER_ID = 42L;
+    private static final String TAG = "Novel Notification";
+    private static final String SUMMARY = "작품 알림 구독 목록 조회";
+    private static final Schema RESPONSE_SCHEMA = Schema.schema("NovelNotificationPageResponse");
+    private static final String NOTIFICATION_TYPE_REQUIRED_MESSAGE = "필수 요청 파라미터가 없습니다: notificationType";
+    private static final String NOTIFICATION_TYPE_MISMATCH_MESSAGE = "요청 값의 형식이 올바르지 않습니다: notificationType";
+
+    private static final String DESCRIPTION = String.join("\n",
+            "설정 화면에서 사용자가 등록한 작품 알림을 유형별로 조회합니다.",
+            "",
+            "알림이 발송된 작품은 목록에서 제외됩니다. 아직 발송되지 않은 등록만 내려갑니다.",
+            "",
+            "최신 등록순으로 내려가며 커서 방식으로 페이지를 이어 붙입니다.",
+            "첫 페이지는 lastSubscriptionId를 생략하거나 0으로 보내고, 다음 페이지는 응답의 nextSubscriptionId를 그대로 넣습니다.",
+            "isLoadable이 false면 더 조회할 항목이 없고, 이때 nextSubscriptionId는 null입니다.",
+            "",
+            "Try it out으로 호출하려면 상단 Authorize에 실제 Access Token을 입력해야 합니다.",
+            "",
+            "이 API가 정의하는 응답은 다음과 같습니다.",
+            "",
+            "- 200 OK — 성공.",
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), NOTIFICATION_TYPE_REQUIRED_MESSAGE),
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), NOTIFICATION_TYPE_MISMATCH_MESSAGE)
+                    + " (COMPLETION, HIATUS_RETURN 외의 값을 보냈을 때 반환합니다.)",
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), LAST_SUBSCRIPTION_ID_POSITIVE_OR_ZERO),
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), SIZE_MIN),
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), SIZE_MAX),
+            errorLine(ACCESS_TOKEN_EXPIRED),
+            errorLine(INVALID_TOKEN) + " (헤더 형식 오류 또는 누락을 포함합니다.)",
+            errorLine(WRONG_TOKEN_TYPE),
+            errorLine(USER_NOT_FOUND) + " (토큰은 유효하지만, 해당 사용자 정보가 없을 때 반환합니다.)",
+            "",
+            "400과 401은 상태 코드만으로 원인을 구분할 수 없습니다. 각 응답의 Examples에서 본문 확인이 필요합니다.");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private NovelNotificationApplication novelNotificationApplication;
+
+    @BeforeEach
+    void setUp() {
+        given(userService.getUserOrException(USER_ID)).willReturn(mock(User.class));
+    }
+
+    @DisplayName("작품 알림 구독 목록을 조회하는 200 응답을 문서화한다")
+    @Test
+    void documentGetSubscriptionsSuccess() throws Exception {
+        given(novelNotificationApplication.getSubscriptions(
+                any(User.class), any(NovelNotificationType.class), anyLong(), anyInt()))
+                .willReturn(new NovelNotificationPageResponse(true, 11L, List.of(
+                        new NovelNotificationItem(
+                                12L, 1L, "https://image.websoso.kr/novel/1.jpg", "재혼 황후", "알파타르트", "2026.08.06"),
+                        new NovelNotificationItem(
+                                11L, 2L, "https://image.websoso.kr/novel/2.jpg", "전지적 독자 시점", "싱숑",
+                                "2026.08.05"))));
+
+        mockMvc.perform(subscriptionsRequest("COMPLETION").with(accessToken(USER_ID)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.isLoadable").value(true))
+                .andExpect(jsonPath("$.nextSubscriptionId").value(11L))
+                .andExpect(jsonPath("$.subscriptions[0].subscriptionId").value(12L))
+                .andExpect(jsonPath("$.subscriptions[1].subscriptionId").value(11L))
+                .andDo(document("my-novel-notifications",
+                        resource(subscriptions()
+                                .responseSchema(RESPONSE_SCHEMA)
+                                .responseFields(subscriptionsResponseFields())
+                                .build())));
+    }
+
+    @DisplayName("알림 유형을 보내지 않은 요청의 400 응답을 문서화한다")
+    @Test
+    void documentGetSubscriptionsWithoutNotificationType() throws Exception {
+        mockMvc.perform(get("/users/me/notification/novels").with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(NOTIFICATION_TYPE_REQUIRED_MESSAGE))
+                .andDo(document("my-novel-notifications-notification-type-required",
+                        resource(withoutQueryParameters()
+                                .responseSchema(ERROR_RESULT_SCHEMA)
+                                .responseFields(errorResultFields())
+                                .build())));
+    }
+
+    @DisplayName("정의되지 않은 알림 유형 요청의 400 응답을 문서화한다")
+    @Test
+    void documentGetSubscriptionsWithUnknownNotificationType() throws Exception {
+        mockMvc.perform(subscriptionsRequest("UNKNOWN").with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(NOTIFICATION_TYPE_MISMATCH_MESSAGE))
+                .andDo(document("my-novel-notifications-notification-type-mismatch",
+                        resource(subscriptionsError().build())));
+    }
+
+    @DisplayName("음수 커서 요청의 400 응답을 문서화한다")
+    @Test
+    void documentGetSubscriptionsWithNegativeCursor() throws Exception {
+        mockMvc.perform(get("/users/me/notification/novels")
+                        .queryParam("notificationType", "COMPLETION")
+                        .queryParam("lastSubscriptionId", "-1")
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(LAST_SUBSCRIPTION_ID_POSITIVE_OR_ZERO))
+                .andDo(document("my-novel-notifications-cursor-negative",
+                        resource(subscriptionsError().build())));
+    }
+
+    @DisplayName("조회 개수가 1 미만인 요청의 400 응답을 문서화한다")
+    @Test
+    void documentGetSubscriptionsWithTooSmallSize() throws Exception {
+        mockMvc.perform(get("/users/me/notification/novels")
+                        .queryParam("notificationType", "COMPLETION")
+                        .queryParam("size", "0")
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(SIZE_MIN))
+                .andDo(document("my-novel-notifications-size-too-small",
+                        resource(subscriptionsError().build())));
+    }
+
+    @DisplayName("조회 개수가 50을 넘는 요청의 400 응답을 문서화한다")
+    @Test
+    void documentGetSubscriptionsWithTooLargeSize() throws Exception {
+        mockMvc.perform(get("/users/me/notification/novels")
+                        .queryParam("notificationType", "COMPLETION")
+                        .queryParam("size", "51")
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(SIZE_MAX))
+                .andDo(document("my-novel-notifications-size-too-large",
+                        resource(subscriptionsError().build())));
+    }
+
+    @DisplayName("만료된 Access Token 요청의 401 AUTH-000 응답을 문서화한다")
+    @Test
+    void documentGetSubscriptionsWithExpiredAccessToken() throws Exception {
+        mockMvc.perform(subscriptionsRequest("COMPLETION").with(expiredAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(ACCESS_TOKEN_EXPIRED.getCode()))
+                .andExpect(jsonPath("$.message").value(ACCESS_TOKEN_EXPIRED.getDescription()))
+                .andDo(document("my-novel-notifications-access-token-expired",
+                        resource(subscriptionsError().build())));
+    }
+
+    @DisplayName("Authorization 헤더가 없는 요청의 401 AUTH-001 응답을 문서화한다")
+    @Test
+    void documentGetSubscriptionsWithInvalidToken() throws Exception {
+        mockMvc.perform(subscriptionsRequest("COMPLETION"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(INVALID_TOKEN.getDescription()))
+                .andDo(document("my-novel-notifications-invalid-token",
+                        resource(subscriptionsError().build())));
+    }
+
+    @DisplayName("Refresh Token으로 인증한 요청의 401 AUTH-003 응답을 문서화한다")
+    @Test
+    void documentGetSubscriptionsWithWrongTokenType() throws Exception {
+        mockMvc.perform(subscriptionsRequest("COMPLETION").with(refreshToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(WRONG_TOKEN_TYPE.getCode()))
+                .andExpect(jsonPath("$.message").value(WRONG_TOKEN_TYPE.getDescription()))
+                .andDo(document("my-novel-notifications-wrong-token-type",
+                        resource(subscriptionsError().build())));
+    }
+
+    @DisplayName("토큰은 유효하지만 사용자가 없는 요청의 404 USER-006 응답을 문서화한다")
+    @Test
+    void documentGetSubscriptionsWithUnknownUser() throws Exception {
+        given(userService.getUserOrException(USER_ID))
+                .willThrow(new CustomUserException(USER_NOT_FOUND, "user with the given id was not found"));
+
+        mockMvc.perform(subscriptionsRequest("COMPLETION").with(accessToken(USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(USER_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(USER_NOT_FOUND.getDescription()))
+                .andDo(document("my-novel-notifications-user-not-found",
+                        resource(subscriptionsError().build())));
+    }
+
+    private ResourceSnippetParametersBuilder subscriptionsError() {
+        return subscriptions()
+                .responseSchema(ERROR_RESULT_SCHEMA)
+                .responseFields(errorResultFields());
+    }
+
+    /**
+     * 필수 파라미터 누락을 문서화할 때 쓴다. REST Docs는 선언한 query parameter가 요청에 없으면
+     * snippet 생성을 실패시키므로, 이 경우에만 파라미터 서술을 붙이지 않는다.
+     */
+    private ResourceSnippetParametersBuilder withoutQueryParameters() {
+        return ResourceSnippetParameters.builder()
+                .tag(TAG)
+                .summary(SUMMARY)
+                .description(DESCRIPTION);
+    }
+
+    private ResourceSnippetParametersBuilder subscriptions() {
+        return withoutQueryParameters()
+                .queryParameters(
+                        parameterWithName("notificationType")
+                                .description("조회할 알림 유형. COMPLETION 또는 HIATUS_RETURN."),
+                        parameterWithName("lastSubscriptionId").optional()
+                                .description("이전 페이지 마지막 구독 ID. 첫 페이지는 생략하거나 0을 보낸다. 기본값 0."),
+                        parameterWithName("size").optional()
+                                .description("조회 개수. 1 이상 50 이하. 기본값 10."));
+    }
+
+    private List<FieldDescriptor> subscriptionsResponseFields() {
+        return List.of(
+                fieldWithPath("isLoadable").type(BOOLEAN).description("다음 페이지가 있는지 여부"),
+                fieldWithPath("nextSubscriptionId").type(NUMBER).optional()
+                        .description("다음 페이지 요청에 넣을 커서. 다음 페이지가 없으면 null이다."),
+                fieldWithPath("subscriptions[]").type(org.springframework.restdocs.payload.JsonFieldType.ARRAY)
+                        .description("등록한 작품 알림 목록"),
+                fieldWithPath("subscriptions[].subscriptionId").type(NUMBER).description("구독 ID"),
+                fieldWithPath("subscriptions[].novelId").type(NUMBER).description("작품 ID"),
+                fieldWithPath("subscriptions[].novelImage").type(STRING).description("작품 이미지 URL"),
+                fieldWithPath("subscriptions[].novelTitle").type(STRING).description("작품 제목"),
+                fieldWithPath("subscriptions[].novelAuthor").type(STRING).description("작가명"),
+                fieldWithPath("subscriptions[].registeredDate").type(STRING)
+                        .description("알림을 등록한 날짜. yyyy.MM.dd 형식."));
+    }
+
+    private MockHttpServletRequestBuilder subscriptionsRequest(String notificationType) {
+        return get("/users/me/notification/novels")
+                .queryParam("notificationType", notificationType)
+                .queryParam("lastSubscriptionId", "0")
+                .queryParam("size", "10");
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/notification/controller/novelnotification/GetNovelNotificationDocsTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/novelnotification/GetNovelNotificationDocsTest.java
@@ -1,0 +1,227 @@
+package org.websoso.WSSServer.notification.controller.novelnotification;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.ACCESS_TOKEN_EXPIRED;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.INVALID_TOKEN;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.WRONG_TOKEN_TYPE;
+import static org.websoso.WSSServer.exception.error.CustomNovelError.NOVEL_NOT_FOUND;
+import static org.websoso.WSSServer.exception.error.CustomUserError.USER_NOT_FOUND;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.NOVEL_ID_POSITIVE;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.accessToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.expiredAccessToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.refreshToken;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.ERROR_RESULT_SCHEMA;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.errorLine;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.errorResultFields;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
+import com.epages.restdocs.apispec.Schema;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.websoso.WSSServer.exception.exception.CustomNovelException;
+import org.websoso.WSSServer.exception.exception.CustomUserException;
+import org.websoso.WSSServer.notification.application.NovelNotificationApplication;
+import org.websoso.WSSServer.notification.controller.NovelNotificationController;
+import org.websoso.WSSServer.notification.controller.response.NovelNotificationResponse;
+import org.websoso.WSSServer.support.auth.AuthenticatedControllerTest;
+import org.websoso.WSSServer.user.domain.User;
+import org.websoso.WSSServer.user.service.UserService;
+
+/**
+ * {@code GET /novels/{novelId}/notification}의 실제 응답을 문서화하는 REST Docs 테스트.
+ * 작품 상세에서 완결·휴재 복귀 알림의 현재 상태를 조회하는 API다.
+ *
+ * <p>경로 변수 검증 실패(400)는 {@code ConstraintViolationException} 경로를 탄다.
+ * 이 예외가 처리되지 않으면 ERROR 디스패치의 재요청이 인증에 실패해 401 AUTH-001로 둔갑하므로,
+ * 검증 메시지가 그대로 전달되는지 이 테스트가 함께 확인한다.
+ */
+@AutoConfigureRestDocs
+@AuthenticatedControllerTest(NovelNotificationController.class)
+class GetNovelNotificationDocsTest {
+
+    private static final Long USER_ID = 42L;
+    private static final Long NOVEL_ID = 1L;
+    private static final Long INVALID_NOVEL_ID = 0L;
+    private static final String TAG = "Novel Notification";
+    private static final String SUMMARY = "작품 알림 설정 조회";
+    private static final Schema RESPONSE_SCHEMA = Schema.schema("NovelNotificationResponse");
+
+    private static final String DESCRIPTION = String.join("\n",
+            "작품 상세에서 사용자가 등록한 완결·휴재 복귀 알림의 현재 상태를 조회합니다.",
+            "",
+            "두 값은 서로 독립적이며, 등록하지 않은 알림은 false로 내려갑니다.",
+            "알림이 이미 발송된 경우에도 false로 내려갑니다. 다시 켜면 새 등록으로 처리되어 등록일이 갱신됩니다.",
+            "",
+            "Try it out으로 호출하려면 상단 Authorize에 실제 Access Token을 입력해야 합니다.",
+            "",
+            "이 API가 정의하는 응답은 다음과 같습니다.",
+            "",
+            "- 200 OK — 성공.",
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), NOVEL_ID_POSITIVE),
+            errorLine(ACCESS_TOKEN_EXPIRED),
+            errorLine(INVALID_TOKEN) + " (헤더 형식 오류 또는 누락을 포함합니다.)",
+            errorLine(WRONG_TOKEN_TYPE),
+            errorLine(USER_NOT_FOUND) + " (토큰은 유효하지만, 해당 사용자 정보가 없을 때 반환합니다.)",
+            errorLine(NOVEL_NOT_FOUND),
+            "",
+            "401은 상태 코드만으로 원인을 구분할 수 없습니다. 401 응답의 Examples에서 코드별 본문 확인이 필요합니다.");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private NovelNotificationApplication novelNotificationApplication;
+
+    @BeforeEach
+    void setUp() {
+        given(userService.getUserOrException(USER_ID)).willReturn(mock(User.class));
+    }
+
+    @DisplayName("작품 알림 설정을 조회하는 200 응답을 문서화한다")
+    @Test
+    void documentGetSettingsSuccess() throws Exception {
+        given(novelNotificationApplication.getSettings(any(User.class), eq(NOVEL_ID)))
+                .willReturn(new NovelNotificationResponse(true, false));
+
+        mockMvc.perform(settingsRequest(NOVEL_ID).with(accessToken(USER_ID)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.isCompletionNotificationEnabled").value(true))
+                .andExpect(jsonPath("$.isHiatusReturnNotificationEnabled").value(false))
+                .andDo(document("novel-notification",
+                        resource(settings()
+                                .responseSchema(RESPONSE_SCHEMA)
+                                .responseFields(settingsResponseFields())
+                                .build())));
+    }
+
+    @DisplayName("양수가 아닌 작품 ID 요청의 400 응답을 문서화한다")
+    @Test
+    void documentGetSettingsWithNonPositiveNovelId() throws Exception {
+        mockMvc.perform(settingsRequest(INVALID_NOVEL_ID).with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(NOVEL_ID_POSITIVE))
+                .andDo(document("novel-notification-novel-id-not-positive",
+                        resource(settingsError().build())));
+    }
+
+    @DisplayName("만료된 Access Token 요청의 401 AUTH-000 응답을 문서화한다")
+    @Test
+    void documentGetSettingsWithExpiredAccessToken() throws Exception {
+        mockMvc.perform(settingsRequest(NOVEL_ID).with(expiredAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(ACCESS_TOKEN_EXPIRED.getCode()))
+                .andExpect(jsonPath("$.message").value(ACCESS_TOKEN_EXPIRED.getDescription()))
+                .andDo(document("novel-notification-access-token-expired",
+                        resource(settingsError().build())));
+    }
+
+    @DisplayName("Authorization 헤더가 없는 요청의 401 AUTH-001 응답을 문서화한다")
+    @Test
+    void documentGetSettingsWithInvalidToken() throws Exception {
+        mockMvc.perform(settingsRequest(NOVEL_ID))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(INVALID_TOKEN.getDescription()))
+                .andDo(document("novel-notification-invalid-token",
+                        resource(settingsError().build())));
+    }
+
+    @DisplayName("Refresh Token으로 인증한 요청의 401 AUTH-003 응답을 문서화한다")
+    @Test
+    void documentGetSettingsWithWrongTokenType() throws Exception {
+        mockMvc.perform(settingsRequest(NOVEL_ID).with(refreshToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(WRONG_TOKEN_TYPE.getCode()))
+                .andExpect(jsonPath("$.message").value(WRONG_TOKEN_TYPE.getDescription()))
+                .andDo(document("novel-notification-wrong-token-type",
+                        resource(settingsError().build())));
+    }
+
+    @DisplayName("토큰은 유효하지만 사용자가 없는 요청의 404 USER-006 응답을 문서화한다")
+    @Test
+    void documentGetSettingsWithUnknownUser() throws Exception {
+        given(userService.getUserOrException(USER_ID))
+                .willThrow(new CustomUserException(USER_NOT_FOUND, "user with the given id was not found"));
+
+        mockMvc.perform(settingsRequest(NOVEL_ID).with(accessToken(USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(USER_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(USER_NOT_FOUND.getDescription()))
+                .andDo(document("novel-notification-user-not-found",
+                        resource(settingsError().build())));
+    }
+
+    @DisplayName("존재하지 않는 작품 요청의 404 NOVEL-001 응답을 문서화한다")
+    @Test
+    void documentGetSettingsWithUnknownNovel() throws Exception {
+        given(novelNotificationApplication.getSettings(any(User.class), eq(NOVEL_ID)))
+                .willThrow(new CustomNovelException(NOVEL_NOT_FOUND, "novel with the given id is not found"));
+
+        mockMvc.perform(settingsRequest(NOVEL_ID).with(accessToken(USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(NOVEL_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(NOVEL_NOT_FOUND.getDescription()))
+                .andDo(document("novel-notification-novel-not-found",
+                        resource(settingsError().build())));
+    }
+
+    private ResourceSnippetParametersBuilder settingsError() {
+        return settings()
+                .responseSchema(ERROR_RESULT_SCHEMA)
+                .responseFields(errorResultFields());
+    }
+
+    private ResourceSnippetParametersBuilder settings() {
+        return ResourceSnippetParameters.builder()
+                .tag(TAG)
+                .summary(SUMMARY)
+                .description(DESCRIPTION)
+                .pathParameters(parameterWithName("novelId").description("조회할 작품 ID. 양수여야 한다."));
+    }
+
+    private List<FieldDescriptor> settingsResponseFields() {
+        return List.of(
+                fieldWithPath("isCompletionNotificationEnabled").type(BOOLEAN)
+                        .description("완결 알림 등록 여부"),
+                fieldWithPath("isHiatusReturnNotificationEnabled").type(BOOLEAN)
+                        .description("휴재 복귀 알림 등록 여부"));
+    }
+
+    private MockHttpServletRequestBuilder settingsRequest(Long novelId) {
+        return get("/novels/{novelId}/notification", novelId);
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/notification/controller/novelnotification/PutNovelNotificationDocsTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/novelnotification/PutNovelNotificationDocsTest.java
@@ -1,0 +1,293 @@
+package org.websoso.WSSServer.notification.controller.novelnotification;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.ACCESS_TOKEN_EXPIRED;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.INVALID_TOKEN;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.WRONG_TOKEN_TYPE;
+import static org.websoso.WSSServer.exception.error.CustomNovelError.NOVEL_NOT_FOUND;
+import static org.websoso.WSSServer.exception.error.CustomUserError.USER_NOT_FOUND;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.COMPLETION_NOTIFICATION_NOT_NULL;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.HIATUS_RETURN_NOTIFICATION_NOT_NULL;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.NOVEL_ID_POSITIVE;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.accessToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.expiredAccessToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.refreshToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.tamperedAccessToken;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.ERROR_RESULT_SCHEMA;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.errorLine;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.errorResultFields;
+import static org.websoso.WSSServer.support.docs.RequestPreprocessors.withoutRequestBody;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
+import com.epages.restdocs.apispec.Schema;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.websoso.WSSServer.exception.exception.CustomNovelException;
+import org.websoso.WSSServer.exception.exception.CustomUserException;
+import org.websoso.WSSServer.notification.application.NovelNotificationApplication;
+import org.websoso.WSSServer.notification.controller.NovelNotificationController;
+import org.websoso.WSSServer.notification.controller.request.NovelNotificationUpdateRequest;
+import org.websoso.WSSServer.support.auth.AuthenticatedControllerTest;
+import org.websoso.WSSServer.user.domain.User;
+import org.websoso.WSSServer.user.service.UserService;
+
+/**
+ * {@code PUT /novels/{novelId}/notification}의 실제 응답을 문서화하는 REST Docs 테스트.
+ * 두 알림 상태를 요청한 값과 동일하게 맞추는 멱등 API이므로, 같은 요청을 반복해도 결과가 같다.
+ */
+@AutoConfigureRestDocs
+@AuthenticatedControllerTest(NovelNotificationController.class)
+class PutNovelNotificationDocsTest {
+
+    private static final Long USER_ID = 42L;
+    private static final Long NOVEL_ID = 1L;
+    private static final Long INVALID_NOVEL_ID = 0L;
+    private static final NovelNotificationUpdateRequest UPDATE_REQUEST =
+            new NovelNotificationUpdateRequest(true, false);
+    private static final String TAG = "Novel Notification";
+    private static final String SUMMARY = "작품 알림 설정 변경";
+    private static final Schema REQUEST_SCHEMA = Schema.schema("NovelNotificationUpdateRequest");
+    private static final String MALFORMED_JSON_MESSAGE = "잘못된 JSON 형식입니다.";
+
+    private static final String DESCRIPTION = String.join("\n",
+            "작품 상세에서 완결·휴재 복귀 알림을 요청한 상태로 맞춥니다.",
+            "",
+            "두 값을 모두 보내야 하며, 각각 true면 등록하고 false면 해제합니다.",
+            "이미 같은 상태여도 성공하는 멱등 API이므로, 토글 결과를 그대로 보내면 됩니다.",
+            "",
+            "Try it out으로 호출하려면 상단 Authorize에 실제 Access Token을 입력해야 합니다.",
+            "",
+            "이 API가 정의하는 응답은 다음과 같습니다.",
+            "",
+            "- 204 No Content — 성공. (응답 본문이 없습니다.)",
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), NOVEL_ID_POSITIVE),
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), COMPLETION_NOTIFICATION_NOT_NULL),
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), HIATUS_RETURN_NOTIFICATION_NOT_NULL),
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), MALFORMED_JSON_MESSAGE)
+                    + " (본문이 JSON으로 읽히지 않을 때 반환합니다.)",
+            errorLine(ACCESS_TOKEN_EXPIRED),
+            errorLine(INVALID_TOKEN) + " (헤더 형식 오류 또는 누락을 포함합니다.)",
+            errorLine(WRONG_TOKEN_TYPE),
+            errorLine(USER_NOT_FOUND) + " (토큰은 유효하지만, 해당 사용자 정보가 없을 때 반환합니다.)",
+            errorLine(NOVEL_NOT_FOUND),
+            "",
+            "400과 401은 상태 코드만으로 원인을 구분할 수 없습니다. 각 응답의 Examples에서 본문 확인이 필요합니다.");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private NovelNotificationApplication novelNotificationApplication;
+
+    @BeforeEach
+    void setUp() {
+        given(userService.getUserOrException(USER_ID)).willReturn(mock(User.class));
+    }
+
+    @DisplayName("작품 알림 설정 변경 성공(204, 본문 없음) 응답을 문서화한다")
+    @Test
+    void documentUpdateSettingsSuccess() throws Exception {
+        mockMvc.perform(updateRequest(NOVEL_ID, UPDATE_REQUEST).with(accessToken(USER_ID)))
+                .andExpect(status().isNoContent())
+                .andExpect(content().string(""))
+                .andDo(document("novel-notification-update",
+                        resource(update()
+                                .requestSchema(REQUEST_SCHEMA)
+                                .requestFields(updateRequestFields())
+                                .build())));
+    }
+
+    @DisplayName("양수가 아닌 작품 ID 요청의 400 응답을 문서화한다")
+    @Test
+    void documentUpdateSettingsWithNonPositiveNovelId() throws Exception {
+        mockMvc.perform(updateRequest(INVALID_NOVEL_ID, UPDATE_REQUEST).with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(NOVEL_ID_POSITIVE))
+                .andDo(document("novel-notification-update-novel-id-not-positive",
+                        withoutRequestBody(),
+                        resource(updateError().build())));
+    }
+
+    @DisplayName("완결 알림 값이 없는 요청의 400 응답을 문서화한다")
+    @Test
+    void documentUpdateSettingsWithoutCompletionValue() throws Exception {
+        mockMvc.perform(updateRequest(NOVEL_ID, new NovelNotificationUpdateRequest(null, false))
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(COMPLETION_NOTIFICATION_NOT_NULL))
+                .andDo(document("novel-notification-update-completion-null",
+                        withoutRequestBody(),
+                        resource(updateError().build())));
+    }
+
+    @DisplayName("휴재 복귀 알림 값이 없는 요청의 400 응답을 문서화한다")
+    @Test
+    void documentUpdateSettingsWithoutHiatusReturnValue() throws Exception {
+        mockMvc.perform(updateRequest(NOVEL_ID, new NovelNotificationUpdateRequest(true, null))
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(HIATUS_RETURN_NOTIFICATION_NOT_NULL))
+                .andDo(document("novel-notification-update-hiatus-return-null",
+                        withoutRequestBody(),
+                        resource(updateError().build())));
+    }
+
+    @DisplayName("본문 JSON 형식이 잘못된 요청의 400 응답을 문서화한다")
+    @Test
+    void documentUpdateSettingsWithMalformedJson() throws Exception {
+        mockMvc.perform(put("/novels/{novelId}/notification", NOVEL_ID)
+                        .contentType(APPLICATION_JSON)
+                        .content("{\"isCompletionNotificationEnabled\":")
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(MALFORMED_JSON_MESSAGE))
+                .andDo(document("novel-notification-update-malformed-json",
+                        withoutRequestBody(),
+                        resource(updateError().build())));
+    }
+
+    @DisplayName("만료된 Access Token 요청의 401 AUTH-000 응답을 문서화한다")
+    @Test
+    void documentUpdateSettingsWithExpiredAccessToken() throws Exception {
+        mockMvc.perform(updateRequest(NOVEL_ID, UPDATE_REQUEST).with(expiredAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(ACCESS_TOKEN_EXPIRED.getCode()))
+                .andExpect(jsonPath("$.message").value(ACCESS_TOKEN_EXPIRED.getDescription()))
+                .andDo(document("novel-notification-update-access-token-expired",
+                        withoutRequestBody(),
+                        resource(updateError().build())));
+    }
+
+    /**
+     * 헤더를 아예 빼지 않고 변조된 토큰을 보낸다.
+     * 이 경로·메서드의 문서 중 Bearer 헤더가 하나도 없는 요청이 섞이면 생성기가 operation의
+     * security requirement를 만들지 않아 Swagger UI에 Authorize 자물쇠가 붙지 않았다.
+     * AUTH-001은 헤더 누락과 형식 오류를 함께 뜻하므로 변조 토큰으로도 같은 응답을 재현한다.
+     */
+    @DisplayName("변조된 Access Token 요청의 401 AUTH-001 응답을 문서화한다")
+    @Test
+    void documentUpdateSettingsWithInvalidToken() throws Exception {
+        mockMvc.perform(updateRequest(NOVEL_ID, UPDATE_REQUEST).with(tamperedAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(INVALID_TOKEN.getDescription()))
+                .andDo(document("novel-notification-update-invalid-token",
+                        withoutRequestBody(),
+                        resource(updateError().build())));
+    }
+
+    @DisplayName("Refresh Token으로 인증한 요청의 401 AUTH-003 응답을 문서화한다")
+    @Test
+    void documentUpdateSettingsWithWrongTokenType() throws Exception {
+        mockMvc.perform(updateRequest(NOVEL_ID, UPDATE_REQUEST).with(refreshToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(WRONG_TOKEN_TYPE.getCode()))
+                .andExpect(jsonPath("$.message").value(WRONG_TOKEN_TYPE.getDescription()))
+                .andDo(document("novel-notification-update-wrong-token-type",
+                        withoutRequestBody(),
+                        resource(updateError().build())));
+    }
+
+    @DisplayName("토큰은 유효하지만 사용자가 없는 요청의 404 USER-006 응답을 문서화한다")
+    @Test
+    void documentUpdateSettingsWithUnknownUser() throws Exception {
+        given(userService.getUserOrException(USER_ID))
+                .willThrow(new CustomUserException(USER_NOT_FOUND, "user with the given id was not found"));
+
+        mockMvc.perform(updateRequest(NOVEL_ID, UPDATE_REQUEST).with(accessToken(USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(USER_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(USER_NOT_FOUND.getDescription()))
+                .andDo(document("novel-notification-update-user-not-found",
+                        withoutRequestBody(),
+                        resource(updateError().build())));
+    }
+
+    @DisplayName("존재하지 않는 작품 요청의 404 NOVEL-001 응답을 문서화한다")
+    @Test
+    void documentUpdateSettingsWithUnknownNovel() throws Exception {
+        willThrow(new CustomNovelException(NOVEL_NOT_FOUND, "novel with the given id is not found"))
+                .given(novelNotificationApplication).updateSettings(any(User.class), eq(NOVEL_ID), eq(UPDATE_REQUEST));
+
+        mockMvc.perform(updateRequest(NOVEL_ID, UPDATE_REQUEST).with(accessToken(USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value(NOVEL_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(NOVEL_NOT_FOUND.getDescription()))
+                .andDo(document("novel-notification-update-novel-not-found",
+                        withoutRequestBody(),
+                        resource(updateError().build())));
+    }
+
+    private ResourceSnippetParametersBuilder updateError() {
+        return update()
+                .responseSchema(ERROR_RESULT_SCHEMA)
+                .responseFields(errorResultFields());
+    }
+
+    private ResourceSnippetParametersBuilder update() {
+        return ResourceSnippetParameters.builder()
+                .tag(TAG)
+                .summary(SUMMARY)
+                .description(DESCRIPTION)
+                .pathParameters(parameterWithName("novelId").description("설정을 변경할 작품 ID. 양수여야 한다."));
+    }
+
+    private List<FieldDescriptor> updateRequestFields() {
+        return List.of(
+                fieldWithPath("isCompletionNotificationEnabled").type(BOOLEAN)
+                        .description("완결 알림을 등록할지 여부. true면 등록하고 false면 해제한다."),
+                fieldWithPath("isHiatusReturnNotificationEnabled").type(BOOLEAN)
+                        .description("휴재 복귀 알림을 등록할지 여부. true면 등록하고 false면 해제한다."));
+    }
+
+    private MockHttpServletRequestBuilder updateRequest(Long novelId, NovelNotificationUpdateRequest request)
+            throws Exception {
+        return put("/novels/{novelId}/notification", novelId)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request));
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/notification/controller/request/NovelNotificationDeleteRequestTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/request/NovelNotificationDeleteRequestTest.java
@@ -1,0 +1,38 @@
+package org.websoso.WSSServer.notification.controller.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.websoso.WSSServer.notification.controller.NovelNotificationValidationMessage.NOVEL_ID_NOT_NULL;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Arrays;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+
+/** 작품 알림 일괄 삭제 요청의 작품 ID 요소 검증을 확인한다. */
+class NovelNotificationDeleteRequestTest {
+
+    /** 작품 ID 목록에 null이 포함되면 검증에 실패하는지 확인한다. */
+    @Test
+    @DisplayName("삭제할 작품 ID에 null을 허용하지 않는다")
+    void rejectsNullNovelId() {
+        NovelNotificationDeleteRequest request = new NovelNotificationDeleteRequest(
+                NovelNotificationType.COMPLETION,
+                Arrays.asList(10L, null)
+        );
+
+        try (ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = validatorFactory.getValidator();
+
+            Set<ConstraintViolation<NovelNotificationDeleteRequest>> violations = validator.validate(request);
+
+            assertThat(violations)
+                    .extracting(ConstraintViolation::getMessage)
+                    .contains(NOVEL_ID_NOT_NULL);
+        }
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/notification/controller/response/NotificationPageResponseTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/response/NotificationPageResponseTest.java
@@ -1,0 +1,46 @@
+package org.websoso.WSSServer.notification.controller.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.websoso.WSSServer.notification.domain.Notification;
+import org.websoso.WSSServer.notification.domain.NotificationType;
+import org.websoso.WSSServer.notification.dto.ReadNotificationDto;
+
+/** 앱 내 알림 목록이 작품 이동 정보를 포함하는지 검증한다. */
+class NotificationPageResponseTest {
+
+    /** 작품 알림의 novelId를 기존 목록 응답에 포함하는지 검증한다. */
+    @Test
+    @DisplayName("작품 알림의 작품 ID를 반환한다")
+    void includesNovelId() {
+        NotificationType notificationType = mock(NotificationType.class);
+        given(notificationType.getNotificationTypeName()).willReturn("완결 알림");
+        given(notificationType.getNotificationTypeImage()).willReturn("image");
+        Notification notification = Notification.createNoticeNotification(
+                "완결 알림",
+                "작품이 완결났어요.",
+                null,
+                1L,
+                notificationType
+        );
+        ReflectionTestUtils.setField(notification, "notificationId", 10L);
+        ReflectionTestUtils.setField(notification, "novelId", 100L);
+        ReflectionTestUtils.setField(notification, "createdDate", LocalDateTime.now());
+
+        NotificationPageResponse response = NotificationPageResponse.from(
+                new SliceImpl<>(List.of(new ReadNotificationDto(notification, false)))
+        );
+
+        assertThat(response.notifications()).singleElement()
+                .extracting("feedId", "novelId", "isNotice")
+                .containsExactly(null, 100L, false);
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/notification/controller/response/NovelNotificationPageResponseTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/response/NovelNotificationPageResponseTest.java
@@ -1,0 +1,69 @@
+package org.websoso.WSSServer.notification.controller.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.websoso.WSSServer.notification.domain.NovelNotificationSubscription;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.user.domain.User;
+
+/** 작품 알림 구독 목록의 작품 정보·날짜·커서 변환을 검증한다. */
+class NovelNotificationPageResponseTest {
+
+    /** 다음 페이지가 있으면 마지막 구독 ID와 표시 정보를 반환하는지 검증한다. */
+    @Test
+    @DisplayName("구독 목록을 설정 화면 응답으로 변환한다")
+    void convertsSubscriptionSlice() {
+        NovelNotificationSubscription first = createSubscription(20L, 100L, "첫 작품", "첫 작가");
+        NovelNotificationSubscription second = createSubscription(10L, 200L, "둘째 작품", "둘째 작가");
+        Slice<NovelNotificationSubscription> slice = new SliceImpl<>(
+                List.of(first, second),
+                PageRequest.of(0, 2),
+                true
+        );
+
+        NovelNotificationPageResponse response = NovelNotificationPageResponse.from(slice);
+
+        assertThat(response.isLoadable()).isTrue();
+        assertThat(response.nextSubscriptionId()).isEqualTo(10L);
+        assertThat(response.subscriptions()).hasSize(2);
+        assertThat(response.subscriptions().get(0))
+                .extracting("novelId", "novelTitle", "novelAuthor", "registeredDate")
+                .containsExactly(100L, "첫 작품", "첫 작가", "2026.07.14");
+    }
+
+    private NovelNotificationSubscription createSubscription(
+            Long subscriptionId,
+            Long novelId,
+            String title,
+            String author
+    ) {
+        Novel novel = mock(Novel.class);
+        given(novel.getNovelId()).willReturn(novelId);
+        given(novel.getNovelImage()).willReturn("image-" + novelId);
+        given(novel.getTitle()).willReturn(title);
+        given(novel.getAuthor()).willReturn(author);
+        NovelNotificationSubscription subscription = NovelNotificationSubscription.create(
+                mock(User.class),
+                novel,
+                NovelNotificationType.COMPLETION
+        );
+        ReflectionTestUtils.setField(
+                subscription,
+                "novelNotificationSubscriptionId",
+                subscriptionId
+        );
+        ReflectionTestUtils.setField(subscription, "createdDate", LocalDateTime.of(2026, 7, 14, 12, 0));
+        return subscription;
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/notification/domain/NovelNotificationSubscriptionTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/domain/NovelNotificationSubscriptionTest.java
@@ -1,0 +1,30 @@
+package org.websoso.WSSServer.notification.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.user.domain.User;
+
+/** 작품 알림 구독 엔티티의 생성 규칙을 검증한다. */
+class NovelNotificationSubscriptionTest {
+
+    /** 사용자·작품·유형을 그대로 보존하는지 검증한다. */
+    @Test
+    @DisplayName("사용자와 작품, 알림 유형으로 구독을 생성한다")
+    void createsSubscription() {
+        User user = User.createBySocial("social-id", "사용자", null);
+        Novel novel = org.mockito.Mockito.mock(Novel.class);
+
+        NovelNotificationSubscription subscription = NovelNotificationSubscription.create(
+                user,
+                novel,
+                NovelNotificationType.COMPLETION
+        );
+
+        assertThat(subscription.getUser()).isSameAs(user);
+        assertThat(subscription.getNovel()).isSameAs(novel);
+        assertThat(subscription.getNotificationType()).isEqualTo(NovelNotificationType.COMPLETION);
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/notification/service/NovelNotificationServiceTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/service/NovelNotificationServiceTest.java
@@ -1,0 +1,229 @@
+package org.websoso.WSSServer.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.websoso.WSSServer.notification.domain.NovelNotificationSubscription;
+import org.websoso.WSSServer.notification.domain.NovelNotificationType;
+import org.websoso.WSSServer.notification.repository.NovelNotificationSubscriptionRepository;
+import org.websoso.WSSServer.novel.domain.Novel;
+import org.websoso.WSSServer.user.domain.User;
+
+/** 작품 알림 구독의 등록·조회·삭제 서비스 동작을 검증한다. */
+@ExtendWith(MockitoExtension.class)
+class NovelNotificationServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long NOVEL_ID = 10L;
+
+    @InjectMocks
+    private NovelNotificationService novelNotificationService;
+
+    @Mock
+    private NovelNotificationSubscriptionRepository subscriptionRepository;
+
+    @Nested
+    @DisplayName("작품 알림 설정 갱신")
+    class UpdateSettings {
+
+        /** 등록되지 않은 유형만 새로 저장하는지 검증한다. */
+        @Test
+        @DisplayName("켠 유형이 등록되어 있지 않으면 새로 저장한다")
+        void savesEnabledTypeWhenAbsent() {
+            User user = createUser();
+            Novel novel = createNovel();
+            given(subscriptionRepository.findAllByUser_UserIdAndNovel_NovelId(USER_ID, NOVEL_ID))
+                    .willReturn(List.of());
+
+            novelNotificationService.updateSettings(user, novel, true, false);
+
+            ArgumentCaptor<NovelNotificationSubscription> captor =
+                    ArgumentCaptor.forClass(NovelNotificationSubscription.class);
+            verify(subscriptionRepository).save(captor.capture());
+            assertThat(captor.getValue().getNotificationType()).isEqualTo(NovelNotificationType.COMPLETION);
+            verify(subscriptionRepository, never()).delete(any(NovelNotificationSubscription.class));
+        }
+
+        /** 끈 유형만 삭제하고 유지할 유형은 건드리지 않는지 검증한다. */
+        @Test
+        @DisplayName("끈 유형이 등록되어 있으면 삭제한다")
+        void deletesDisabledTypeWhenPresent() {
+            User user = createUser();
+            Novel novel = createNovel();
+            NovelNotificationSubscription completion = createSubscription(NovelNotificationType.COMPLETION);
+            NovelNotificationSubscription hiatusReturn = createSubscription(NovelNotificationType.HIATUS_RETURN);
+            given(subscriptionRepository.findAllByUser_UserIdAndNovel_NovelId(USER_ID, NOVEL_ID))
+                    .willReturn(List.of(completion, hiatusReturn));
+
+            novelNotificationService.updateSettings(user, novel, true, false);
+
+            verify(subscriptionRepository).delete(hiatusReturn);
+            verify(subscriptionRepository, never()).delete(completion);
+            verify(subscriptionRepository, never()).save(any(NovelNotificationSubscription.class));
+        }
+
+        /** 발송이 끝난 구독을 다시 켜면 지우고 새로 등록해 등록일이 갱신되는지 검증한다. */
+        @Test
+        @DisplayName("발송이 끝난 구독을 다시 켜면 지우고 새로 등록한다")
+        void reregistersSentSubscriptionWhenEnabledAgain() {
+            User user = createUser();
+            Novel novel = createNovel();
+            NovelNotificationSubscription sent = createSentSubscription(NovelNotificationType.COMPLETION);
+            given(subscriptionRepository.findAllByUser_UserIdAndNovel_NovelId(USER_ID, NOVEL_ID))
+                    .willReturn(List.of(sent));
+
+            novelNotificationService.updateSettings(user, novel, true, false);
+
+            InOrder inOrder = inOrder(subscriptionRepository);
+            inOrder.verify(subscriptionRepository).delete(sent);
+            inOrder.verify(subscriptionRepository).flush();
+            ArgumentCaptor<NovelNotificationSubscription> captor =
+                    ArgumentCaptor.forClass(NovelNotificationSubscription.class);
+            inOrder.verify(subscriptionRepository).save(captor.capture());
+            assertThat(captor.getValue().getNotificationType()).isEqualTo(NovelNotificationType.COMPLETION);
+            assertThat(captor.getValue().isSent()).isFalse();
+        }
+
+        /** 이미 요청과 같은 상태면 저장도 삭제도 하지 않는지 검증한다. */
+        @Test
+        @DisplayName("이미 요청과 같은 상태면 아무것도 저장하거나 삭제하지 않는다")
+        void doesNothingWhenAlreadyInRequestedState() {
+            User user = createUser();
+            Novel novel = createNovel();
+            given(subscriptionRepository.findAllByUser_UserIdAndNovel_NovelId(USER_ID, NOVEL_ID))
+                    .willReturn(List.of(createSubscription(NovelNotificationType.COMPLETION)));
+
+            novelNotificationService.updateSettings(user, novel, true, false);
+
+            verify(subscriptionRepository, never()).save(any(NovelNotificationSubscription.class));
+            verify(subscriptionRepository, never()).delete(any(NovelNotificationSubscription.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("작품 알림 설정 조회")
+    class GetEnabledTypes {
+
+        /** 저장된 구독에서 활성 알림 유형만 반환하는지 검증한다. */
+        @Test
+        @DisplayName("등록된 알림 유형 집합을 반환한다")
+        void returnsEnabledTypes() {
+            NovelNotificationSubscription completion = NovelNotificationSubscription.create(
+                    createUser(),
+                    org.mockito.Mockito.mock(Novel.class),
+                    NovelNotificationType.COMPLETION
+            );
+            given(subscriptionRepository.findAllByUser_UserIdAndNovel_NovelId(USER_ID, NOVEL_ID))
+                    .willReturn(List.of(completion));
+
+            Set<NovelNotificationType> result = novelNotificationService.getEnabledTypes(USER_ID, NOVEL_ID);
+
+            assertThat(result).containsExactly(NovelNotificationType.COMPLETION);
+        }
+
+        /** 발송이 끝난 구독은 토글이 꺼진 것으로 보이는지 검증한다. */
+        @Test
+        @DisplayName("발송이 끝난 구독은 활성 유형에서 제외한다")
+        void excludesSentSubscription() {
+            given(subscriptionRepository.findAllByUser_UserIdAndNovel_NovelId(USER_ID, NOVEL_ID))
+                    .willReturn(List.of(
+                            createSentSubscription(NovelNotificationType.COMPLETION),
+                            createSubscription(NovelNotificationType.HIATUS_RETURN)
+                    ));
+
+            Set<NovelNotificationType> result = novelNotificationService.getEnabledTypes(USER_ID, NOVEL_ID);
+
+            assertThat(result).containsExactly(NovelNotificationType.HIATUS_RETURN);
+        }
+    }
+
+    @Nested
+    @DisplayName("작품 알림 목록 조회와 삭제")
+    class ManageSubscriptions {
+
+        /** 커서와 크기를 Repository 페이지 요청으로 전달하는지 검증한다. */
+        @Test
+        @DisplayName("알림 유형별 구독 목록을 조회한다")
+        void getsSubscriptionsByType() {
+            Long lastSubscriptionId = 30L;
+            int size = 10;
+            PageRequest pageRequest = PageRequest.of(0, size);
+            Slice<NovelNotificationSubscription> expected = new SliceImpl<>(List.of());
+            given(subscriptionRepository.findSubscriptions(
+                    USER_ID,
+                    NovelNotificationType.HIATUS_RETURN,
+                    lastSubscriptionId,
+                    pageRequest
+            )).willReturn(expected);
+
+            Slice<NovelNotificationSubscription> result = novelNotificationService.getSubscriptions(
+                    USER_ID,
+                    NovelNotificationType.HIATUS_RETURN,
+                    lastSubscriptionId,
+                    size
+            );
+
+            assertThat(result).isSameAs(expected);
+        }
+
+        /** 사용자와 유형, 작품 목록을 제한 조건으로 전달하는지 검증한다. */
+        @Test
+        @DisplayName("선택한 작품의 같은 유형 구독을 일괄 삭제한다")
+        void deletesSelectedSubscriptions() {
+            List<Long> novelIds = List.of(10L, 20L);
+
+            novelNotificationService.deleteSubscriptions(USER_ID, NovelNotificationType.COMPLETION, novelIds);
+
+            verify(subscriptionRepository).deleteSubscriptions(
+                    USER_ID,
+                    NovelNotificationType.COMPLETION,
+                    novelIds
+            );
+        }
+    }
+
+    private NovelNotificationSubscription createSentSubscription(NovelNotificationType notificationType) {
+        NovelNotificationSubscription subscription = createSubscription(notificationType);
+        ReflectionTestUtils.setField(subscription, "isSent", true);
+        return subscription;
+    }
+
+    private NovelNotificationSubscription createSubscription(NovelNotificationType notificationType) {
+        return NovelNotificationSubscription.create(
+                createUser(),
+                org.mockito.Mockito.mock(Novel.class),
+                notificationType
+        );
+    }
+
+    private User createUser() {
+        User user = User.createBySocial("social-id", "사용자", null);
+        ReflectionTestUtils.setField(user, "userId", USER_ID);
+        return user;
+    }
+
+    private Novel createNovel() {
+        Novel novel = org.mockito.Mockito.mock(Novel.class);
+        given(novel.getNovelId()).willReturn(NOVEL_ID);
+        return novel;
+    }
+}


### PR DESCRIPTION
## Related Issue
- feat/#567 -> dev
- close #567

## Key Changes

- 작품별 완결·휴재 복귀 알림 구독을 저장하는 도메인과 테이블을 추가했습니다. `(user_id, novel_id, notification_type)`에 유니크 제약을 둬 같은 구독이 중복 저장되지 않게 하고, 발송 여부(`is_sent`)를 함께 두어 등록 시 `false`로 시작합니다. 발송은 어드민에서 처리하므로 이 서버에는 값을 바꾸는 메서드를 두지 않았습니다. 목록 조회가 사용자·유형·발송 여부로 걸러 최신순 정렬하므로 인덱스도 `(user_id, notification_type, is_sent, id)` 순으로 구성했습니다. (38b5011c)
- 구독 목록 조회와 일괄 삭제를 QueryDSL로 작성했습니다. 목록은 아직 발송되지 않은 구독만 커서 방식으로 내려가며, 작품을 `fetch join`으로 함께 읽어 한 쿼리로 끝냅니다. 단건 등록·삭제는 별도 메서드 없이 `JpaRepository`의 `save`, `delete`를 그대로 사용합니다. 벌크 삭제는 영속성 컨텍스트를 거치지 않으므로 실행 전후로 직접 `flush`/`clear` 합니다. (cb8ea84a)
- 구독 등록·해제·조회 유스케이스를 서비스로 묶었습니다. `updateSettings`는 현재 등록 상태를 한 번 조회한 뒤 요청과 다른 유형만 저장하거나 삭제하므로, 같은 요청을 반복해도 결과가 같고 이미 같은 상태면 쿼리를 보내지 않습니다. 클라이언트는 현재 상태를 몰라도 토글 결과만 보내면 됩니다. 발송이 끝난 구독은 조회와 갱신 양쪽에서 미등록으로 취급합니다. 설정 조회에서 제외하고, 다시 켜면 지우고 새로 등록해 등록일을 갱신합니다. (3e4f82da)
- 요청·응답 모델을 정의했습니다. 변경 요청은 두 알림의 목표 상태를, 삭제 요청은 유형과 작품 목록(최대 100개)을 받습니다. 응답은 작품 상세용 두 토글 상태와 설정 화면용 목록·다음 커서입니다. 검증 실패 메시지는 `NovelNotificationValidationMessage`에 상수로 모아 같은 뜻의 메시지가 갈리지 않게 했습니다. (6a24f12c)
- 작품 존재 검증과 구독 유스케이스를 조합하는 애플리케이션 계층을 추가했습니다. 설정 조회·변경은 먼저 작품을 조회해 없으면 `NOVEL-001`을 던져, 없는 작품에 알림이 등록돼 목록에 빈 항목이 생기는 것을 막습니다. (cc250a7f)
- 작품 알림 API 4개를 추가했습니다. 작품 기준 설정은 작품 하위 리소스에, 내 구독 목록은 기존 `/users/me/...` 컨벤션 아래에 뒀습니다. 목록 조회는 `size`를 1~50으로 제한합니다. (961390b1)
  - `GET /novels/{novelId}/notification` 작품 알림 설정 조회
  - `PUT /novels/{novelId}/notification` 작품 알림 설정 변경
  - `GET /users/me/notification/novels` 내 구독 목록 조회
  - `DELETE /users/me/notification/novels` 내 구독 일괄 삭제
- 앱 내 알림 목록이 작품 알림을 다루도록 확장했습니다. `Notification`에 `novelId`를 추가하고 알림 유형에 `NOVEL` 그룹을 뒀으며, 목록 응답이 `feedId`와 나란히 `novelId`를 내려 클라이언트가 이동 대상을 필드 유무로 판단하게 했습니다. 기존 생성 계약은 `novelId`를 `null`로 채우는 오버로드로 유지해 공지·피드 알림 쪽은 바뀌지 않습니다. (f938629a)
- `@Validated` 파라미터 검증 실패가 401로 둔갑하던 문제를 수정했습니다. `ConstraintViolationException`에 핸들러가 없어 예외가 ERROR 디스패치로 넘어갔고, 그 재요청은 `SecurityContext`가 비어 인증에 실패해 `AUTH-001`이 나갔습니다. 그래서 제약 조건에 정의한 메시지가 클라이언트에 전달되지 않았습니다. 같은 경로를 타던 필수 파라미터 누락과 타입 변환 실패도 함께 400으로 처리하며, 실제 인증 실패는 그대로 401입니다. (53ae7e50)
- 작품 알림 API 4개를 REST Docs로 문서화했습니다(37 케이스). 성공 응답과 애플리케이션이 정의한 실패 응답을 모두 실제 요청으로 재현하고 에러 코드·메시지까지 단언합니다. 에러 코드가 여러 개인 400과 401은 문서 식별자를 원인별로 나눠 Swagger UI의 Examples에서 코드별 본문을 고를 수 있습니다. (131c8c3b)

- 구독 목록 조회의 쿼리 파라미터에 타입과 유효값을 명시했습니다. `notificationType`은 `enumValues` 속성으로 유효값을 명세에 넣어 Swagger UI가 선택 상자를 띄우고, 값은 `NovelNotificationType`에서 읽으므로 유형이 늘어나면 문서도 따라갑니다. `lastSubscriptionId`·`size`는 정수 타입과 기본값(0, 10)을 지정해 Try it out 입력칸이 채워집니다. 요청 본문 쪽은 `restdocs-api-spec`의 JSON 스키마 생성기가 `enumValues`를 읽지 않아 서술로만 남겼습니다. (8f3ef42d)

## To Reviewers

- **DDL을 먼저 적용해야 합니다.** `notification` 테이블의 `novel_id` 컬럼이 없으면 신규 API뿐 아니라 **기존 `GET /notifications`까지 실패**합니다. `src/main/resources/db/ddl/567_novel_notification_subscription.sql`을 배포 전에 적용해 주세요.
- API 경로가 이슈 초안과 다릅니다. 초안의 `/novels/{novelId}/notification-settings`, `/novel-notification-settings`를 각각 `/novels/{novelId}/notification`, `/users/me/notification/novels`로 정리했습니다. 같은 기능인데 한쪽만 최상위 하이픈 경로였고, 구독 목록은 "내" 리소스인데 소유자가 경로에 드러나지 않아서입니다. 이슈 본문도 함께 수정했습니다.
- 휴재 복귀 알림 처리 방식이 이슈 초안과 다릅니다. 초안은 발송 성공 시 어드민이 구독을 **삭제**하는 방식이었으나, 발송 여부(`is_sent`) 컬럼을 두고 **어드민이 `true`로 갱신**하면 목록에서 제외되는 방식으로 바꿨습니다. 발송 이력이 남아 재시도와 추적이 가능합니다. 어드민 쪽 구현이 이 전제와 맞는지 확인이 필요합니다.
- **발송 여부는 목록 조회와 작품 상세 양쪽에 적용했습니다.** 발송이 끝난 구독은 `GET /novels/{novelId}/notification`에서도 `false`로 내려갑니다. 이 상태에서 다시 켜면 기존 구독을 지우고 새로 등록해 **등록일이 갱신**됩니다. `(user, novel, type)` UNIQUE 제약이 있어 저장 전에 삭제를 먼저 반영하며, 등록일은 `@CreatedDate`가 새로 채웁니다. 이슈의 "해제 후 재등록 시 새 등록일 저장" 정책을 발송 완료 건에도 동일하게 적용한 것입니다.
- **`notification_type` 데이터가 이 PR에 없습니다.** `NotificationTypeGroup.NOVEL`이 "완결 알림", "휴재 복귀 알림" 두 이름을 참조하는데, 해당 행을 넣는 DDL은 포함하지 않았습니다. 어드민이 알림을 만들 때 쓸 `notification_type_id`가 필요하다면 별도로 넣어야 합니다.
- 작품 알림 레코드를 만드는 코드는 이 서버에 없습니다. 이슈의 제외 범위대로 어드민이 `notification` 테이블에 `novel_id`를 채워 INSERT하는 전제입니다.
- 구독 정리는 애플리케이션 코드가 아니라 DDL의 `ON DELETE CASCADE`로 처리합니다. 회원 탈퇴·작품 삭제 시 고아 데이터가 남지 않습니다.
- 멱등성은 등록·해제 모두 만족합니다. 이미 켜져 있으면 INSERT를 보내지 않고, 등록되지 않은 작품 ID가 섞인 삭제 요청도 성공합니다. 다만 **해제 후 재등록 시 새 등록일이 저장**되는 것은 의도된 동작입니다(이슈 확정 정책).
- `GlobalExceptionHandler` 수정은 이 API에 필요해 포함했지만 전역에 적용됩니다. 지금까지 401로 나가던 파라미터 검증 실패·필수 파라미터 누락·타입 변환 실패가 400으로 바뀌므로, 다른 API의 클라이언트가 이 401에 의존하고 있지 않은지 확인 부탁드립니다.

## References

- [완결/휴재알림 기획](https://app.notion.com/p/7-da19f0679668838795bd811eb3d51ca2?source=copy_link)
- 로컬 검증: `./gradlew clean apiDocs` 통과, 알림 관련 테스트 54건 통과, dev DB 연결 상태에서 등록·재등록(멱등)·해제·목록 조회·검증 오류 응답을 실제 요청으로 확인했습니다. `is_sent` 동작은 dev DB에 컬럼 적용 후 확인이 필요합니다.
