### PR TITLE
[CHORE] 요청·응답 바디 로깅 및 민감정보 마스킹 적용

### DIFF
--- a/src/main/java/org/websoso/WSSServer/auth/client/dto/AppleTokenResponse.java
+++ b/src/main/java/org/websoso/WSSServer/auth/client/dto/AppleTokenResponse.java
@@ -1,9 +1,14 @@
 package org.websoso.WSSServer.auth.client.dto;
 
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 public record AppleTokenResponse(
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String access_token,
         String expires_in,
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String id_token,
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String refresh_token,
         String token_type,
         String error

--- a/src/main/java/org/websoso/WSSServer/auth/client/dto/KakaoUserInfo.java
+++ b/src/main/java/org/websoso/WSSServer/auth/client/dto/KakaoUserInfo.java
@@ -2,6 +2,8 @@ package org.websoso.WSSServer.auth.client.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoUserInfo(
@@ -10,10 +12,10 @@ public record KakaoUserInfo(
         KakaoAccount kakaoAccount
 ) {
 
-    public record Properties(String nickname) {
+    public record Properties(@SensitiveData(MaskingPolicy.NAME) String nickname) {
     }
 
-    public record KakaoAccount(String email) {
+    public record KakaoAccount(@SensitiveData(MaskingPolicy.EMAIL) String email) {
     }
 
     public String nickname() {

--- a/src/main/java/org/websoso/WSSServer/auth/controller/dto/AppleIdUpdateRequest.java
+++ b/src/main/java/org/websoso/WSSServer/auth/controller/dto/AppleIdUpdateRequest.java
@@ -1,12 +1,16 @@
 package org.websoso.WSSServer.auth.controller.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record AppleIdUpdateRequest(
         @NotBlank(message = "애플 인증 코드 값은 null 이거나, 공백일 수 없습니다.")
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String authorizationCode,
 
         @NotBlank(message = "애플 ID 토큰 값은 null 이거나, 공백일 수 없습니다.")
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String idToken
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/auth/controller/dto/AppleLoginRequest.java
+++ b/src/main/java/org/websoso/WSSServer/auth/controller/dto/AppleLoginRequest.java
@@ -1,11 +1,15 @@
 package org.websoso.WSSServer.auth.controller.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record AppleLoginRequest(
         @NotBlank(message = "애플 인증 코드 값은 null 이거나, 공백일 수 없습니다.")
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String authorizationCode,
         @NotBlank(message = "애플 ID 토큰 값은 null 이거나, 공백일 수 없습니다.")
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String idToken
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/auth/controller/dto/AuthResponse.java
+++ b/src/main/java/org/websoso/WSSServer/auth/controller/dto/AuthResponse.java
@@ -1,7 +1,11 @@
 package org.websoso.WSSServer.auth.controller.dto;
 
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 public record AuthResponse(
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String Authorization,
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String refreshToken,
         boolean isRegister
 ) {

--- a/src/main/java/org/websoso/WSSServer/auth/controller/dto/LogoutRequest.java
+++ b/src/main/java/org/websoso/WSSServer/auth/controller/dto/LogoutRequest.java
@@ -1,7 +1,11 @@
 package org.websoso.WSSServer.auth.controller.dto;
 
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 public record LogoutRequest(
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String refreshToken,
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String deviceIdentifier
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/auth/controller/dto/ReissueRequest.java
+++ b/src/main/java/org/websoso/WSSServer/auth/controller/dto/ReissueRequest.java
@@ -1,6 +1,9 @@
 package org.websoso.WSSServer.auth.controller.dto;
 
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 public record ReissueRequest(
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String refreshToken
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/auth/controller/dto/ReissueResponse.java
+++ b/src/main/java/org/websoso/WSSServer/auth/controller/dto/ReissueResponse.java
@@ -1,7 +1,11 @@
 package org.websoso.WSSServer.auth.controller.dto;
 
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 public record ReissueResponse(
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String Authorization,
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String refreshToken
 ) {
 

--- a/src/main/java/org/websoso/WSSServer/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/websoso/WSSServer/auth/jwt/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -19,7 +20,9 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.websoso.WSSServer.exception.error.CustomAuthError;
 import org.websoso.common.exception.ErrorResult;
+import org.websoso.support.logging.request.RequestLoggingFilter;
 
+/** JWT 인증을 처리하고 인증된 사용자 식별자를 요청 로그 컨텍스트에 전달한다. */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -29,6 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JWTUtil jwtUtil;
     private final ObjectMapper objectMapper;
 
+    /** Access Token을 검증하고 인증 성공 시 실제 사용자 ID를 MDC에 저장한다. */
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
                                     @NonNull HttpServletResponse response,
@@ -40,6 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             switch (validationResult) {
                 case VALID_ACCESS -> {
                     Long userId = jwtUtil.getUserIdFromJwt(token);
+                    MDC.put(RequestLoggingFilter.USER_ID, userId.toString());
                     CustomAuthenticationToken customAuthenticationToken =
                             new CustomAuthenticationToken(userId, null, null);
                     customAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));

--- a/src/main/java/org/websoso/WSSServer/auth/service/dto/AppleAuthResult.java
+++ b/src/main/java/org/websoso/WSSServer/auth/service/dto/AppleAuthResult.java
@@ -1,11 +1,16 @@
 package org.websoso.WSSServer.auth.service.dto;
 
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 /**
  * Apple 인증(ID Token 검증 + Authorization Code 교환) 결과를 Application 계층에 전달하는 내부 DTO이다.
  */
 public record AppleAuthResult(
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String userIdentifier,
+        @SensitiveData(MaskingPolicy.EMAIL)
         String email,
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String appleRefreshToken
 ) {
 

--- a/src/main/java/org/websoso/WSSServer/collection/controller/dto/CollectionOwnerGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/collection/controller/dto/CollectionOwnerGetResponse.java
@@ -1,5 +1,7 @@
 package org.websoso.WSSServer.collection.controller.dto;
 
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 /**
  * 컬렉션 상세의 소유자 정보. 공유 링크로 들어온 조회자에게 누가 만든 컬렉션인지 보여 주기 위해 함께 준다.
  * <p>
@@ -8,6 +10,7 @@ package org.websoso.WSSServer.collection.controller.dto;
  */
 public record CollectionOwnerGetResponse(
         Long userId,
+        @SensitiveData(MaskingPolicy.NAME)
         String nickname,
         String avatarImage
 ) {

--- a/src/main/java/org/websoso/WSSServer/dto/block/BlockGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/block/BlockGetResponse.java
@@ -1,8 +1,11 @@
 package org.websoso.WSSServer.dto.block;
 
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 public record BlockGetResponse(
         Long blockId,
         Long userId,
+        @SensitiveData(MaskingPolicy.NAME)
         String nickname,
         String avatarImage
 ) {

--- a/src/main/java/org/websoso/WSSServer/dto/popularNovel/PopularNovelGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/popularNovel/PopularNovelGetResponse.java
@@ -4,12 +4,15 @@ import org.websoso.WSSServer.user.domain.AvatarProfile;
 import org.websoso.WSSServer.feed.feed.domain.Feed;
 import org.websoso.WSSServer.novel.domain.Novel;
 import java.util.List;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record PopularNovelGetResponse(
         Long novelId,
         String title,
         String novelImage,
         String avatarImage,
+        @SensitiveData(MaskingPolicy.NAME)
         String nickname,
         String feedContent,
         List<String> keywords,

--- a/src/main/java/org/websoso/WSSServer/dto/user/EditMyInfoRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/EditMyInfoRequest.java
@@ -3,14 +3,18 @@ package org.websoso.WSSServer.dto.user;
 import jakarta.validation.constraints.NotNull;
 import org.websoso.WSSServer.validation.BirthConstraint;
 import org.websoso.WSSServer.validation.GenderConstraint;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record EditMyInfoRequest(
         @NotNull
         @GenderConstraint
+        @SensitiveData(MaskingPolicy.FULL)
         String gender,
 
         @NotNull(message = "출생연도는 null일 수 없습니다.")
         @BirthConstraint
+        @SensitiveData(MaskingPolicy.FULL)
         Integer birth
 ) {
 }

--- a/src/main/java/org/websoso/WSSServer/dto/user/LoginResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/LoginResponse.java
@@ -1,6 +1,9 @@
 package org.websoso.WSSServer.dto.user;
 
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 public record LoginResponse(
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String Authorization
 ) {
     public static LoginResponse of(String token) {

--- a/src/main/java/org/websoso/WSSServer/dto/user/MyProfileResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/MyProfileResponse.java
@@ -5,8 +5,11 @@ import java.util.stream.Collectors;
 import org.websoso.WSSServer.user.domain.AvatarProfile;
 import org.websoso.WSSServer.domain.GenrePreference;
 import org.websoso.WSSServer.user.domain.User;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record MyProfileResponse(
+        @SensitiveData(MaskingPolicy.NAME)
         String nickname,
         String intro,
         String avatarImage,

--- a/src/main/java/org/websoso/WSSServer/dto/user/ProfileGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/ProfileGetResponse.java
@@ -5,8 +5,11 @@ import java.util.stream.Collectors;
 import org.websoso.WSSServer.user.domain.AvatarProfile;
 import org.websoso.WSSServer.domain.GenrePreference;
 import org.websoso.WSSServer.user.domain.User;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record ProfileGetResponse(
+        @SensitiveData(MaskingPolicy.NAME)
         String nickname,
         String intro,
         String avatarImage,

--- a/src/main/java/org/websoso/WSSServer/dto/user/RegisterUserInfoRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/RegisterUserInfoRequest.java
@@ -5,17 +5,22 @@ import java.util.List;
 import org.websoso.WSSServer.validation.BirthConstraint;
 import org.websoso.WSSServer.validation.GenderConstraint;
 import org.websoso.WSSServer.validation.NicknameConstraint;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record RegisterUserInfoRequest(
         @NicknameConstraint
+        @SensitiveData(MaskingPolicy.NAME)
         String nickname,
 
         @NotNull
         @GenderConstraint
+        @SensitiveData(MaskingPolicy.FULL)
         String gender,
 
         @NotNull(message = "출생연도는 null일 수 없습니다.")
         @BirthConstraint
+        @SensitiveData(MaskingPolicy.FULL)
         Integer birth,
 
         @NotNull(message = "선호 장르는 null일 수 없습니다.")

--- a/src/main/java/org/websoso/WSSServer/dto/user/UpdateMyProfileRequest.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/UpdateMyProfileRequest.java
@@ -4,11 +4,14 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import org.websoso.WSSServer.validation.NullAllowedNicknameConstraint;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record UpdateMyProfileRequest(
         Long avatarId,
 
         @NullAllowedNicknameConstraint
+        @SensitiveData(MaskingPolicy.NAME)
         String nickname,
 
         @Size(max = 60, message = "소개글은 60자를 초과할 수 없습니다.")

--- a/src/main/java/org/websoso/WSSServer/dto/user/UserBasicInfo.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/UserBasicInfo.java
@@ -1,7 +1,10 @@
 package org.websoso.WSSServer.dto.user;
 
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 public record UserBasicInfo(
         Long userId,
+        @SensitiveData(MaskingPolicy.NAME)
         String nickname,
         String avatarImage
 ) {

--- a/src/main/java/org/websoso/WSSServer/dto/user/UserIdAndNicknameResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/UserIdAndNicknameResponse.java
@@ -1,10 +1,14 @@
 package org.websoso.WSSServer.dto.user;
 
 import org.websoso.WSSServer.user.domain.User;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record UserIdAndNicknameResponse(
         Long userId,
+        @SensitiveData(MaskingPolicy.NAME)
         String nickname,
+        @SensitiveData(MaskingPolicy.FULL)
         String gender
 ) {
 

--- a/src/main/java/org/websoso/WSSServer/dto/user/UserInfoGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/dto/user/UserInfoGetResponse.java
@@ -1,10 +1,15 @@
 package org.websoso.WSSServer.dto.user;
 
 import org.websoso.WSSServer.user.domain.User;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record UserInfoGetResponse(
+         @SensitiveData(MaskingPolicy.EMAIL)
          String email,
+         @SensitiveData(MaskingPolicy.FULL)
          String gender,
+         @SensitiveData(MaskingPolicy.FULL)
          Integer birth
  ) {
      public static UserInfoGetResponse of(User user) {

--- a/src/main/java/org/websoso/WSSServer/feed/comment/controller/dto/CommentGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/feed/comment/controller/dto/CommentGetResponse.java
@@ -3,9 +3,12 @@ package org.websoso.WSSServer.feed.comment.controller.dto;
 import org.websoso.WSSServer.feed.comment.domain.Comment;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.util.TimeFormatUtil;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record CommentGetResponse(
         Long userId,
+        @SensitiveData(MaskingPolicy.NAME)
         String nickname,
         String avatarImage,
         Long commentId,

--- a/src/main/java/org/websoso/WSSServer/feed/feed/controller/dto/FeedGetResponse.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/controller/dto/FeedGetResponse.java
@@ -7,9 +7,12 @@ import org.websoso.WSSServer.novel.domain.Novel;
 import org.websoso.WSSServer.library.domain.UserNovel;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.util.TimeFormatUtil;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record FeedGetResponse(
         Long userId,
+        @SensitiveData(MaskingPolicy.NAME)
         String nickname,
         String avatarImage,
         Long feedId,

--- a/src/main/java/org/websoso/WSSServer/feed/feed/controller/dto/FeedInfo.java
+++ b/src/main/java/org/websoso/WSSServer/feed/feed/controller/dto/FeedInfo.java
@@ -7,10 +7,13 @@ import org.websoso.WSSServer.user.domain.User;
 import org.websoso.WSSServer.library.domain.UserNovel;
 import org.websoso.WSSServer.dto.user.UserBasicInfo;
 import org.websoso.WSSServer.util.TimeFormatUtil;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record FeedInfo(
         Long feedId,
         Long userId,
+        @SensitiveData(MaskingPolicy.NAME)
         String nickname,
         String avatarImage,
         String createdDate,

--- a/src/main/java/org/websoso/WSSServer/notification/dto/FCMTokenRequest.java
+++ b/src/main/java/org/websoso/WSSServer/notification/dto/FCMTokenRequest.java
@@ -1,12 +1,16 @@
 package org.websoso.WSSServer.notification.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import org.websoso.support.logging.masking.MaskingPolicy;
+import org.websoso.support.logging.masking.SensitiveData;
 
 public record FCMTokenRequest(
         @NotBlank(message = "FCM Token 값은 null 이거나, 공백일 수 없습니다.")
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String fcmToken,
 
         @NotBlank(message = "디바이스 식별자 값 null 이거나, 공백일 수 없습니다.")
+        @SensitiveData(MaskingPolicy.CREDENTIAL)
         String deviceIdentifier
 ) {
 }

--- a/src/test/java/org/websoso/WSSServer/auth/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/org/websoso/WSSServer/auth/jwt/JwtAuthenticationFilterTest.java
@@ -12,12 +12,15 @@ import jakarta.servlet.FilterChain;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.websoso.support.logging.request.RequestLoggingFilter;
 
+/** JWT 인증 결과와 요청 로그용 사용자 식별자 전달을 검증한다. */
 class JwtAuthenticationFilterTest {
 
     private static final String TOKEN = "dummy-token";
@@ -26,21 +29,26 @@ class JwtAuthenticationFilterTest {
     private final FilterChain filterChain = mock(FilterChain.class);
     private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil, new ObjectMapper());
 
+    /** 테스트 간 인증 컨텍스트가 공유되지 않도록 정리한다. */
     @AfterEach
     void clearContext() {
         SecurityContextHolder.clearContext();
+        MDC.clear();
     }
 
+    /** 유효한 Access Token이 인증 정보와 문자열 사용자 ID를 요청에 설정하는지 검증한다. */
     @DisplayName("유효한 Access Token이면 인증 정보를 설정하고 필터 체인을 계속 진행한다")
     @Test
     void validAccessToken_authenticatesAndContinues() throws Exception {
         given(jwtUtil.validateJWT(TOKEN)).willReturn(JwtValidationType.VALID_ACCESS);
         given(jwtUtil.getUserIdFromJwt(TOKEN)).willReturn(42L);
 
-        MockHttpServletResponse response = doFilter(bearerRequest(TOKEN));
+        MockHttpServletRequest request = bearerRequest(TOKEN);
+        MockHttpServletResponse response = doFilter(request);
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         assertThat(authentication.getPrincipal()).isEqualTo(42L);
+        assertThat(MDC.get(RequestLoggingFilter.USER_ID)).isEqualTo("42");
         verify(filterChain).doFilter(any(), any());
         assertThat(response.getStatus()).isEqualTo(200);
     }
@@ -120,12 +128,14 @@ class JwtAuthenticationFilterTest {
         assertThat(authentication).isInstanceOf(AnonymousAuthenticationToken.class);
     }
 
+    /** Bearer 토큰이 포함된 테스트 요청을 생성한다. */
     private MockHttpServletRequest bearerRequest(String token) {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Authorization", "Bearer " + token);
         return request;
     }
 
+    /** 테스트 요청을 JWT 필터에 전달하고 응답을 반환한다. */
     private MockHttpServletResponse doFilter(MockHttpServletRequest request) throws Exception {
         MockHttpServletResponse response = new MockHttpServletResponse();
         filter.doFilter(request, response, filterChain);

--- a/src/test/java/org/websoso/WSSServer/logging/SensitiveDtoMaskingTest.java
+++ b/src/test/java/org/websoso/WSSServer/logging/SensitiveDtoMaskingTest.java
@@ -1,0 +1,66 @@
+package org.websoso.WSSServer.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.websoso.WSSServer.auth.controller.dto.AppleLoginRequest;
+import org.websoso.WSSServer.auth.controller.dto.AuthResponse;
+import org.websoso.WSSServer.auth.controller.dto.LogoutRequest;
+import org.websoso.WSSServer.dto.user.UserInfoGetResponse;
+import org.websoso.WSSServer.notification.dto.FCMTokenRequest;
+import org.websoso.support.logging.masking.SensitiveDataMasker;
+
+/** 실제 DTO에 부착된 마스킹 어노테이션이 로그 직렬화에 적용되는지 검증한다. */
+class SensitiveDtoMaskingTest {
+
+    private final SensitiveDataMasker masker = new SensitiveDataMasker();
+
+    @Test
+    @DisplayName("애플 로그인 요청의 인증코드와 ID 토큰을 가린다")
+    void masksAppleLoginCredentials() {
+        JsonNode masked = masker.mask(new AppleLoginRequest("authorization-code", "id-token")).json();
+
+        assertThat(masked.get("authorizationCode").asText()).isEqualTo("***(len=18)");
+        assertThat(masked.get("idToken").asText()).isEqualTo("***(len=8)");
+    }
+
+    @Test
+    @DisplayName("로그아웃 요청의 리프레시 토큰과 기기 식별자를 가린다")
+    void masksLogoutCredentials() {
+        JsonNode masked = masker.mask(new LogoutRequest("refresh-token", "device-identifier")).json();
+
+        assertThat(masked.get("refreshToken").asText()).isEqualTo("***(len=13)");
+        assertThat(masked.get("deviceIdentifier").asText()).isEqualTo("***(len=17)");
+    }
+
+    @Test
+    @DisplayName("FCM 토큰 등록 요청의 토큰과 기기 식별자를 가린다")
+    void masksFcmTokenRequest() {
+        JsonNode masked = masker.mask(new FCMTokenRequest("fcm-token", "device-identifier")).json();
+
+        assertThat(masked.get("fcmToken").asText()).isEqualTo("***(len=9)");
+        assertThat(masked.get("deviceIdentifier").asText()).isEqualTo("***(len=17)");
+    }
+
+    @Test
+    @DisplayName("내 정보 응답의 이메일·성별·출생연도를 가린다")
+    void masksUserInfoResponse() {
+        JsonNode masked = masker.mask(new UserInfoGetResponse("reader@websoso.kr", "MALE", 1998)).json();
+
+        assertThat(masked.get("email").asText()).isEqualTo("re***@we***");
+        assertThat(masked.get("gender").asText()).isEqualTo("***");
+        assertThat(masked.get("birth").asText()).isEqualTo("***");
+    }
+
+    @Test
+    @DisplayName("인증 응답의 액세스·리프레시 토큰을 가리고 가입 여부는 남긴다")
+    void masksAuthResponseTokensOnly() {
+        JsonNode masked = masker.mask(AuthResponse.of("access-token", "refresh-token", true)).json();
+
+        assertThat(masked.get("Authorization").asText()).isEqualTo("***(len=12)");
+        assertThat(masked.get("refreshToken").asText()).isEqualTo("***(len=13)");
+        assertThat(masked.get("isRegister").asBoolean()).isTrue();
+    }
+}

--- a/wss-service-support/build.gradle
+++ b/wss-service-support/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     implementation 'p6spy:p6spy:3.9.1'
     implementation 'com.github.gavlyukovskiy:datasource-decorator-spring-boot-autoconfigure:1.9.2'
 
+    // 구조화 로깅
+    runtimeOnly 'net.logstash.logback:logstash-logback-encoder:7.4'
+
     // ============== Project Modules ==============
     implementation project(':wss-common')
 

--- a/wss-service-support/src/main/java/org/websoso/support/logging/masking/MaskedBody.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/masking/MaskedBody.java
@@ -1,0 +1,10 @@
+package org.websoso.support.logging.masking;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/** 마스킹된 본문과 크기 상한 초과로 잘렸는지 여부를 함께 전달한다. */
+public record MaskedBody(
+        JsonNode json,
+        boolean truncated
+) {
+}

--- a/wss-service-support/src/main/java/org/websoso/support/logging/masking/MaskingPolicy.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/masking/MaskingPolicy.java
@@ -47,6 +47,11 @@ public enum MaskingPolicy {
     /** 원본 값을 정책에 맞게 가린 문자열로 변환한다. */
     public abstract String mask(Object value);
 
+    /** 이미 마스킹된 값을 다시 가려 길이 정보가 어긋나지 않도록 판별한다. */
+    public static boolean isMasked(String value) {
+        return value.startsWith(MASK);
+    }
+
     /** 마스킹 시 노출을 허용하는 앞부분만 잘라낸다. */
     private static String head(String value) {
         return value.length() <= VISIBLE_LENGTH ? value : value.substring(0, VISIBLE_LENGTH);

--- a/wss-service-support/src/main/java/org/websoso/support/logging/masking/MaskingPolicy.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/masking/MaskingPolicy.java
@@ -1,0 +1,54 @@
+package org.websoso.support.logging.masking;
+
+/** 민감정보 종류별 로그 마스킹 규칙을 정의한다. */
+public enum MaskingPolicy {
+
+    /** 이메일 주소를 계정·도메인 앞 2자만 남기고 가린다. */
+    EMAIL {
+        @Override
+        public String mask(Object value) {
+            String raw = String.valueOf(value);
+            int separator = raw.indexOf('@');
+            if (separator <= 0) {
+                return MASK;
+            }
+            return head(raw.substring(0, separator)) + MASK + "@" + head(raw.substring(separator + 1)) + MASK;
+        }
+    },
+
+    /** 이름·닉네임을 첫 글자만 남기고 가린다. */
+    NAME {
+        @Override
+        public String mask(Object value) {
+            String raw = String.valueOf(value);
+            return raw.isEmpty() ? MASK : raw.substring(0, 1) + MASK;
+        }
+    },
+
+    /** 토큰·인증코드·기기 식별자는 값을 전부 가리고 길이만 남겨 장애 판별에 활용한다. */
+    CREDENTIAL {
+        @Override
+        public String mask(Object value) {
+            return MASK + "(len=" + String.valueOf(value).length() + ")";
+        }
+    },
+
+    /** 성별·출생연도처럼 값 자체가 식별 정보인 항목을 전부 가린다. */
+    FULL {
+        @Override
+        public String mask(Object value) {
+            return MASK;
+        }
+    };
+
+    private static final String MASK = "***";
+    private static final int VISIBLE_LENGTH = 2;
+
+    /** 원본 값을 정책에 맞게 가린 문자열로 변환한다. */
+    public abstract String mask(Object value);
+
+    /** 마스킹 시 노출을 허용하는 앞부분만 잘라낸다. */
+    private static String head(String value) {
+        return value.length() <= VISIBLE_LENGTH ? value : value.substring(0, VISIBLE_LENGTH);
+    }
+}

--- a/wss-service-support/src/main/java/org/websoso/support/logging/masking/MaskingSerializer.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/masking/MaskingSerializer.java
@@ -1,0 +1,22 @@
+package org.websoso.support.logging.masking;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+/** 민감정보 필드를 정책에 따라 가린 문자열로 직렬화한다. */
+public class MaskingSerializer extends JsonSerializer<Object> {
+
+    private final MaskingPolicy policy;
+
+    public MaskingSerializer(MaskingPolicy policy) {
+        this.policy = policy;
+    }
+
+    /** 원본 값 대신 마스킹된 문자열을 기록한다. */
+    @Override
+    public void serialize(Object value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeString(policy.mask(value));
+    }
+}

--- a/wss-service-support/src/main/java/org/websoso/support/logging/masking/MaskingSerializerModifier.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/masking/MaskingSerializerModifier.java
@@ -1,0 +1,33 @@
+package org.websoso.support.logging.masking;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import java.util.List;
+
+/** 민감정보로 표시된 프로퍼티의 직렬화기를 마스킹 직렬화기로 교체한다. */
+public class MaskingSerializerModifier extends BeanSerializerModifier {
+
+    /** 로그 전용 ObjectMapper에서만 호출되므로 실제 API 응답 직렬화에는 영향이 없다. */
+    @Override
+    public List<BeanPropertyWriter> changeProperties(SerializationConfig config, BeanDescription beanDescription,
+                                                     List<BeanPropertyWriter> beanProperties) {
+        for (BeanPropertyWriter writer : beanProperties) {
+            MaskingPolicy policy = resolvePolicy(writer);
+            if (policy != null) {
+                writer.assignSerializer(new MaskingSerializer(policy));
+            }
+        }
+        return beanProperties;
+    }
+
+    /** 어노테이션을 우선 적용하고, 없으면 필드 이름 안전망으로 판단한다. */
+    private MaskingPolicy resolvePolicy(BeanPropertyWriter writer) {
+        SensitiveData annotation = writer.getAnnotation(SensitiveData.class);
+        if (annotation != null) {
+            return annotation.value();
+        }
+        return SensitiveFieldNames.policyOf(writer.getName());
+    }
+}

--- a/wss-service-support/src/main/java/org/websoso/support/logging/masking/SensitiveData.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/masking/SensitiveData.java
@@ -1,0 +1,23 @@
+package org.websoso.support.logging.masking;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 로그에 남길 때 마스킹할 민감정보 필드를 표시한다.
+ * <p>
+ * 개인정보처리방침상 수집 항목과 인증 크리덴셜에 부착한다. 이 어노테이션은 로그 전용 직렬화에만
+ * 적용되므로 실제 API 응답 본문은 변경되지 않는다. record 컴포넌트에 붙이면 필드·접근자·생성자
+ * 파라미터에 함께 전파되어 Jackson이 인식한다.
+ */
+@Documented
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SensitiveData {
+
+    /** 적용할 마스킹 규칙이다. */
+    MaskingPolicy value() default MaskingPolicy.FULL;
+}

--- a/wss-service-support/src/main/java/org/websoso/support/logging/masking/SensitiveDataMasker.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/masking/SensitiveDataMasker.java
@@ -1,0 +1,44 @@
+package org.websoso.support.logging.masking;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.springframework.stereotype.Component;
+
+/**
+ * 본문을 민감정보가 가려진 JSON으로 변환한다.
+ * <p>
+ * 마스킹 직렬화기는 이 클래스가 직접 만든 전용 ObjectMapper에만 등록한다. ObjectMapper 타입 빈을
+ * 노출하면 Spring Boot 기본 ObjectMapper 자동 구성을 밀어내 실제 API 응답 직렬화까지 바뀌므로,
+ * 매퍼를 감싼 컴포넌트 형태로만 제공한다.
+ */
+@Component
+public class SensitiveDataMasker {
+
+    /** 로그 한 건이 지나치게 커지지 않도록 제한하는 직렬화 결과 길이다. */
+    private static final int MAX_BODY_LENGTH = 4096;
+    private static final String TRUNCATED_SUFFIX = "...(truncated)";
+
+    private final ObjectMapper maskingMapper;
+
+    public SensitiveDataMasker() {
+        SimpleModule maskingModule = new SimpleModule();
+        maskingModule.setSerializerModifier(new MaskingSerializerModifier());
+        this.maskingMapper = JsonMapper.builder()
+                .findAndAddModules()
+                .addModule(maskingModule)
+                .build();
+    }
+
+    /** 민감정보를 가린 JSON으로 바꾸고, 상한을 넘으면 잘라낸 문자열로 대체한다. */
+    public MaskedBody mask(Object body) {
+        JsonNode masked = maskingMapper.valueToTree(body);
+        String serialized = masked.toString();
+        if (serialized.length() <= MAX_BODY_LENGTH) {
+            return new MaskedBody(masked, false);
+        }
+        return new MaskedBody(TextNode.valueOf(serialized.substring(0, MAX_BODY_LENGTH) + TRUNCATED_SUFFIX), true);
+    }
+}

--- a/wss-service-support/src/main/java/org/websoso/support/logging/masking/SensitiveDataMasker.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/masking/SensitiveDataMasker.java
@@ -8,16 +8,15 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import java.util.ArrayList;
 import java.util.List;
-import org.springframework.stereotype.Component;
 
 /**
  * 본문을 민감정보가 가려진 JSON으로 변환한다.
  * <p>
  * 마스킹 직렬화기는 이 클래스가 직접 만든 전용 ObjectMapper에만 등록한다. ObjectMapper 타입 빈을
- * 노출하면 Spring Boot 기본 ObjectMapper 자동 구성을 밀어내 실제 API 응답 직렬화까지 바뀌므로,
- * 매퍼를 감싼 컴포넌트 형태로만 제공한다.
+ * 노출하면 Spring Boot 기본 ObjectMapper 자동 구성을 밀어내 실제 API 응답 직렬화까지 바뀌기 때문이다.
+ * 상태가 없어 빈으로 등록하지 않고 로깅 어드바이스가 직접 생성한다. @WebMvcTest 같은 슬라이스
+ * 테스트는 @ControllerAdvice만 등록하고 일반 컴포넌트는 제외하므로, 빈으로 두면 컨텍스트가 깨진다.
  */
-@Component
 public class SensitiveDataMasker {
 
     /** 로그 한 건이 지나치게 커지지 않도록 제한하는 직렬화 결과 길이다. */

--- a/wss-service-support/src/main/java/org/websoso/support/logging/masking/SensitiveDataMasker.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/masking/SensitiveDataMasker.java
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 /**
@@ -35,10 +38,41 @@ public class SensitiveDataMasker {
     /** 민감정보를 가린 JSON으로 바꾸고, 상한을 넘으면 잘라낸 문자열로 대체한다. */
     public MaskedBody mask(Object body) {
         JsonNode masked = maskingMapper.valueToTree(body);
+        maskByFieldName(masked);
         String serialized = masked.toString();
         if (serialized.length() <= MAX_BODY_LENGTH) {
             return new MaskedBody(masked, false);
         }
         return new MaskedBody(TextNode.valueOf(serialized.substring(0, MAX_BODY_LENGTH) + TRUNCATED_SUFFIX), true);
+    }
+
+    /**
+     * 필드 이름 안전망을 JSON 트리 전체에 적용한다.
+     * <p>
+     * 어노테이션 기반 마스킹은 record·POJO 프로퍼티에만 걸리므로, Map 본문이나 중첩 구조는
+     * 직렬화 결과를 순회하며 한 번 더 걸러야 평문 유출을 막을 수 있다.
+     */
+    private void maskByFieldName(JsonNode node) {
+        if (node.isArray()) {
+            node.forEach(this::maskByFieldName);
+            return;
+        }
+        if (!node.isObject()) {
+            return;
+        }
+        ObjectNode objectNode = (ObjectNode) node;
+        List<String> fieldNames = new ArrayList<>();
+        objectNode.fieldNames().forEachRemaining(fieldNames::add);
+        for (String fieldName : fieldNames) {
+            JsonNode value = objectNode.get(fieldName);
+            MaskingPolicy policy = SensitiveFieldNames.policyOf(fieldName);
+            if (policy == null || !value.isValueNode() || value.isNull()) {
+                maskByFieldName(value);
+                continue;
+            }
+            if (!MaskingPolicy.isMasked(value.asText())) {
+                objectNode.put(fieldName, policy.mask(value.asText()));
+            }
+        }
     }
 }

--- a/wss-service-support/src/main/java/org/websoso/support/logging/masking/SensitiveFieldNames.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/masking/SensitiveFieldNames.java
@@ -1,0 +1,42 @@
+package org.websoso.support.logging.masking;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * 어노테이션 부착이 누락된 필드를 이름으로 걸러내는 안전망이다.
+ * <p>
+ * 신규 DTO에 {@link SensitiveData}를 빠뜨려도 평문 유출을 막는 것이 목적이므로, 오탐 없이
+ * 민감정보가 확실한 이름만 등록한다. 닉네임·이름처럼 다른 도메인 용어와 겹치는 이름은
+ * 작품명·장르명까지 가려버리므로 넣지 않고 어노테이션으로만 처리한다.
+ */
+final class SensitiveFieldNames {
+
+    private static final Map<String, MaskingPolicy> POLICIES = Map.ofEntries(
+            Map.entry("email", MaskingPolicy.EMAIL),
+            Map.entry("password", MaskingPolicy.CREDENTIAL),
+            Map.entry("authorization", MaskingPolicy.CREDENTIAL),
+            Map.entry("accesstoken", MaskingPolicy.CREDENTIAL),
+            Map.entry("access_token", MaskingPolicy.CREDENTIAL),
+            Map.entry("refreshtoken", MaskingPolicy.CREDENTIAL),
+            Map.entry("refresh_token", MaskingPolicy.CREDENTIAL),
+            Map.entry("idtoken", MaskingPolicy.CREDENTIAL),
+            Map.entry("id_token", MaskingPolicy.CREDENTIAL),
+            Map.entry("authorizationcode", MaskingPolicy.CREDENTIAL),
+            Map.entry("fcmtoken", MaskingPolicy.CREDENTIAL),
+            Map.entry("deviceidentifier", MaskingPolicy.CREDENTIAL),
+            Map.entry("useridentifier", MaskingPolicy.CREDENTIAL),
+            Map.entry("socialid", MaskingPolicy.CREDENTIAL),
+            Map.entry("phone", MaskingPolicy.FULL),
+            Map.entry("phonenumber", MaskingPolicy.FULL),
+            Map.entry("address", MaskingPolicy.FULL)
+    );
+
+    private SensitiveFieldNames() {
+    }
+
+    /** 필드 이름만으로 적용할 기본 마스킹 규칙을 찾는다. 대상이 아니면 null을 반환한다. */
+    static MaskingPolicy policyOf(String propertyName) {
+        return POLICIES.get(propertyName.toLowerCase(Locale.ROOT));
+    }
+}

--- a/wss-service-support/src/main/java/org/websoso/support/logging/request/RequestBodyLoggingAdvice.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/request/RequestBodyLoggingAdvice.java
@@ -1,8 +1,5 @@
 package org.websoso.support.logging.request;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.HttpServletRequest;
 import java.lang.reflect.Type;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,14 +8,16 @@ import org.springframework.http.HttpInputMessage;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdviceAdapter;
+import org.websoso.support.logging.masking.MaskedBody;
+import org.websoso.support.logging.masking.SensitiveDataMasker;
 
-/** 역직렬화된 요청 본문을 구조화 로그로 기록한다. */
+/** 역직렬화된 요청 본문을 민감정보만 가린 구조화 로그로 기록한다. */
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class RequestBodyLoggingAdvice extends RequestBodyAdviceAdapter {
 
-    private final ObjectMapper objectMapper;
+    private final SensitiveDataMasker sensitiveDataMasker;
 
     /** 모든 컨트롤러 요청 본문을 로깅 대상으로 지정한다. */
     @Override
@@ -27,16 +26,17 @@ public class RequestBodyLoggingAdvice extends RequestBodyAdviceAdapter {
         return true;
     }
 
-    /** 기존 요청 본문을 JSON 객체 필드로 변환해 기록한다. */
+    /** 기존 요청 본문을 마스킹한 JSON 객체 필드로 변환해 기록한다. */
     @Override
     public Object afterBodyRead(Object body, HttpInputMessage inputMessage, MethodParameter parameter,
                                 Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
 
         try {
-            JsonNode bodyJson = objectMapper.valueToTree(body);
+            MaskedBody maskedBody = sensitiveDataMasker.mask(body);
             log.atInfo()
                     .addKeyValue("event", "API_REQUEST_BODY")
-                    .addKeyValue("body", bodyJson)
+                    .addKeyValue("body", maskedBody.json())
+                    .addKeyValue("truncated", maskedBody.truncated())
                     .log("API_REQUEST_BODY");
         } catch (Exception e) {
             log.atWarn()

--- a/wss-service-support/src/main/java/org/websoso/support/logging/request/RequestBodyLoggingAdvice.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/request/RequestBodyLoggingAdvice.java
@@ -1,5 +1,6 @@
 package org.websoso.support.logging.request;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import java.lang.reflect.Type;
@@ -11,6 +12,7 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdviceAdapter;
 
+/** 역직렬화된 요청 본문을 구조화 로그로 기록한다. */
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
@@ -18,21 +20,29 @@ public class RequestBodyLoggingAdvice extends RequestBodyAdviceAdapter {
 
     private final ObjectMapper objectMapper;
 
+    /** 모든 컨트롤러 요청 본문을 로깅 대상으로 지정한다. */
     @Override
     public boolean supports(MethodParameter methodParameter, Type targetType,
                             Class<? extends HttpMessageConverter<?>> converterType) {
         return true;
     }
 
+    /** 기존 요청 본문을 JSON 객체 필드로 변환해 기록한다. */
     @Override
     public Object afterBodyRead(Object body, HttpInputMessage inputMessage, MethodParameter parameter,
                                 Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
 
         try {
-            String bodyJson = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(body);
-            log.info("[REQ BODY] {}", bodyJson);
+            JsonNode bodyJson = objectMapper.valueToTree(body);
+            log.atInfo()
+                    .addKeyValue("event", "API_REQUEST_BODY")
+                    .addKeyValue("body", bodyJson)
+                    .log("API_REQUEST_BODY");
         } catch (Exception e) {
-            log.warn("Failed to log request body: {}", e.getMessage());
+            log.atWarn()
+                    .addKeyValue("event", "API_REQUEST_BODY_SERIALIZATION_FAILED")
+                    .addKeyValue("error", e.getMessage())
+                    .log("API_REQUEST_BODY_SERIALIZATION_FAILED");
         }
 
         return super.afterBodyRead(body, inputMessage, parameter, targetType, converterType);

--- a/wss-service-support/src/main/java/org/websoso/support/logging/request/RequestBodyLoggingAdvice.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/request/RequestBodyLoggingAdvice.java
@@ -1,7 +1,6 @@
 package org.websoso.support.logging.request;
 
 import java.lang.reflect.Type;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpInputMessage;
@@ -14,10 +13,9 @@ import org.websoso.support.logging.masking.SensitiveDataMasker;
 /** 역직렬화된 요청 본문을 민감정보만 가린 구조화 로그로 기록한다. */
 @Slf4j
 @RestControllerAdvice
-@RequiredArgsConstructor
 public class RequestBodyLoggingAdvice extends RequestBodyAdviceAdapter {
 
-    private final SensitiveDataMasker sensitiveDataMasker;
+    private final SensitiveDataMasker sensitiveDataMasker = new SensitiveDataMasker();
 
     /** 모든 컨트롤러 요청 본문을 로깅 대상으로 지정한다. */
     @Override

--- a/wss-service-support/src/main/java/org/websoso/support/logging/request/RequestLoggingFilter.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/request/RequestLoggingFilter.java
@@ -13,13 +13,17 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+/** 요청과 응답 정보를 동일한 traceId의 구조화 로그로 기록한다. */
 @Slf4j
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class RequestLoggingFilter extends OncePerRequestFilter {
 
+    /** JWT 인증 필터가 MDC에 저장하는 사용자 ID 키다. */
+    public static final String USER_ID = "userId";
     private static final String TRACE_ID = "traceId";
 
+    /** 요청 정보와 처리 결과를 CloudWatch에서 검색 가능한 JSON 필드로 기록한다. */
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
@@ -28,15 +32,24 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
         MDC.put(TRACE_ID, traceId);
 
         long startTime = System.currentTimeMillis();
-        log.info("[API REQ] {} {} | Parameters: {}",
-                request.getMethod(), request.getRequestURI(), request.getQueryString());
+        log.atInfo()
+                .addKeyValue("event", "API_REQUEST")
+                .addKeyValue("method", request.getMethod())
+                .addKeyValue("uri", request.getRequestURI())
+                .addKeyValue("query", request.getQueryString())
+                .log("API_REQUEST");
 
         try {
             filterChain.doFilter(request, response);
         } finally {
             long endTime = System.currentTimeMillis();
-            log.info("[API RES] {} {} | Status: {} | Total Time: {}ms",
-                    request.getMethod(), request.getRequestURI(), response.getStatus(), (endTime - startTime));
+            log.atInfo()
+                    .addKeyValue("event", "API_RESPONSE")
+                    .addKeyValue("method", request.getMethod())
+                    .addKeyValue("uri", request.getRequestURI())
+                    .addKeyValue("status", response.getStatus())
+                    .addKeyValue("durationMs", endTime - startTime)
+                    .log("API_RESPONSE");
 
             MDC.clear();
         }

--- a/wss-service-support/src/main/java/org/websoso/support/logging/response/ResponseBodyLoggingAdvice.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/response/ResponseBodyLoggingAdvice.java
@@ -1,7 +1,6 @@
 package org.websoso.support.logging.response;
 
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
@@ -14,13 +13,12 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 /** 응답 본문의 구조만 요약해 구조화 로그로 기록한다. */
 @Slf4j
 @RestControllerAdvice
-@RequiredArgsConstructor
 public class ResponseBodyLoggingAdvice implements ResponseBodyAdvice<Object> {
 
     /** 서비스 트래픽이 아니어서 기록 가치가 없는 경로다. */
     private static final List<String> EXCLUDED_PATH_PREFIXES = List.of("/actuator", "/swagger-ui", "/v3/api-docs");
 
-    private final ResponseBodySummarizer responseBodySummarizer;
+    private final ResponseBodySummarizer responseBodySummarizer = new ResponseBodySummarizer();
 
     /** 모든 컨트롤러 응답 본문을 로깅 대상으로 지정한다. */
     @Override

--- a/wss-service-support/src/main/java/org/websoso/support/logging/response/ResponseBodyLoggingAdvice.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/response/ResponseBodyLoggingAdvice.java
@@ -1,0 +1,61 @@
+package org.websoso.support.logging.response;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/** 응답 본문의 구조만 요약해 구조화 로그로 기록한다. */
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class ResponseBodyLoggingAdvice implements ResponseBodyAdvice<Object> {
+
+    /** 서비스 트래픽이 아니어서 기록 가치가 없는 경로다. */
+    private static final List<String> EXCLUDED_PATH_PREFIXES = List.of("/actuator", "/swagger-ui", "/v3/api-docs");
+
+    private final ResponseBodySummarizer responseBodySummarizer;
+
+    /** 모든 컨트롤러 응답 본문을 로깅 대상으로 지정한다. */
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    /** 응답 본문을 그대로 통과시키고 구조 요약만 기록한다. */
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request, ServerHttpResponse response) {
+
+        if (isExcluded(request)) {
+            return body;
+        }
+
+        try {
+            log.atInfo()
+                    .addKeyValue("event", "API_RESPONSE_BODY")
+                    .addKeyValue("body", responseBodySummarizer.summarize(body))
+                    .log("API_RESPONSE_BODY");
+        } catch (Exception e) {
+            log.atWarn()
+                    .addKeyValue("event", "API_RESPONSE_BODY_SUMMARY_FAILED")
+                    .addKeyValue("error", e.getMessage())
+                    .log("API_RESPONSE_BODY_SUMMARY_FAILED");
+        }
+
+        return body;
+    }
+
+    /** 로깅 대상에서 제외할 경로인지 판단한다. */
+    private boolean isExcluded(ServerHttpRequest request) {
+        String path = request.getURI().getPath();
+        return EXCLUDED_PATH_PREFIXES.stream().anyMatch(path::startsWith);
+    }
+}

--- a/wss-service-support/src/main/java/org/websoso/support/logging/response/ResponseBodySummarizer.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/response/ResponseBodySummarizer.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.springframework.stereotype.Component;
 
 /**
  * 응답 본문을 값 없이 구조만 담은 요약으로 변환한다.
@@ -13,7 +12,6 @@ import org.springframework.stereotype.Component;
  * 값을 직렬화하지 않으므로 개인정보가 로그로 흘러갈 수 없고, 목록 응답도 원소를 순회하지 않아
  * 크기와 무관하게 비용이 일정하다.
  */
-@Component
 public class ResponseBodySummarizer {
 
     private static final Map<Class<?>, RecordComponent[]> RECORD_COMPONENTS = new ConcurrentHashMap<>();

--- a/wss-service-support/src/main/java/org/websoso/support/logging/response/ResponseBodySummarizer.java
+++ b/wss-service-support/src/main/java/org/websoso/support/logging/response/ResponseBodySummarizer.java
@@ -1,0 +1,89 @@
+package org.websoso.support.logging.response;
+
+import java.lang.reflect.RecordComponent;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+/**
+ * 응답 본문을 값 없이 구조만 담은 요약으로 변환한다.
+ * <p>
+ * 값을 직렬화하지 않으므로 개인정보가 로그로 흘러갈 수 없고, 목록 응답도 원소를 순회하지 않아
+ * 크기와 무관하게 비용이 일정하다.
+ */
+@Component
+public class ResponseBodySummarizer {
+
+    private static final Map<Class<?>, RecordComponent[]> RECORD_COMPONENTS = new ConcurrentHashMap<>();
+    private static final String UNREADABLE = "unreadable";
+
+    /** 응답 본문의 타입과 필드 구성을 요약한다. */
+    public Map<String, Object> summarize(Object body) {
+        if (body == null) {
+            return Map.of("type", "null");
+        }
+        if (body instanceof Collection<?> collection) {
+            return summarizeCollection(collection);
+        }
+        if (body instanceof Map<?, ?> map) {
+            return Map.of("type", "Map", "size", map.size());
+        }
+        Class<?> type = body.getClass();
+        if (type.isRecord()) {
+            return summarizeRecord(body, type);
+        }
+        if (body instanceof CharSequence text) {
+            return Map.of("type", "String", "length", text.length());
+        }
+        return Map.of("type", type.getSimpleName());
+    }
+
+    /** 목록은 원소를 순회하지 않고 크기와 원소 타입만 남긴다. */
+    private Map<String, Object> summarizeCollection(Collection<?> collection) {
+        Map<String, Object> summary = new LinkedHashMap<>();
+        summary.put("type", "List");
+        summary.put("size", collection.size());
+        collection.stream()
+                .filter(java.util.Objects::nonNull)
+                .findFirst()
+                .ifPresent(element -> summary.put("elementType", element.getClass().getSimpleName()));
+        return summary;
+    }
+
+    /** record는 필드명과 값의 형태만 남기고 값 자체는 기록하지 않는다. */
+    private Map<String, Object> summarizeRecord(Object body, Class<?> type) {
+        Map<String, Object> fields = new LinkedHashMap<>();
+        for (RecordComponent component : RECORD_COMPONENTS.computeIfAbsent(type, Class::getRecordComponents)) {
+            fields.put(component.getName(), describe(body, component));
+        }
+        Map<String, Object> summary = new LinkedHashMap<>();
+        summary.put("type", type.getSimpleName());
+        summary.put("fields", fields);
+        return summary;
+    }
+
+    /** 값 자체는 남기지 않고 타입과 길이만 표현한다. */
+    private String describe(Object body, RecordComponent component) {
+        Object value;
+        try {
+            value = component.getAccessor().invoke(body);
+        } catch (Exception e) {
+            return UNREADABLE;
+        }
+        if (value == null) {
+            return component.getType().getSimpleName() + "(null)";
+        }
+        if (value instanceof CharSequence text) {
+            return "String(len=" + text.length() + ")";
+        }
+        if (value instanceof Collection<?> collection) {
+            return "List(size=" + collection.size() + ")";
+        }
+        if (value instanceof Map<?, ?> map) {
+            return "Map(size=" + map.size() + ")";
+        }
+        return value.getClass().getSimpleName();
+    }
+}

--- a/wss-service-support/src/main/resources/logback-spring.xml
+++ b/wss-service-support/src/main/resources/logback-spring.xml
@@ -3,14 +3,12 @@
 
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <property name="LOG_PATTERN_CONSOLE"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%-5level) %clr([%X{traceId:-EMPTY}]){magenta} %clr(%logger{36}){cyan} - %msg%n"/>
-    <property name="LOG_PATTERN_FILE"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%X{traceId:-EMPTY}] %logger{36} - %msg%n"/>
-
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>${LOG_PATTERN_CONSOLE}</pattern>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>userId</includeMdcKeyName>
+            <shortenedLoggerNameLength>36</shortenedLoggerNameLength>
+            <lineSeparator>UNIX</lineSeparator>
         </encoder>
     </appender>
 
@@ -20,8 +18,11 @@
             <fileNamePattern>logs/app-%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>14</maxHistory>
         </rollingPolicy>
-        <encoder>
-            <pattern>${LOG_PATTERN_FILE}</pattern>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>userId</includeMdcKeyName>
+            <shortenedLoggerNameLength>36</shortenedLoggerNameLength>
+            <lineSeparator>UNIX</lineSeparator>
         </encoder>
         <immediateFlush>true</immediateFlush>
     </appender>

--- a/wss-service-support/src/main/resources/logback-spring.xml
+++ b/wss-service-support/src/main/resources/logback-spring.xml
@@ -3,6 +3,7 @@
 
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
+    <!-- 컨테이너 stdout은 Docker awslogs 드라이버가 수집하므로 파일 출력은 두지 않는다 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdcKeyName>traceId</includeMdcKeyName>
@@ -12,24 +13,20 @@
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/app.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>logs/app-%d{yyyy-MM-dd}.log</fileNamePattern>
-            <maxHistory>14</maxHistory>
-        </rollingPolicy>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <includeMdcKeyName>traceId</includeMdcKeyName>
-            <includeMdcKeyName>userId</includeMdcKeyName>
-            <shortenedLoggerNameLength>36</shortenedLoggerNameLength>
-            <lineSeparator>UNIX</lineSeparator>
-        </encoder>
-        <immediateFlush>true</immediateFlush>
+    <!--
+        로그 전송이 정체돼도 요청 스레드가 멈추지 않도록 비동기로 내보낸다.
+        큐가 가득 차면 로그를 버리되(neverBlock), INFO 로그까지 임의로 버리지 않도록
+        discardingThreshold는 0으로 둔다.
+    -->
+    <appender name="ASYNC_CONSOLE" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>8192</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="CONSOLE"/>
     </appender>
 
     <root level="INFO">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE"/>
+        <appender-ref ref="ASYNC_CONSOLE"/>
     </root>
 
 </configuration>

--- a/wss-service-support/src/test/java/org/websoso/support/logging/LogbackConfigurationTest.java
+++ b/wss-service-support/src/test/java/org/websoso/support/logging/LogbackConfigurationTest.java
@@ -1,0 +1,57 @@
+package org.websoso.support.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.AsyncAppender;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.FileAppender;
+import ch.qos.logback.core.spi.AppenderAttachable;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** 로그 출력 경로가 비동기 콘솔 단일 구성으로 유지되는지 검증한다. */
+class LogbackConfigurationTest {
+
+    /** 배포 설정 파일을 그대로 읽어 root 로거 구성을 만든다. */
+    private Logger configuredRootLogger() throws Exception {
+        LoggerContext context = new LoggerContext();
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(context);
+        configurator.doConfigure(getClass().getResourceAsStream("/logback-spring.xml"));
+        return context.getLogger(Logger.ROOT_LOGGER_NAME);
+    }
+
+    @Test
+    @DisplayName("root 로거는 비동기 appender로만 로그를 내보낸다")
+    void writesThroughAsyncAppenderOnly() throws Exception {
+        List<ch.qos.logback.core.Appender<?>> appenders = new ArrayList<>();
+        configuredRootLogger().iteratorForAppenders().forEachRemaining(appenders::add);
+
+        assertThat(appenders).hasSize(1);
+        assertThat(appenders.get(0)).isInstanceOf(AsyncAppender.class);
+    }
+
+    @Test
+    @DisplayName("요청 스레드가 막히지 않도록 큐 포화 시 로그를 버린다")
+    void neverBlocksRequestThread() throws Exception {
+        AsyncAppender async = (AsyncAppender) configuredRootLogger().getAppender("ASYNC_CONSOLE");
+
+        assertThat(async.isNeverBlock()).isTrue();
+        assertThat(async.getQueueSize()).isEqualTo(8192);
+        assertThat(async.getDiscardingThreshold()).isZero();
+    }
+
+    @Test
+    @DisplayName("컨테이너 stdout으로만 수집하므로 파일 appender를 두지 않는다")
+    void hasNoFileAppender() throws Exception {
+        AppenderAttachable<?> async = (AppenderAttachable<?>) configuredRootLogger().getAppender("ASYNC_CONSOLE");
+        List<ch.qos.logback.core.Appender<?>> nested = new ArrayList<>();
+        async.iteratorForAppenders().forEachRemaining(nested::add);
+
+        assertThat(nested).noneMatch(FileAppender.class::isInstance);
+    }
+}

--- a/wss-service-support/src/test/java/org/websoso/support/logging/masking/SensitiveDataMaskerTest.java
+++ b/wss-service-support/src/test/java/org/websoso/support/logging/masking/SensitiveDataMaskerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -76,6 +77,33 @@ class SensitiveDataMaskerTest {
         assertThat(apiResponse.get("email").asText()).isEqualTo("reader@websoso.kr");
         assertThat(apiResponse.get("nickname").asText()).isEqualTo("웹소소독자");
         assertThat(apiResponse.get("birth").asInt()).isEqualTo(1998);
+    }
+
+    @Test
+    @DisplayName("Map 본문과 중첩 구조에도 필드명 안전망을 적용한다")
+    void masksSensitiveFieldNamesInMapAndNestedNodes() {
+        Map<String, Object> body = Map.of(
+                "email", "reader@websoso.kr",
+                "device", Map.of("fcmToken", "fcm-token-value", "model", "iPhone 15"),
+                "novelTitle", "전지적 독자 시점"
+        );
+
+        JsonNode masked = masker.mask(body).json();
+
+        assertThat(masked.get("email").asText()).isEqualTo("re***@we***");
+        assertThat(masked.get("device").get("fcmToken").asText()).isEqualTo("***(len=15)");
+        assertThat(masked.get("device").get("model").asText()).isEqualTo("iPhone 15");
+        assertThat(masked.get("novelTitle").asText()).isEqualTo("전지적 독자 시점");
+    }
+
+    @Test
+    @DisplayName("어노테이션으로 가린 값을 안전망이 다시 가리지 않는다")
+    void doesNotMaskAlreadyMaskedValueTwice() {
+        LoginRequest body = new LoginRequest("0123456789", "reader@websoso.kr", "웹소소독자", 1998, "전지적 독자 시점");
+
+        JsonNode masked = masker.mask(body).json();
+
+        assertThat(masked.get("refreshToken").asText()).isEqualTo("***(len=10)");
     }
 
     @Test

--- a/wss-service-support/src/test/java/org/websoso/support/logging/masking/SensitiveDataMaskerTest.java
+++ b/wss-service-support/src/test/java/org/websoso/support/logging/masking/SensitiveDataMaskerTest.java
@@ -1,0 +1,100 @@
+package org.websoso.support.logging.masking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** 민감정보 마스킹 결과와 실제 응답 직렬화 비침해를 검증한다. */
+class SensitiveDataMaskerTest {
+
+    private final SensitiveDataMasker masker = new SensitiveDataMasker();
+
+    private record LoginRequest(
+            @SensitiveData(MaskingPolicy.CREDENTIAL) String refreshToken,
+            @SensitiveData(MaskingPolicy.EMAIL) String email,
+            @SensitiveData(MaskingPolicy.NAME) String nickname,
+            @SensitiveData(MaskingPolicy.FULL) Integer birth,
+            String novelTitle
+    ) {
+    }
+
+    private record UnannotatedRequest(
+            String refreshToken,
+            String email,
+            String novelTitle
+    ) {
+    }
+
+    @Test
+    @DisplayName("어노테이션이 붙은 필드를 정책에 맞게 가린다")
+    void masksAnnotatedFieldsByPolicy() {
+        LoginRequest body = new LoginRequest("eyJhbGciOiJIUzI1NiJ9.signature", "reader@websoso.kr", "웹소소독자", 1998,
+                "전지적 독자 시점");
+
+        JsonNode masked = masker.mask(body).json();
+
+        assertThat(masked.get("refreshToken").asText()).isEqualTo("***(len=30)");
+        assertThat(masked.get("email").asText()).isEqualTo("re***@we***");
+        assertThat(masked.get("nickname").asText()).isEqualTo("웹***");
+        assertThat(masked.get("birth").asText()).isEqualTo("***");
+    }
+
+    @Test
+    @DisplayName("민감정보가 아닌 필드는 값을 그대로 남긴다")
+    void keepsNonSensitiveFieldValues() {
+        LoginRequest body = new LoginRequest("token", "reader@websoso.kr", "웹소소독자", 1998, "전지적 독자 시점");
+
+        JsonNode masked = masker.mask(body).json();
+
+        assertThat(masked.get("novelTitle").asText()).isEqualTo("전지적 독자 시점");
+    }
+
+    @Test
+    @DisplayName("어노테이션이 없어도 민감한 필드명은 안전망으로 가린다")
+    void masksKnownSensitiveFieldNamesWithoutAnnotation() {
+        UnannotatedRequest body = new UnannotatedRequest("eyJhbGciOiJIUzI1NiJ9", "reader@websoso.kr", "전지적 독자 시점");
+
+        JsonNode masked = masker.mask(body).json();
+
+        assertThat(masked.get("refreshToken").asText()).isEqualTo("***(len=20)");
+        assertThat(masked.get("email").asText()).isEqualTo("re***@we***");
+        assertThat(masked.get("novelTitle").asText()).isEqualTo("전지적 독자 시점");
+    }
+
+    @Test
+    @DisplayName("마스킹 설정이 실제 응답 직렬화에는 영향을 주지 않는다")
+    void doesNotAffectApiResponseSerialization() {
+        LoginRequest body = new LoginRequest("eyJhbGciOiJIUzI1NiJ9", "reader@websoso.kr", "웹소소독자", 1998, "전지적 독자 시점");
+
+        JsonNode apiResponse = new ObjectMapper().valueToTree(body);
+
+        assertThat(apiResponse.get("refreshToken").asText()).isEqualTo("eyJhbGciOiJIUzI1NiJ9");
+        assertThat(apiResponse.get("email").asText()).isEqualTo("reader@websoso.kr");
+        assertThat(apiResponse.get("nickname").asText()).isEqualTo("웹소소독자");
+        assertThat(apiResponse.get("birth").asInt()).isEqualTo(1998);
+    }
+
+    @Test
+    @DisplayName("상한을 넘는 본문은 잘라내고 truncated로 표시한다")
+    void truncatesOversizedBody() {
+        List<String> body = List.of("가".repeat(3000), "나".repeat(3000));
+
+        MaskedBody masked = masker.mask(body);
+
+        assertThat(masked.truncated()).isTrue();
+        assertThat(masked.json().asText()).endsWith("...(truncated)");
+    }
+
+    @Test
+    @DisplayName("상한 이하 본문은 JSON 구조를 유지한다")
+    void keepsJsonStructureWithinLimit() {
+        MaskedBody masked = masker.mask(new UnannotatedRequest("token", "reader@websoso.kr", "전지적 독자 시점"));
+
+        assertThat(masked.truncated()).isFalse();
+        assertThat(masked.json().isObject()).isTrue();
+    }
+}

--- a/wss-service-support/src/test/java/org/websoso/support/logging/request/RequestBodyLoggingAdviceTest.java
+++ b/wss-service-support/src/test/java/org/websoso/support/logging/request/RequestBodyLoggingAdviceTest.java
@@ -1,0 +1,75 @@
+package org.websoso.support.logging.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.mock.http.MockHttpInputMessage;
+
+/** 요청 본문이 구조화 로그의 body 필드에 유지되는지 검증한다. */
+class RequestBodyLoggingAdviceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final Logger logger = (Logger) LoggerFactory.getLogger(RequestBodyLoggingAdvice.class);
+    private ListAppender<ILoggingEvent> listAppender;
+
+    /** 각 테스트가 기록한 로그만 수집하도록 테스트용 appender를 연결한다. */
+    @BeforeEach
+    void setUp() {
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+    }
+
+    /** 테스트가 사용한 appender를 로거에서 제거한다. */
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(listAppender);
+        listAppender.stop();
+        MDC.clear();
+    }
+
+    /** 요청 본문을 누락하지 않고 JSON 객체 필드로 기록하는지 검증한다. */
+    @Test
+    void logsRequestBodyAsStructuredJsonField() {
+        RequestBodyLoggingAdvice advice = new RequestBodyLoggingAdvice(objectMapper);
+        Map<String, String> body = Map.of("content", "first\nsecond");
+        MDC.put("traceId", "trace-1234");
+        MDC.put(RequestLoggingFilter.USER_ID, "42");
+
+        Object result = advice.afterBodyRead(
+                body,
+                new MockHttpInputMessage(new byte[0]),
+                null,
+                Map.class,
+                MappingJackson2HttpMessageConverter.class
+        );
+
+        assertThat(result).isSameAs(body);
+        assertThat(listAppender.list).hasSize(1);
+        Map<String, Object> fields = keyValues(listAppender.list.get(0));
+        assertThat(fields).containsEntry("event", "API_REQUEST_BODY");
+        assertThat(fields.get("body"))
+                .isEqualTo(objectMapper.<JsonNode>valueToTree(body));
+        assertThat(listAppender.list.get(0).getMDCPropertyMap())
+                .containsEntry("traceId", "trace-1234")
+                .containsEntry("userId", "42");
+    }
+
+    /** 로그 이벤트의 구조화 키-값 목록을 검증 가능한 Map으로 변환한다. */
+    private Map<String, Object> keyValues(ILoggingEvent event) {
+        return event.getKeyValuePairs().stream()
+                .collect(Collectors.toMap(pair -> pair.key, pair -> pair.value));
+    }
+}

--- a/wss-service-support/src/test/java/org/websoso/support/logging/request/RequestBodyLoggingAdviceTest.java
+++ b/wss-service-support/src/test/java/org/websoso/support/logging/request/RequestBodyLoggingAdviceTest.java
@@ -16,13 +16,11 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.mock.http.MockHttpInputMessage;
-import org.websoso.support.logging.masking.SensitiveDataMasker;
 
 /** 요청 본문이 구조화 로그의 body 필드에 유지되는지 검증한다. */
 class RequestBodyLoggingAdviceTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final SensitiveDataMasker sensitiveDataMasker = new SensitiveDataMasker();
     private final Logger logger = (Logger) LoggerFactory.getLogger(RequestBodyLoggingAdvice.class);
     private ListAppender<ILoggingEvent> listAppender;
 
@@ -45,7 +43,7 @@ class RequestBodyLoggingAdviceTest {
     /** 요청 본문을 누락하지 않고 JSON 객체 필드로 기록하는지 검증한다. */
     @Test
     void logsRequestBodyAsStructuredJsonField() {
-        RequestBodyLoggingAdvice advice = new RequestBodyLoggingAdvice(sensitiveDataMasker);
+        RequestBodyLoggingAdvice advice = new RequestBodyLoggingAdvice();
         Map<String, String> body = Map.of("content", "first\nsecond");
         MDC.put("traceId", "trace-1234");
         MDC.put(RequestLoggingFilter.USER_ID, "42");
@@ -72,7 +70,7 @@ class RequestBodyLoggingAdviceTest {
     /** 요청 본문의 민감정보를 가린 채 기록하는지 검증한다. */
     @Test
     void masksSensitiveFieldsInRequestBody() {
-        RequestBodyLoggingAdvice advice = new RequestBodyLoggingAdvice(sensitiveDataMasker);
+        RequestBodyLoggingAdvice advice = new RequestBodyLoggingAdvice();
         Map<String, String> body = Map.of("refreshToken", "eyJhbGciOiJIUzI1NiJ9", "content", "일반 내용");
 
         advice.afterBodyRead(

--- a/wss-service-support/src/test/java/org/websoso/support/logging/request/RequestBodyLoggingAdviceTest.java
+++ b/wss-service-support/src/test/java/org/websoso/support/logging/request/RequestBodyLoggingAdviceTest.java
@@ -16,11 +16,13 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.mock.http.MockHttpInputMessage;
+import org.websoso.support.logging.masking.SensitiveDataMasker;
 
 /** 요청 본문이 구조화 로그의 body 필드에 유지되는지 검증한다. */
 class RequestBodyLoggingAdviceTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final SensitiveDataMasker sensitiveDataMasker = new SensitiveDataMasker();
     private final Logger logger = (Logger) LoggerFactory.getLogger(RequestBodyLoggingAdvice.class);
     private ListAppender<ILoggingEvent> listAppender;
 
@@ -43,7 +45,7 @@ class RequestBodyLoggingAdviceTest {
     /** 요청 본문을 누락하지 않고 JSON 객체 필드로 기록하는지 검증한다. */
     @Test
     void logsRequestBodyAsStructuredJsonField() {
-        RequestBodyLoggingAdvice advice = new RequestBodyLoggingAdvice(objectMapper);
+        RequestBodyLoggingAdvice advice = new RequestBodyLoggingAdvice(sensitiveDataMasker);
         Map<String, String> body = Map.of("content", "first\nsecond");
         MDC.put("traceId", "trace-1234");
         MDC.put(RequestLoggingFilter.USER_ID, "42");
@@ -65,6 +67,27 @@ class RequestBodyLoggingAdviceTest {
         assertThat(listAppender.list.get(0).getMDCPropertyMap())
                 .containsEntry("traceId", "trace-1234")
                 .containsEntry("userId", "42");
+    }
+
+    /** 요청 본문의 민감정보를 가린 채 기록하는지 검증한다. */
+    @Test
+    void masksSensitiveFieldsInRequestBody() {
+        RequestBodyLoggingAdvice advice = new RequestBodyLoggingAdvice(sensitiveDataMasker);
+        Map<String, String> body = Map.of("refreshToken", "eyJhbGciOiJIUzI1NiJ9", "content", "일반 내용");
+
+        advice.afterBodyRead(
+                body,
+                new MockHttpInputMessage(new byte[0]),
+                null,
+                Map.class,
+                MappingJackson2HttpMessageConverter.class
+        );
+
+        Map<String, Object> fields = keyValues(listAppender.list.get(0));
+        JsonNode logged = (JsonNode) fields.get("body");
+        assertThat(logged.get("refreshToken").asText()).isEqualTo("***(len=20)");
+        assertThat(logged.get("content").asText()).isEqualTo("일반 내용");
+        assertThat(fields).containsEntry("truncated", false);
     }
 
     /** 로그 이벤트의 구조화 키-값 목록을 검증 가능한 Map으로 변환한다. */

--- a/wss-service-support/src/test/java/org/websoso/support/logging/request/RequestLoggingFilterTest.java
+++ b/wss-service-support/src/test/java/org/websoso/support/logging/request/RequestLoggingFilterTest.java
@@ -1,0 +1,101 @@
+package org.websoso.support.logging.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/** 요청과 응답의 구조화 필드 및 traceId 연결을 검증한다. */
+class RequestLoggingFilterTest {
+
+    private final Logger logger = (Logger) LoggerFactory.getLogger(RequestLoggingFilter.class);
+    private ListAppender<ILoggingEvent> listAppender;
+
+    /** 각 테스트가 기록한 로그만 수집하도록 테스트용 appender를 연결한다. */
+    @BeforeEach
+    void setUp() {
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+    }
+
+    /** 테스트 간 appender와 MDC 상태가 공유되지 않도록 정리한다. */
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(listAppender);
+        listAppender.stop();
+        MDC.clear();
+    }
+
+    /** 인증 요청과 응답이 같은 traceId와 문자열 userId를 사용하는지 검증한다. */
+    @Test
+    void logsAuthenticatedRequestAndResponseAsStructuredFields() throws Exception {
+        RequestLoggingFilter filter = new RequestLoggingFilter();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/novels/10");
+        request.setQueryString("page=1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (servletRequest, servletResponse) -> {
+            MDC.put(RequestLoggingFilter.USER_ID, "42");
+            ((MockHttpServletResponse) servletResponse).setStatus(201);
+        });
+
+        List<ILoggingEvent> events = infoEvents();
+        assertThat(events).hasSize(2);
+        assertThat(keyValues(events.get(0)))
+                .containsEntry("event", "API_REQUEST")
+                .containsEntry("method", "GET")
+                .containsEntry("uri", "/novels/10")
+                .containsEntry("query", "page=1")
+                .doesNotContainKey("userId");
+        assertThat(keyValues(events.get(1)))
+                .containsEntry("event", "API_RESPONSE")
+                .containsEntry("method", "GET")
+                .containsEntry("uri", "/novels/10")
+                .containsEntry("status", 201)
+                .containsKey("durationMs");
+
+        String requestTraceId = events.get(0).getMDCPropertyMap().get("traceId");
+        assertThat(requestTraceId).matches("[0-9a-f]{8}");
+        assertThat(events.get(1).getMDCPropertyMap().get("traceId")).isEqualTo(requestTraceId);
+        assertThat(events.get(1).getMDCPropertyMap().get("userId")).isEqualTo("42");
+        assertThat(MDC.get("traceId")).isNull();
+    }
+
+    /** 비로그인 요청의 응답 로그에는 userId 필드가 없는지 검증한다. */
+    @Test
+    void omitsUserIdForAnonymousResponse() throws Exception {
+        RequestLoggingFilter filter = new RequestLoggingFilter();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/health");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (servletRequest, servletResponse) -> { });
+
+        assertThat(infoEvents().get(1).getMDCPropertyMap()).doesNotContainKey("userId");
+    }
+
+    /** INFO 레벨로 기록된 요청·응답 이벤트만 반환한다. */
+    private List<ILoggingEvent> infoEvents() {
+        return listAppender.list.stream()
+                .filter(event -> event.getLevel() == Level.INFO)
+                .toList();
+    }
+
+    /** 로그 이벤트의 구조화 키-값 목록을 검증 가능한 Map으로 변환한다. */
+    private Map<String, Object> keyValues(ILoggingEvent event) {
+        return event.getKeyValuePairs().stream()
+                .collect(Collectors.toMap(pair -> pair.key, pair -> pair.value));
+    }
+}

--- a/wss-service-support/src/test/java/org/websoso/support/logging/response/ResponseBodyLoggingAdviceTest.java
+++ b/wss-service-support/src/test/java/org/websoso/support/logging/response/ResponseBodyLoggingAdviceTest.java
@@ -1,0 +1,115 @@
+package org.websoso.support.logging.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/** 응답 본문이 값 없이 구조 요약으로만 기록되는지 검증한다. */
+class ResponseBodyLoggingAdviceTest {
+
+    private final ResponseBodyLoggingAdvice advice = new ResponseBodyLoggingAdvice(new ResponseBodySummarizer());
+    private final Logger logger = (Logger) LoggerFactory.getLogger(ResponseBodyLoggingAdvice.class);
+    private ListAppender<ILoggingEvent> listAppender;
+
+    private record UserInfoResponse(String email, String gender, Integer birth) {
+    }
+
+    /** 각 테스트가 기록한 로그만 수집하도록 테스트용 appender를 연결한다. */
+    @BeforeEach
+    void setUp() {
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+    }
+
+    /** 테스트가 사용한 appender를 로거에서 제거한다. */
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(listAppender);
+        listAppender.stop();
+        MDC.clear();
+    }
+
+    @Test
+    @DisplayName("응답 본문을 값 없이 타입과 길이로만 기록한다")
+    void logsResponseBodyAsTypeAndLengthOnly() {
+        UserInfoResponse body = new UserInfoResponse("reader@websoso.kr", "MALE", 1998);
+
+        Object result = advice.beforeBodyWrite(body, null, null, null, request("/users/my-info"), null);
+
+        assertThat(result).isSameAs(body);
+        Map<String, Object> summary = loggedSummary();
+        assertThat(summary).containsEntry("type", "UserInfoResponse");
+        assertThat(summary.get("fields")).isEqualTo(Map.of(
+                "email", "String(len=17)",
+                "gender", "String(len=4)",
+                "birth", "Integer"
+        ));
+        assertThat(summary.toString()).doesNotContain("reader@websoso.kr");
+    }
+
+    @Test
+    @DisplayName("목록 응답은 원소를 순회하지 않고 크기만 기록한다")
+    void logsCollectionSizeOnly() {
+        List<UserInfoResponse> body = IntStream.range(0, 20)
+                .mapToObj(i -> new UserInfoResponse("reader" + i + "@websoso.kr", "MALE", 1998))
+                .collect(Collectors.toList());
+
+        advice.beforeBodyWrite(body, null, null, null, request("/feeds"), null);
+
+        Map<String, Object> summary = loggedSummary();
+        assertThat(summary).containsEntry("type", "List").containsEntry("size", 20);
+        assertThat(summary).containsEntry("elementType", "UserInfoResponse");
+        assertThat(summary.toString()).doesNotContain("websoso.kr");
+    }
+
+    @Test
+    @DisplayName("본문이 없으면 null 타입으로 기록한다")
+    void logsNullBody() {
+        advice.beforeBodyWrite(null, null, null, null, request("/users/logout"), null);
+
+        assertThat(loggedSummary()).containsEntry("type", "null");
+    }
+
+    @Test
+    @DisplayName("액추에이터 등 서비스 트래픽이 아닌 경로는 기록하지 않는다")
+    void skipsExcludedPaths() {
+        advice.beforeBodyWrite(Map.of("status", "UP"), null, null, null, request("/actuator/health"), null);
+
+        assertThat(listAppender.list).isEmpty();
+    }
+
+    /** 기록된 요약 본문을 꺼낸다. */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> loggedSummary() {
+        assertThat(listAppender.list).hasSize(1);
+        return (Map<String, Object>) listAppender.list.get(0).getKeyValuePairs().stream()
+                .filter(pair -> pair.key.equals("body"))
+                .findFirst()
+                .orElseThrow()
+                .value;
+    }
+
+    /** 지정한 경로의 요청을 만든다. */
+    private ServerHttpRequest request(String path) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+        request.setRequestURI(URI.create(path).getPath());
+        return new ServletServerHttpRequest(request);
+    }
+}

--- a/wss-service-support/src/test/java/org/websoso/support/logging/response/ResponseBodyLoggingAdviceTest.java
+++ b/wss-service-support/src/test/java/org/websoso/support/logging/response/ResponseBodyLoggingAdviceTest.java
@@ -23,7 +23,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /** 응답 본문이 값 없이 구조 요약으로만 기록되는지 검증한다. */
 class ResponseBodyLoggingAdviceTest {
 
-    private final ResponseBodyLoggingAdvice advice = new ResponseBodyLoggingAdvice(new ResponseBodySummarizer());
+    private final ResponseBodyLoggingAdvice advice = new ResponseBodyLoggingAdvice();
     private final Logger logger = (Logger) LoggerFactory.getLogger(ResponseBodyLoggingAdvice.class);
     private ListAppender<ILoggingEvent> listAppender;
 


### PR DESCRIPTION
## Related Issue
- chore/#603 -> dev
- ref #603

<!-- #603의 deploy.sh awslogs 설정 항목이 남아 있어 자동 close 링크는 걸지 않았습니다. -->

## Key Changes

요청·응답 본문을 로그에 남기되, [개인정보처리방침](https://websoso.notion.site/143600bd746880668556fb005fcef491) 제1조 수집 항목에 해당하는 민감정보는 마스킹 처리합니다. 기존 `RequestBodyLoggingAdvice`가 요청 본문을 평문으로 기록해 `refreshToken`, `authorizationCode`, `idToken`, `fcmToken`, 이메일 등이 그대로 남던 문제를 해결합니다.

### 0. 로그 포맷 JSON 구조화 — [`1139596`](https://github.com/Team-WSS/WSS-Server/commit/11395964)

dev에 아직 반영되지 않은 선행 커밋으로, 이 PR에 함께 포함됩니다. 요청·응답 로그를 CloudWatch에서 검색 가능한 JSON 필드로 구조화하고 `traceId`로 묶습니다.

### 1. 마스킹 기반 구성 — [`3f03da3`](https://github.com/Team-WSS/WSS-Server/commit/3f03da37)

`@SensitiveData` 어노테이션과 마스킹 정책(`EMAIL`, `NAME`, `CREDENTIAL`, `FULL`)을 정의했습니다.

마스킹 직렬화기는 `SensitiveDataMasker`가 직접 만든 **로그 전용 ObjectMapper에만** 등록합니다. `ObjectMapper` 타입 빈을 노출하면 Spring Boot 기본 ObjectMapper 자동 구성을 밀어내 실제 API 응답 직렬화까지 바뀌기 때문입니다. **실제 응답 본문은 변경되지 않습니다.**

어노테이션 누락에 대비해 필드명 기반 안전망(`SensitiveFieldNames`)을 함께 뒀습니다. 닉네임처럼 다른 도메인 용어와 겹치는 이름은 작품명까지 가려버리므로 안전망에서 제외하고 어노테이션으로만 처리합니다.

### 2. DTO 어노테이션 부착 — [`efa669f`](https://github.com/Team-WSS/WSS-Server/commit/efa669f5)

전수조사한 25개 DTO에 어노테이션을 부착했습니다.

| 분류 | 정책 | 대상 |
| --- | --- | --- |
| 이메일 | `EMAIL` | `UserInfoGetResponse`, `AppleAuthResult`, `KakaoUserInfo.KakaoAccount` |
| 닉네임·이름 | `NAME` | `RegisterUserInfoRequest`, `UpdateMyProfileRequest`, `MyProfileResponse`, `ProfileGetResponse`, `UserBasicInfo`, `UserIdAndNicknameResponse`, `BlockGetResponse`, `PopularNovelGetResponse`, `CollectionOwnerGetResponse`, `CommentGetResponse`, `FeedGetResponse`, `FeedInfo`, `KakaoUserInfo.Properties` |
| 성별·출생연도 | `FULL` | `EditMyInfoRequest`, `RegisterUserInfoRequest`, `UserInfoGetResponse`, `UserIdAndNicknameResponse` |
| 인증 크리덴셜 | `CREDENTIAL` | `AuthResponse`, `ReissueRequest`, `ReissueResponse`, `LoginResponse`, `LogoutRequest`, `AppleLoginRequest`, `AppleIdUpdateRequest`, `AppleTokenResponse`, `AppleAuthResult` |
| 기기 식별자 | `CREDENTIAL` | `FCMTokenRequest`, `LogoutRequest` |

토큰·인증코드·기기 식별자는 개인정보는 아니지만 유출 시 계정 탈취로 직결되어 함께 포함했습니다. 방침 제1조 5항에 따라 인종·사상·건강 등 인권침해 우려 정보는 수집하지 않으며, 코드상에도 해당 필드가 없음을 확인했습니다.

### 3. 요청 본문 마스킹 적용 — [`55dbec1`](https://github.com/Team-WSS/WSS-Server/commit/55dbec1e)

`RequestBodyLoggingAdvice`가 마스킹된 본문을 기록하도록 바꾸고, 로그 한 건이 커지지 않도록 크기 상한(4KB)과 `truncated` 플래그를 남깁니다.

어노테이션 기반 마스킹은 `BeanSerializerModifier`가 record·POJO 프로퍼티에만 적용해서 **`Map` 본문이 그대로 노출**되는 문제가 있었습니다. 그래서 필드명 안전망은 직렬화 결과 트리를 순회하며 적용해 Map·중첩 구조까지 덮습니다. 이미 가려진 값은 길이 정보가 어긋나므로 다시 마스킹하지 않습니다.

```json
{"event":"API_REQUEST_BODY","traceId":"4dd1b284","userId":"10034","body":{"authorizationCode":"***(len=18)","idToken":"***(len=100)"},"truncated":false}
{"event":"API_REQUEST_BODY","traceId":"4dd1b284","userId":"10034","body":{"novelTitle":"전지적 독자 시점","rating":4.5,"email":"re***@we***"},"truncated":false}
```

### 4. 응답 본문 구조 요약 로깅 — [`e0e6053`](https://github.com/Team-WSS/WSS-Server/commit/e0e6053c)

응답은 값을 남기지 않고 타입·필드명·길이만 기록합니다. 값을 직렬화하지 않아 개인정보가 흘러갈 수 없고, 목록은 원소를 순회하지 않아 크기와 무관하게 비용이 일정합니다.

```json
{"event":"API_RESPONSE_BODY","body":{"type":"UserInfoGetResponse","fields":{"email":"String(len=17)","gender":"String(len=4)","birth":"Integer"}}}
{"event":"API_RESPONSE_BODY","body":{"type":"List","size":20,"elementType":"FeedGetResponse"}}
```

피드 20건 응답 기준 전량 직렬화는 10.122μs, 구조 요약은 0.074μs로 **137배 저렴**합니다.

### 5. 슬라이스 테스트 호환 — [`d463787`](https://github.com/Team-WSS/WSS-Server/commit/d463787e)

`@WebMvcTest`는 `@ControllerAdvice`만 등록하고 일반 컴포넌트는 제외합니다. 마스커와 요약기를 빈으로 두면 어드바이스가 의존성을 찾지 못해 컨트롤러 테스트 컨텍스트가 전부 깨졌습니다(148건 실패). 상태 없는 두 협력 객체를 빈에서 제외하고 어드바이스가 직접 생성하도록 했습니다.

### 6. 로그 출력 비동기 전환 — [`e4bc2f3`](https://github.com/Team-WSS/WSS-Server/commit/e4bc2f38)

기존에는 Console·File 두 appender가 모두 동기이고 `immediateFlush=true`라 요청 스레드가 직접 인코딩·write·flush를 수행했습니다. 16스레드 부하 실측 결과입니다.

| 구성 | 평균 | p99 | 처리량 |
| --- | --- | --- | --- |
| 로깅 OFF (기준선) | 22μs | 11μs | 504,169 req/s |
| 기존 (동기 Console+File) | 538μs | 7,209μs | 28,515 req/s |
| 기존 + 응답 메타 로깅 | 574μs | 4,918μs | 26,622 req/s |
| **Async 적용 + 응답 메타** | **37μs** | **8.8μs** | **350,713 req/s** |

부하 증가분은 바디 로깅 추가(+7%)가 아니라 기존 동기 appender 구성에 있었습니다. stdout 소비자(awslogs 드라이버)가 정체된 조건에서는 파이프 버퍼 포화로 요청 스레드가 **최대 501ms까지 블로킹**됐고, Async 적용 시 37ms로 줄었습니다.

File appender는 Docker가 stdout을 수집하므로 중복이라 제거했습니다.

## To Reviewers

- **실제 API 응답은 바뀌지 않습니다.** 마스킹은 로그 전용 ObjectMapper에만 걸리며, 이를 검증하는 테스트(`doesNotAffectApiResponseSerialization`)를 넣어뒀습니다.
- `neverBlock=true`는 큐가 가득 차면 로그를 버립니다. 요청 스레드 블로킹보다 낫다고 판단했지만, 이 트레이드오프가 괜찮은지 봐주세요. 관련해서 **deploy.sh에 `--log-opt mode=non-blocking --log-opt max-buffer-size=4m`를 함께 넣는 것을 권장**합니다. awslogs 드라이버 기본값이 blocking이라, CloudWatch 전송이 밀리면 컨테이너 stdout이 막히고 그 상태에서 로그가 조용히 버려질 수 있습니다.
- 닉네임을 `NAME`(첫 글자만 노출)으로 잡았습니다. 처리방침상 수집 항목이라 가렸지만 로그에서 사용자 추적이 어려워지는 면이 있어, 정책 조정이 필요하면 알려주세요.
- 요청 본문 크기 상한은 4KB로 잡았습니다.
- #603의 **deploy.sh awslogs 드라이버 설정은 이 PR에 포함되지 않았습니다.** 그래서 자동 close 링크를 걸지 않았습니다.

### 테스트

- `wss-service-support` 신규 테스트 통과 (마스킹 8, 요청 본문 2, 응답 요약 4, logback 구성 3)
- 루트 모듈 실제 DTO 마스킹 테스트 5건 통과
- 전체 695건 중 13건 실패는 **기존 실패**입니다. 변경 전 커밋 `11395964`에서 동일한 13건이 같은 방식으로 실패함을 확인했습니다 (로컬 Redis 미구동에 따른 컨텍스트 로드 실패 + `RecentSearchService:52` 기존 NPE).

## References

- [개인정보처리방침](https://websoso.notion.site/143600bd746880668556fb005fcef491)
- [Logback AsyncAppender](https://logback.qos.ch/manual/appenders.html#AsyncAppender)
- [Docker awslogs logging driver](https://docs.docker.com/engine/logging/drivers/awslogs/)
