### PR TITLE
[TEST] 작품 알림 변경 반영 노티피케이션 API 테스트 및 문서화

### DIFF
--- a/src/test/java/org/websoso/WSSServer/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,100 @@
+package org.websoso.WSSServer.notification.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.websoso.WSSServer.application.NotificationApplication;
+import org.websoso.WSSServer.notification.controller.response.NotificationDetailResponse;
+import org.websoso.WSSServer.notification.controller.response.NotificationPageResponse;
+import org.websoso.WSSServer.notification.controller.response.NotificationReadStatusResponse;
+import org.websoso.WSSServer.user.domain.User;
+
+/** 알림 Controller의 요청 위임과 상태 코드를 검증한다. */
+@SuppressWarnings("deprecation")
+class NotificationControllerTest {
+
+    private final NotificationApplication notificationApplication = mock(NotificationApplication.class);
+    private final NotificationController controller = new NotificationController(notificationApplication);
+    private final User user = mock(User.class);
+
+    @DisplayName("알림 목록 조회 결과와 200을 반환한다")
+    @Test
+    void getsNotifications() {
+        NotificationPageResponse expected = new NotificationPageResponse(false, List.of());
+        given(notificationApplication.getNotifications(user, 20L, 15)).willReturn(expected);
+
+        ResponseEntity<NotificationPageResponse> response = controller.getNotifications(user, 20L, 15);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isSameAs(expected);
+        then(notificationApplication).should().getNotifications(user, 20L, 15);
+    }
+
+    @DisplayName("공지 알림 상세 조회 결과와 200을 반환한다")
+    @Test
+    void getsNotificationDetail() {
+        NotificationDetailResponse expected =
+                new NotificationDetailResponse("서비스 점검 안내", "2026.08.22", "점검 상세 내용");
+        given(notificationApplication.getNotificationDetail(user, 10L)).willReturn(expected);
+
+        ResponseEntity<NotificationDetailResponse> response = controller.getNotification(user, 10L);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isSameAs(expected);
+        then(notificationApplication).should().getNotificationDetail(user, 10L);
+    }
+
+    @DisplayName("읽지 않은 알림 상태 조회 결과와 200을 반환한다")
+    @Test
+    void getsNotificationStatus() {
+        NotificationReadStatusResponse expected = new NotificationReadStatusResponse(true);
+        given(notificationApplication.getReadStatus(user)).willReturn(expected);
+
+        ResponseEntity<NotificationReadStatusResponse> response = controller.getNotificationStatus(user);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isSameAs(expected);
+        then(notificationApplication).should().getReadStatus(user);
+    }
+
+    @DisplayName("알림을 읽음 처리하고 204를 반환한다")
+    @Test
+    void updatesNotificationReadStatus() {
+        ResponseEntity<Void> response = controller.createNotificationAsReadStatus(user, 10L);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(response.getBody()).isNull();
+        then(notificationApplication).should().updateNotificationReadStatus(user, 10L);
+    }
+
+    @DisplayName("기존 읽지 않은 알림 상태 조회 결과와 200을 반환한다")
+    @Test
+    void getsNotificationStatusDeprecated() {
+        NotificationReadStatusResponse expected = new NotificationReadStatusResponse(true);
+        given(notificationApplication.getReadStatus(user)).willReturn(expected);
+
+        ResponseEntity<NotificationReadStatusResponse> response =
+                controller.checkNotificationsReadStatusDeprecated(user);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isSameAs(expected);
+        then(notificationApplication).should().getReadStatus(user);
+    }
+
+    @DisplayName("기존 알림 읽음 처리는 201을 반환한다")
+    @Test
+    void createsNotificationAsReadDeprecated() {
+        ResponseEntity<Void> response = controller.createNotificationAsRead(user, 10L);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNull();
+        then(notificationApplication).should().updateNotificationReadStatus(user, 10L);
+    }
+}

--- a/src/test/java/org/websoso/WSSServer/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/NotificationControllerTest.java
@@ -17,7 +17,6 @@ import org.websoso.WSSServer.notification.controller.response.NotificationReadSt
 import org.websoso.WSSServer.user.domain.User;
 
 /** 알림 Controller의 요청 위임과 상태 코드를 검증한다. */
-@SuppressWarnings("deprecation")
 class NotificationControllerTest {
 
     private final NotificationApplication notificationApplication = mock(NotificationApplication.class);
@@ -74,6 +73,7 @@ class NotificationControllerTest {
         then(notificationApplication).should().updateNotificationReadStatus(user, 10L);
     }
 
+    @SuppressWarnings("deprecation")
     @DisplayName("기존 읽지 않은 알림 상태 조회 결과와 200을 반환한다")
     @Test
     void getsNotificationStatusDeprecated() {
@@ -88,6 +88,7 @@ class NotificationControllerTest {
         then(notificationApplication).should().getReadStatus(user);
     }
 
+    @SuppressWarnings("deprecation")
     @DisplayName("기존 알림 읽음 처리는 201을 반환한다")
     @Test
     void createsNotificationAsReadDeprecated() {
@@ -97,4 +98,5 @@ class NotificationControllerTest {
         assertThat(response.getBody()).isNull();
         then(notificationApplication).should().updateNotificationReadStatus(user, 10L);
     }
+
 }

--- a/src/test/java/org/websoso/WSSServer/notification/controller/notification/NotificationDocsTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/notification/NotificationDocsTest.java
@@ -79,6 +79,8 @@ class NotificationDocsTest {
     private static final String SIZE_MIN_MESSAGE = "must be greater than or equal to 1";
     private static final String SIZE_MAX_MESSAGE = "must be less than or equal to 50";
     private static final String NOTIFICATION_ID_POSITIVE_MESSAGE = "must be greater than 0";
+    private static final String VALIDATION_MESSAGE_NOTICE =
+            "검증 실패 응답의 message는 요청 Accept-Language에 따라 달라질 수 있으므로, 클라이언트는 code로 분기해야 합니다.";
     private static final Schema PAGE_RESPONSE_SCHEMA = Schema.schema("NotificationPageResponse");
     private static final Schema DETAIL_RESPONSE_SCHEMA = Schema.schema("NotificationDetailResponse");
     private static final Schema STATUS_RESPONSE_SCHEMA = Schema.schema("NotificationReadStatusResponse");
@@ -88,6 +90,7 @@ class NotificationDocsTest {
             "첫 페이지는 lastNotificationId를 생략하거나 0으로 보내고, 다음 페이지는 마지막 notificationId를 커서로 보냅니다.",
             "피드 알림은 feedId, 작품 완결·휴재 복귀 알림은 novelId가 이동 대상이며 나머지 이동 ID는 null입니다.",
             "isLoadable이 false면 다음 페이지가 없습니다.",
+            VALIDATION_MESSAGE_NOTICE,
             "",
             "Try it out으로 호출하려면 상단 Authorize에 실제 Access Token을 입력해야 합니다.",
             "",
@@ -105,6 +108,7 @@ class NotificationDocsTest {
     private static final String DETAIL_DESCRIPTION = String.join("\n",
             "공지·이벤트 알림의 상세 내용을 조회하고 해당 알림을 읽음 처리합니다.",
             "피드 또는 작품 이동 알림은 상세 조회 대상이 아니며 NOTIFICATION-003을 반환합니다.",
+            VALIDATION_MESSAGE_NOTICE,
             "",
             "이 API가 정의하는 응답은 다음과 같습니다.",
             "",
@@ -131,6 +135,7 @@ class NotificationDocsTest {
     private static final String READ_DESCRIPTION = String.join("\n",
             "사용자에게 발송된 알림을 읽음 상태로 변경합니다.",
             "이미 읽은 알림을 다시 요청해도 성공하는 멱등 API입니다.",
+            VALIDATION_MESSAGE_NOTICE,
             "",
             "이 API가 정의하는 응답은 다음과 같습니다.",
             "",
@@ -150,7 +155,10 @@ class NotificationDocsTest {
             "이 API가 정의하는 응답은 다음과 같습니다.",
             "",
             "- 200 OK — 성공.",
-            errorLine(INVALID_TOKEN));
+            errorLine(ACCESS_TOKEN_EXPIRED),
+            errorLine(INVALID_TOKEN),
+            errorLine(WRONG_TOKEN_TYPE),
+            errorLine(USER_NOT_FOUND));
 
     private static final String LEGACY_READ_DESCRIPTION = String.join("\n",
             "Deprecated API입니다. 신규 구현에서는 PATCH /notifications/{notificationId}/read-status를 사용합니다.",
@@ -160,7 +168,12 @@ class NotificationDocsTest {
             "이 API가 정의하는 응답은 다음과 같습니다.",
             "",
             "- 201 Created — 성공. (응답 본문이 없습니다.)",
-            errorLine(INVALID_TOKEN));
+            errorLine(ACCESS_TOKEN_EXPIRED),
+            errorLine(INVALID_TOKEN),
+            errorLine(WRONG_TOKEN_TYPE),
+            errorLine(NOTIFICATION_READ_FORBIDDEN),
+            errorLine(NOTIFICATION_NOT_FOUND),
+            errorLine(USER_NOT_FOUND));
 
     @Autowired
     private MockMvc mockMvc;
@@ -545,6 +558,17 @@ class NotificationDocsTest {
                                 .build())));
     }
 
+    @DisplayName("기존 알림 상태 조회의 만료 토큰 401 응답을 문서화한다")
+    @Test
+    void documentGetNotificationStatusDeprecatedWithExpiredToken() throws Exception {
+        mockMvc.perform(get("/notifications/unread").with(expiredAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ACCESS_TOKEN_EXPIRED.getCode()))
+                .andExpect(jsonPath("$.message").value(ACCESS_TOKEN_EXPIRED.getDescription()))
+                .andDo(document("notification-unread-get-deprecated-access-token-expired",
+                        resource(notificationLegacyStatusError().build())));
+    }
+
     @DisplayName("기존 알림 상태 조회의 변조 토큰 401 응답을 문서화한다")
     @Test
     void documentGetNotificationStatusDeprecatedWithInvalidToken() throws Exception {
@@ -553,10 +577,32 @@ class NotificationDocsTest {
                 .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
                 .andExpect(jsonPath("$.message").value(INVALID_TOKEN.getDescription()))
                 .andDo(document("notification-unread-get-deprecated-invalid-token",
-                        resource(notificationLegacyStatus()
-                                .responseSchema(ERROR_RESULT_SCHEMA)
-                                .responseFields(errorResultFields())
-                                .build())));
+                        resource(notificationLegacyStatusError().build())));
+    }
+
+    @DisplayName("기존 알림 상태 조회의 Refresh Token 401 응답을 문서화한다")
+    @Test
+    void documentGetNotificationStatusDeprecatedWithWrongTokenType() throws Exception {
+        mockMvc.perform(get("/notifications/unread").with(refreshToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(WRONG_TOKEN_TYPE.getCode()))
+                .andExpect(jsonPath("$.message").value(WRONG_TOKEN_TYPE.getDescription()))
+                .andDo(document("notification-unread-get-deprecated-wrong-token-type",
+                        resource(notificationLegacyStatusError().build())));
+    }
+
+    @DisplayName("기존 알림 상태 조회의 사용자가 없으면 404 응답을 문서화한다")
+    @Test
+    void documentGetNotificationStatusDeprecatedWithUnknownUser() throws Exception {
+        given(userService.getUserOrException(USER_ID))
+                .willThrow(new CustomUserException(USER_NOT_FOUND, "user not found"));
+
+        mockMvc.perform(get("/notifications/unread").with(accessToken(USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(USER_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(USER_NOT_FOUND.getDescription()))
+                .andDo(document("notification-unread-get-deprecated-user-not-found",
+                        resource(notificationLegacyStatusError().build())));
     }
 
     @DisplayName("기존 알림 읽음 처리 201 응답을 Deprecated API로 문서화한다")
@@ -569,6 +615,17 @@ class NotificationDocsTest {
                         resource(notificationLegacyRead().build())));
     }
 
+    @DisplayName("기존 알림 읽음 처리의 만료 토큰 401 응답을 문서화한다")
+    @Test
+    void documentCreateNotificationAsReadDeprecatedWithExpiredToken() throws Exception {
+        mockMvc.perform(notificationLegacyReadRequest().with(expiredAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ACCESS_TOKEN_EXPIRED.getCode()))
+                .andExpect(jsonPath("$.message").value(ACCESS_TOKEN_EXPIRED.getDescription()))
+                .andDo(document("notification-read-post-deprecated-access-token-expired",
+                        resource(notificationLegacyReadError().build())));
+    }
+
     @DisplayName("기존 알림 읽음 처리의 변조 토큰 401 응답을 문서화한다")
     @Test
     void documentCreateNotificationAsReadDeprecatedWithInvalidToken() throws Exception {
@@ -577,10 +634,52 @@ class NotificationDocsTest {
                 .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
                 .andExpect(jsonPath("$.message").value(INVALID_TOKEN.getDescription()))
                 .andDo(document("notification-read-post-deprecated-invalid-token",
-                        resource(notificationLegacyRead()
-                                .responseSchema(ERROR_RESULT_SCHEMA)
-                                .responseFields(errorResultFields())
-                                .build())));
+                        resource(notificationLegacyReadError().build())));
+    }
+
+    @DisplayName("기존 알림 읽음 처리의 Refresh Token 401 응답을 문서화한다")
+    @Test
+    void documentCreateNotificationAsReadDeprecatedWithWrongTokenType() throws Exception {
+        mockMvc.perform(notificationLegacyReadRequest().with(refreshToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(WRONG_TOKEN_TYPE.getCode()))
+                .andExpect(jsonPath("$.message").value(WRONG_TOKEN_TYPE.getDescription()))
+                .andDo(document("notification-read-post-deprecated-wrong-token-type",
+                        resource(notificationLegacyReadError().build())));
+    }
+
+    @DisplayName("기존 알림 읽음 처리의 사용자가 없으면 404 응답을 문서화한다")
+    @Test
+    void documentCreateNotificationAsReadDeprecatedWithUnknownUser() throws Exception {
+        given(userService.getUserOrException(USER_ID))
+                .willThrow(new CustomUserException(USER_NOT_FOUND, "user not found"));
+
+        mockMvc.perform(notificationLegacyReadRequest().with(accessToken(USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(USER_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(USER_NOT_FOUND.getDescription()))
+                .andDo(document("notification-read-post-deprecated-user-not-found",
+                        resource(notificationLegacyReadError().build())));
+    }
+
+    @DisplayName("기존 알림 읽음 처리에서 알림이 없으면 404 응답을 문서화한다")
+    @Test
+    void documentCreateNotificationAsReadDeprecatedNotFound() throws Exception {
+        willThrow(new CustomNotificationException(NOTIFICATION_NOT_FOUND, "notification not found"))
+                .given(notificationApplication)
+                .updateNotificationReadStatus(any(User.class), eq(NOTIFICATION_ID));
+
+        documentLegacyReadError(NOTIFICATION_NOT_FOUND, "notification-read-post-deprecated-not-found");
+    }
+
+    @DisplayName("기존 알림 읽음 처리에서 다른 사용자의 알림이면 403 응답을 문서화한다")
+    @Test
+    void documentCreateNotificationAsReadDeprecatedForbidden() throws Exception {
+        willThrow(new CustomNotificationException(NOTIFICATION_READ_FORBIDDEN, "notification read forbidden"))
+                .given(notificationApplication)
+                .updateNotificationReadStatus(any(User.class), eq(NOTIFICATION_ID));
+
+        documentLegacyReadError(NOTIFICATION_READ_FORBIDDEN, "notification-read-post-deprecated-forbidden");
     }
 
     @DisplayName("알림 목록 요청의 사용자가 없으면 404 응답을 문서화한다")
@@ -623,6 +722,14 @@ class NotificationDocsTest {
                 .andExpect(jsonPath("$.code").value(error.getCode()))
                 .andExpect(jsonPath("$.message").value(error.getDescription()))
                 .andDo(document(identifier, resource(notificationReadError().build())));
+    }
+
+    private void documentLegacyReadError(ICustomError error, String identifier) throws Exception {
+        mockMvc.perform(notificationLegacyReadRequest().with(accessToken(USER_ID)))
+                .andExpect(status().is(error.getStatusCode().value()))
+                .andExpect(jsonPath("$.code").value(error.getCode()))
+                .andExpect(jsonPath("$.message").value(error.getDescription()))
+                .andDo(document(identifier, resource(notificationLegacyReadError().build())));
     }
 
     private ResourceSnippetParametersBuilder notificationListError() {
@@ -688,6 +795,12 @@ class NotificationDocsTest {
                 .deprecated(true);
     }
 
+    private ResourceSnippetParametersBuilder notificationLegacyStatusError() {
+        return notificationLegacyStatus()
+                .responseSchema(ERROR_RESULT_SCHEMA)
+                .responseFields(errorResultFields());
+    }
+
     private ResourceSnippetParametersBuilder notificationLegacyRead() {
         return ResourceSnippetParameters.builder()
                 .tag(TAG)
@@ -697,6 +810,12 @@ class NotificationDocsTest {
                         .type(SimpleType.INTEGER)
                         .description("읽음 처리할 알림 ID"))
                 .deprecated(true);
+    }
+
+    private ResourceSnippetParametersBuilder notificationLegacyReadError() {
+        return notificationLegacyRead()
+                .responseSchema(ERROR_RESULT_SCHEMA)
+                .responseFields(errorResultFields());
     }
 
     private List<ParameterDescriptorWithType> notificationQueryParameters() {

--- a/src/test/java/org/websoso/WSSServer/notification/controller/notification/NotificationDocsTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/notification/NotificationDocsTest.java
@@ -44,6 +44,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
 import com.epages.restdocs.apispec.Schema;
 import com.epages.restdocs.apispec.SimpleType;
 import java.util.List;
+import java.util.Locale;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -66,7 +67,7 @@ import org.websoso.WSSServer.user.domain.User;
 import org.websoso.WSSServer.user.service.UserService;
 import org.websoso.common.exception.ICustomError;
 
-/** 노티피케이션 Controller의 운영 API 4개를 문서화하는 REST Docs 테스트. */
+/** 노티피케이션 Controller의 운영 API 4개와 Deprecated API 2개를 문서화하는 REST Docs 테스트. */
 @AutoConfigureRestDocs
 @AuthenticatedControllerTest(NotificationController.class)
 class NotificationDocsTest {
@@ -74,6 +75,10 @@ class NotificationDocsTest {
     private static final Long USER_ID = 42L;
     private static final Long NOTIFICATION_ID = 10L;
     private static final String TAG = "Notification";
+    private static final String CURSOR_MIN_MESSAGE = "must be greater than or equal to 0";
+    private static final String SIZE_MIN_MESSAGE = "must be greater than or equal to 1";
+    private static final String SIZE_MAX_MESSAGE = "must be less than or equal to 50";
+    private static final String NOTIFICATION_ID_POSITIVE_MESSAGE = "must be greater than 0";
     private static final Schema PAGE_RESPONSE_SCHEMA = Schema.schema("NotificationPageResponse");
     private static final Schema DETAIL_RESPONSE_SCHEMA = Schema.schema("NotificationDetailResponse");
     private static final Schema STATUS_RESPONSE_SCHEMA = Schema.schema("NotificationReadStatusResponse");
@@ -89,7 +94,9 @@ class NotificationDocsTest {
             "이 API가 정의하는 응답은 다음과 같습니다.",
             "",
             "- 200 OK — 성공.",
-            "- 400 BAD_REQUEST — 커서가 음수이거나 size가 1 미만 또는 50 초과인 요청.",
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), CURSOR_MIN_MESSAGE),
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), SIZE_MIN_MESSAGE),
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), SIZE_MAX_MESSAGE),
             errorLine(ACCESS_TOKEN_EXPIRED),
             errorLine(INVALID_TOKEN),
             errorLine(WRONG_TOKEN_TYPE),
@@ -102,7 +109,7 @@ class NotificationDocsTest {
             "이 API가 정의하는 응답은 다음과 같습니다.",
             "",
             "- 200 OK — 성공.",
-            "- 400 BAD_REQUEST — notificationId가 양수가 아닌 요청.",
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), NOTIFICATION_ID_POSITIVE_MESSAGE),
             errorLine(ACCESS_TOKEN_EXPIRED),
             errorLine(INVALID_TOKEN),
             errorLine(WRONG_TOKEN_TYPE),
@@ -128,7 +135,7 @@ class NotificationDocsTest {
             "이 API가 정의하는 응답은 다음과 같습니다.",
             "",
             "- 204 No Content — 성공. (응답 본문이 없습니다.)",
-            "- 400 BAD_REQUEST — notificationId가 양수가 아닌 요청.",
+            errorLine(BAD_REQUEST, BAD_REQUEST.name(), NOTIFICATION_ID_POSITIVE_MESSAGE),
             errorLine(ACCESS_TOKEN_EXPIRED),
             errorLine(INVALID_TOKEN),
             errorLine(WRONG_TOKEN_TYPE),
@@ -181,8 +188,16 @@ class NotificationDocsTest {
                 .andExpect(jsonPath("$.isLoadable").value(true))
                 .andExpect(jsonPath("$.notifications[0].feedId").value(31L))
                 .andExpect(jsonPath("$.notifications[0].novelId").isEmpty())
+                .andExpect(jsonPath("$.notifications[0].isNotice").value(false))
                 .andExpect(jsonPath("$.notifications[1].feedId").isEmpty())
                 .andExpect(jsonPath("$.notifications[1].novelId").value(7L))
+                .andExpect(jsonPath("$.notifications[1].isNotice").value(false))
+                .andExpect(jsonPath("$.notifications[2].feedId").isEmpty())
+                .andExpect(jsonPath("$.notifications[2].novelId").value(8L))
+                .andExpect(jsonPath("$.notifications[2].isNotice").value(false))
+                .andExpect(jsonPath("$.notifications[3].feedId").isEmpty())
+                .andExpect(jsonPath("$.notifications[3].novelId").isEmpty())
+                .andExpect(jsonPath("$.notifications[3].isNotice").value(true))
                 .andDo(document("notifications-get",
                         resource(notificationList()
                                 .responseSchema(PAGE_RESPONSE_SCHEMA)
@@ -208,9 +223,11 @@ class NotificationDocsTest {
         mockMvc.perform(get("/notifications")
                         .queryParam("lastNotificationId", "-1")
                         .queryParam("size", "10")
+                        .locale(Locale.ENGLISH)
                         .with(accessToken(USER_ID)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(CURSOR_MIN_MESSAGE))
                 .andDo(document("notifications-get-cursor-negative",
                         resource(notificationListError().build())));
     }
@@ -218,13 +235,13 @@ class NotificationDocsTest {
     @DisplayName("1 미만 조회 개수의 400 응답을 문서화한다")
     @Test
     void documentGetNotificationsWithTooSmallSize() throws Exception {
-        documentListValidationError("0", "notifications-get-size-too-small");
+        documentListValidationError("0", SIZE_MIN_MESSAGE, "notifications-get-size-too-small");
     }
 
     @DisplayName("50 초과 조회 개수의 400 응답을 문서화한다")
     @Test
     void documentGetNotificationsWithTooLargeSize() throws Exception {
-        documentListValidationError("51", "notifications-get-size-too-large");
+        documentListValidationError("51", SIZE_MAX_MESSAGE, "notifications-get-size-too-large");
     }
 
     @DisplayName("알림 목록 요청의 만료 토큰 401 응답을 문서화한다")
@@ -233,6 +250,7 @@ class NotificationDocsTest {
         mockMvc.perform(notificationsRequest().with(expiredAccessToken(USER_ID)))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(ACCESS_TOKEN_EXPIRED.getCode()))
+                .andExpect(jsonPath("$.message").value(ACCESS_TOKEN_EXPIRED.getDescription()))
                 .andDo(document("notifications-get-access-token-expired",
                         resource(notificationListError().build())));
     }
@@ -243,6 +261,7 @@ class NotificationDocsTest {
         mockMvc.perform(notificationsRequest().with(tamperedAccessToken(USER_ID)))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(INVALID_TOKEN.getDescription()))
                 .andDo(document("notifications-get-invalid-token",
                         resource(notificationListError().build())));
     }
@@ -253,6 +272,7 @@ class NotificationDocsTest {
         mockMvc.perform(notificationsRequest().with(refreshToken(USER_ID)))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(WRONG_TOKEN_TYPE.getCode()))
+                .andExpect(jsonPath("$.message").value(WRONG_TOKEN_TYPE.getDescription()))
                 .andDo(document("notifications-get-wrong-token-type",
                         resource(notificationListError().build())));
     }
@@ -279,9 +299,12 @@ class NotificationDocsTest {
     @DisplayName("양수가 아닌 상세 알림 ID의 400 응답을 문서화한다")
     @Test
     void documentGetNotificationDetailWithNonPositiveId() throws Exception {
-        mockMvc.perform(get("/notifications/{notificationId}", 0L).with(accessToken(USER_ID)))
+        mockMvc.perform(get("/notifications/{notificationId}", 0L)
+                        .locale(Locale.ENGLISH)
+                        .with(accessToken(USER_ID)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(NOTIFICATION_ID_POSITIVE_MESSAGE))
                 .andDo(document("notification-detail-get-id-not-positive",
                         resource(notificationDetailError().build())));
     }
@@ -304,13 +327,50 @@ class NotificationDocsTest {
         documentDetailError(NOTIFICATION_TYPE_INVALID, "notification-detail-get-type-invalid");
     }
 
+    @DisplayName("공지 알림 상세 요청의 만료 토큰 401 응답을 문서화한다")
+    @Test
+    void documentGetNotificationDetailWithExpiredToken() throws Exception {
+        mockMvc.perform(notificationDetailRequest().with(expiredAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ACCESS_TOKEN_EXPIRED.getCode()))
+                .andExpect(jsonPath("$.message").value(ACCESS_TOKEN_EXPIRED.getDescription()))
+                .andDo(document("notification-detail-get-access-token-expired",
+                        resource(notificationDetailError().build())));
+    }
+
     @DisplayName("공지 알림 상세 요청의 변조 토큰 401 응답을 문서화한다")
     @Test
     void documentGetNotificationDetailWithInvalidToken() throws Exception {
         mockMvc.perform(notificationDetailRequest().with(tamperedAccessToken(USER_ID)))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(INVALID_TOKEN.getDescription()))
                 .andDo(document("notification-detail-get-invalid-token",
+                        resource(notificationDetailError().build())));
+    }
+
+    @DisplayName("공지 알림 상세 요청의 Refresh Token 401 응답을 문서화한다")
+    @Test
+    void documentGetNotificationDetailWithWrongTokenType() throws Exception {
+        mockMvc.perform(notificationDetailRequest().with(refreshToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(WRONG_TOKEN_TYPE.getCode()))
+                .andExpect(jsonPath("$.message").value(WRONG_TOKEN_TYPE.getDescription()))
+                .andDo(document("notification-detail-get-wrong-token-type",
+                        resource(notificationDetailError().build())));
+    }
+
+    @DisplayName("공지 알림 상세 요청의 사용자가 없으면 404 응답을 문서화한다")
+    @Test
+    void documentGetNotificationDetailWithUnknownUser() throws Exception {
+        given(userService.getUserOrException(USER_ID))
+                .willThrow(new CustomUserException(USER_NOT_FOUND, "user not found"));
+
+        mockMvc.perform(notificationDetailRequest().with(accessToken(USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(USER_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(USER_NOT_FOUND.getDescription()))
+                .andDo(document("notification-detail-get-user-not-found",
                         resource(notificationDetailError().build())));
     }
 
@@ -331,13 +391,36 @@ class NotificationDocsTest {
                                 .build())));
     }
 
+    @DisplayName("알림 상태 요청의 만료 토큰 401 응답을 문서화한다")
+    @Test
+    void documentGetNotificationStatusWithExpiredToken() throws Exception {
+        mockMvc.perform(get("/notifications/status").with(expiredAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ACCESS_TOKEN_EXPIRED.getCode()))
+                .andExpect(jsonPath("$.message").value(ACCESS_TOKEN_EXPIRED.getDescription()))
+                .andDo(document("notification-status-get-access-token-expired",
+                        resource(notificationStatusError().build())));
+    }
+
     @DisplayName("알림 상태 요청의 변조 토큰 401 응답을 문서화한다")
     @Test
     void documentGetNotificationStatusWithInvalidToken() throws Exception {
         mockMvc.perform(get("/notifications/status").with(tamperedAccessToken(USER_ID)))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(INVALID_TOKEN.getDescription()))
                 .andDo(document("notification-status-get-invalid-token",
+                        resource(notificationStatusError().build())));
+    }
+
+    @DisplayName("알림 상태 요청의 Refresh Token 401 응답을 문서화한다")
+    @Test
+    void documentGetNotificationStatusWithWrongTokenType() throws Exception {
+        mockMvc.perform(get("/notifications/status").with(refreshToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(WRONG_TOKEN_TYPE.getCode()))
+                .andExpect(jsonPath("$.message").value(WRONG_TOKEN_TYPE.getDescription()))
+                .andDo(document("notification-status-get-wrong-token-type",
                         resource(notificationStatusError().build())));
     }
 
@@ -350,6 +433,7 @@ class NotificationDocsTest {
         mockMvc.perform(get("/notifications/status").with(accessToken(USER_ID)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(USER_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(USER_NOT_FOUND.getDescription()))
                 .andDo(document("notification-status-get-user-not-found",
                         resource(notificationStatusError().build())));
     }
@@ -368,9 +452,11 @@ class NotificationDocsTest {
     @Test
     void documentUpdateNotificationReadStatusWithNonPositiveId() throws Exception {
         mockMvc.perform(patch("/notifications/{notificationId}/read-status", 0L)
+                        .locale(Locale.ENGLISH)
                         .with(accessToken(USER_ID)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(NOTIFICATION_ID_POSITIVE_MESSAGE))
                 .andDo(document("notification-read-status-patch-id-not-positive",
                         resource(notificationReadError().build())));
     }
@@ -395,13 +481,50 @@ class NotificationDocsTest {
         documentReadError(NOTIFICATION_READ_FORBIDDEN, "notification-read-status-patch-forbidden");
     }
 
+    @DisplayName("알림 읽음 요청의 만료 토큰 401 응답을 문서화한다")
+    @Test
+    void documentUpdateNotificationReadStatusWithExpiredToken() throws Exception {
+        mockMvc.perform(notificationReadRequest().with(expiredAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ACCESS_TOKEN_EXPIRED.getCode()))
+                .andExpect(jsonPath("$.message").value(ACCESS_TOKEN_EXPIRED.getDescription()))
+                .andDo(document("notification-read-status-patch-access-token-expired",
+                        resource(notificationReadError().build())));
+    }
+
     @DisplayName("알림 읽음 요청의 변조 토큰 401 응답을 문서화한다")
     @Test
     void documentUpdateNotificationReadStatusWithInvalidToken() throws Exception {
         mockMvc.perform(notificationReadRequest().with(tamperedAccessToken(USER_ID)))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(INVALID_TOKEN.getDescription()))
                 .andDo(document("notification-read-status-patch-invalid-token",
+                        resource(notificationReadError().build())));
+    }
+
+    @DisplayName("알림 읽음 요청의 Refresh Token 401 응답을 문서화한다")
+    @Test
+    void documentUpdateNotificationReadStatusWithWrongTokenType() throws Exception {
+        mockMvc.perform(notificationReadRequest().with(refreshToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(WRONG_TOKEN_TYPE.getCode()))
+                .andExpect(jsonPath("$.message").value(WRONG_TOKEN_TYPE.getDescription()))
+                .andDo(document("notification-read-status-patch-wrong-token-type",
+                        resource(notificationReadError().build())));
+    }
+
+    @DisplayName("알림 읽음 요청의 사용자가 없으면 404 응답을 문서화한다")
+    @Test
+    void documentUpdateNotificationReadStatusWithUnknownUser() throws Exception {
+        given(userService.getUserOrException(USER_ID))
+                .willThrow(new CustomUserException(USER_NOT_FOUND, "user not found"));
+
+        mockMvc.perform(notificationReadRequest().with(accessToken(USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(USER_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(USER_NOT_FOUND.getDescription()))
+                .andDo(document("notification-read-status-patch-user-not-found",
                         resource(notificationReadError().build())));
     }
 
@@ -428,6 +551,7 @@ class NotificationDocsTest {
         mockMvc.perform(get("/notifications/unread").with(tamperedAccessToken(USER_ID)))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(INVALID_TOKEN.getDescription()))
                 .andDo(document("notification-unread-get-deprecated-invalid-token",
                         resource(notificationLegacyStatus()
                                 .responseSchema(ERROR_RESULT_SCHEMA)
@@ -451,6 +575,7 @@ class NotificationDocsTest {
         mockMvc.perform(notificationLegacyReadRequest().with(tamperedAccessToken(USER_ID)))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andExpect(jsonPath("$.message").value(INVALID_TOKEN.getDescription()))
                 .andDo(document("notification-read-post-deprecated-invalid-token",
                         resource(notificationLegacyRead()
                                 .responseSchema(ERROR_RESULT_SCHEMA)
@@ -458,7 +583,7 @@ class NotificationDocsTest {
                                 .build())));
     }
 
-    @DisplayName("유효한 토큰의 사용자가 없으면 404 응답을 문서화한다")
+    @DisplayName("알림 목록 요청의 사용자가 없으면 404 응답을 문서화한다")
     @Test
     void documentUnknownUser() throws Exception {
         given(userService.getUserOrException(USER_ID))
@@ -467,17 +592,20 @@ class NotificationDocsTest {
         mockMvc.perform(notificationsRequest().with(accessToken(USER_ID)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(USER_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(USER_NOT_FOUND.getDescription()))
                 .andDo(document("notifications-get-user-not-found",
                         resource(notificationListError().build())));
     }
 
-    private void documentListValidationError(String size, String identifier) throws Exception {
+    private void documentListValidationError(String size, String expectedMessage, String identifier) throws Exception {
         mockMvc.perform(get("/notifications")
                         .queryParam("lastNotificationId", "0")
                         .queryParam("size", size)
+                        .locale(Locale.ENGLISH)
                         .with(accessToken(USER_ID)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(expectedMessage))
                 .andDo(document(identifier, resource(notificationListError().build())));
     }
 
@@ -565,7 +693,9 @@ class NotificationDocsTest {
                 .tag(TAG)
                 .summary("[Deprecated] 알림 읽음 처리")
                 .description(LEGACY_READ_DESCRIPTION)
-                .pathParameters(notificationIdParameter("읽음 처리할 알림 ID"))
+                .pathParameters(parameterWithName("notificationId")
+                        .type(SimpleType.INTEGER)
+                        .description("읽음 처리할 알림 ID"))
                 .deprecated(true);
     }
 
@@ -573,7 +703,6 @@ class NotificationDocsTest {
         return List.of(
                 parameterWithName("lastNotificationId").optional()
                         .type(SimpleType.INTEGER)
-                        .defaultValue(0)
                         .description("이전 페이지의 마지막 알림 ID. 첫 페이지는 생략하거나 0을 보낸다."),
                 parameterWithName("size").optional()
                         .type(SimpleType.INTEGER)
@@ -609,7 +738,7 @@ class NotificationDocsTest {
         return List.of(
                 fieldWithPath("notificationTitle").type(STRING).description("공지 알림 제목"),
                 fieldWithPath("notificationCreatedDate").type(STRING).description("공지 생성일. yyyy.MM.dd 형식."),
-                fieldWithPath("notificationDetail").type(STRING).description("공지 상세 내용"));
+                fieldWithPath("notificationDetail").type(STRING).optional().description("공지 상세 내용"));
     }
 
     private List<FieldDescriptor> notificationStatusFields() {
@@ -619,10 +748,12 @@ class NotificationDocsTest {
 
     private NotificationPageResponse notificationPageResponse() {
         return new NotificationPageResponse(true, List.of(
-                new NotificationItem(102L, "https://image.websoso.kr/notification/feed.png",
+                new NotificationItem(103L, "https://image.websoso.kr/notification/feed.png",
                         "재혼 황후", "내 글에 댓글이 달렸어요.", "3분 전", false, false, 31L, null),
+                new NotificationItem(102L, "https://image.websoso.kr/notification/novel.png",
+                        "재혼 황후", "작품이 완결되었어요.", "30분 전", false, false, null, 7L),
                 new NotificationItem(101L, "https://image.websoso.kr/notification/novel.png",
-                        "재혼 황후", "작품 연재가 재개되었어요.", "1시간 전", false, false, null, 7L),
+                        "화산귀환", "작품 연재가 재개되었어요.", "1시간 전", false, false, null, 8L),
                 new NotificationItem(100L, "https://image.websoso.kr/notification/notice.png",
                         "서비스 점검 안내", "공지 내용을 확인해 주세요.", "2026.08.20", true, true, null, null)));
     }
@@ -644,4 +775,5 @@ class NotificationDocsTest {
     private MockHttpServletRequestBuilder notificationLegacyReadRequest() {
         return post("/notifications/{notificationId}/read", NOTIFICATION_ID);
     }
+
 }

--- a/src/test/java/org/websoso/WSSServer/notification/controller/notification/NotificationDocsTest.java
+++ b/src/test/java/org/websoso/WSSServer/notification/controller/notification/NotificationDocsTest.java
@@ -1,0 +1,647 @@
+package org.websoso.WSSServer.notification.controller.notification;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.ACCESS_TOKEN_EXPIRED;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.INVALID_TOKEN;
+import static org.websoso.WSSServer.exception.error.CustomAuthError.WRONG_TOKEN_TYPE;
+import static org.websoso.WSSServer.exception.error.CustomNotificationError.NOTIFICATION_NOT_FOUND;
+import static org.websoso.WSSServer.exception.error.CustomNotificationError.NOTIFICATION_READ_FORBIDDEN;
+import static org.websoso.WSSServer.exception.error.CustomNotificationError.NOTIFICATION_TYPE_INVALID;
+import static org.websoso.WSSServer.exception.error.CustomUserError.USER_NOT_FOUND;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.accessToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.expiredAccessToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.refreshToken;
+import static org.websoso.WSSServer.support.auth.TestBearerToken.tamperedAccessToken;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.ERROR_RESULT_SCHEMA;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.errorLine;
+import static org.websoso.WSSServer.support.docs.ErrorResponseDocumentation.errorResultFields;
+
+import com.epages.restdocs.apispec.ParameterDescriptorWithType;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.ResourceSnippetParametersBuilder;
+import com.epages.restdocs.apispec.Schema;
+import com.epages.restdocs.apispec.SimpleType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.websoso.WSSServer.application.NotificationApplication;
+import org.websoso.WSSServer.exception.exception.CustomNotificationException;
+import org.websoso.WSSServer.exception.exception.CustomUserException;
+import org.websoso.WSSServer.notification.controller.NotificationController;
+import org.websoso.WSSServer.notification.controller.response.NotificationDetailResponse;
+import org.websoso.WSSServer.notification.controller.response.NotificationPageResponse;
+import org.websoso.WSSServer.notification.controller.response.NotificationPageResponse.NotificationItem;
+import org.websoso.WSSServer.notification.controller.response.NotificationReadStatusResponse;
+import org.websoso.WSSServer.support.auth.AuthenticatedControllerTest;
+import org.websoso.WSSServer.user.domain.User;
+import org.websoso.WSSServer.user.service.UserService;
+import org.websoso.common.exception.ICustomError;
+
+/** 노티피케이션 Controller의 운영 API 4개를 문서화하는 REST Docs 테스트. */
+@AutoConfigureRestDocs
+@AuthenticatedControllerTest(NotificationController.class)
+class NotificationDocsTest {
+
+    private static final Long USER_ID = 42L;
+    private static final Long NOTIFICATION_ID = 10L;
+    private static final String TAG = "Notification";
+    private static final Schema PAGE_RESPONSE_SCHEMA = Schema.schema("NotificationPageResponse");
+    private static final Schema DETAIL_RESPONSE_SCHEMA = Schema.schema("NotificationDetailResponse");
+    private static final Schema STATUS_RESPONSE_SCHEMA = Schema.schema("NotificationReadStatusResponse");
+
+    private static final String LIST_DESCRIPTION = String.join("\n",
+            "사용자에게 발송된 알림을 최신순으로 조회합니다.",
+            "첫 페이지는 lastNotificationId를 생략하거나 0으로 보내고, 다음 페이지는 마지막 notificationId를 커서로 보냅니다.",
+            "피드 알림은 feedId, 작품 완결·휴재 복귀 알림은 novelId가 이동 대상이며 나머지 이동 ID는 null입니다.",
+            "isLoadable이 false면 다음 페이지가 없습니다.",
+            "",
+            "Try it out으로 호출하려면 상단 Authorize에 실제 Access Token을 입력해야 합니다.",
+            "",
+            "이 API가 정의하는 응답은 다음과 같습니다.",
+            "",
+            "- 200 OK — 성공.",
+            "- 400 BAD_REQUEST — 커서가 음수이거나 size가 1 미만 또는 50 초과인 요청.",
+            errorLine(ACCESS_TOKEN_EXPIRED),
+            errorLine(INVALID_TOKEN),
+            errorLine(WRONG_TOKEN_TYPE),
+            errorLine(USER_NOT_FOUND));
+
+    private static final String DETAIL_DESCRIPTION = String.join("\n",
+            "공지·이벤트 알림의 상세 내용을 조회하고 해당 알림을 읽음 처리합니다.",
+            "피드 또는 작품 이동 알림은 상세 조회 대상이 아니며 NOTIFICATION-003을 반환합니다.",
+            "",
+            "이 API가 정의하는 응답은 다음과 같습니다.",
+            "",
+            "- 200 OK — 성공.",
+            "- 400 BAD_REQUEST — notificationId가 양수가 아닌 요청.",
+            errorLine(ACCESS_TOKEN_EXPIRED),
+            errorLine(INVALID_TOKEN),
+            errorLine(WRONG_TOKEN_TYPE),
+            errorLine(NOTIFICATION_TYPE_INVALID),
+            errorLine(NOTIFICATION_NOT_FOUND),
+            errorLine(USER_NOT_FOUND));
+
+    private static final String STATUS_DESCRIPTION = String.join("\n",
+            "사용자에게 읽지 않은 알림이 하나라도 있는지 조회합니다.",
+            "",
+            "이 API가 정의하는 응답은 다음과 같습니다.",
+            "",
+            "- 200 OK — 성공.",
+            errorLine(ACCESS_TOKEN_EXPIRED),
+            errorLine(INVALID_TOKEN),
+            errorLine(WRONG_TOKEN_TYPE),
+            errorLine(USER_NOT_FOUND));
+
+    private static final String READ_DESCRIPTION = String.join("\n",
+            "사용자에게 발송된 알림을 읽음 상태로 변경합니다.",
+            "이미 읽은 알림을 다시 요청해도 성공하는 멱등 API입니다.",
+            "",
+            "이 API가 정의하는 응답은 다음과 같습니다.",
+            "",
+            "- 204 No Content — 성공. (응답 본문이 없습니다.)",
+            "- 400 BAD_REQUEST — notificationId가 양수가 아닌 요청.",
+            errorLine(ACCESS_TOKEN_EXPIRED),
+            errorLine(INVALID_TOKEN),
+            errorLine(WRONG_TOKEN_TYPE),
+            errorLine(NOTIFICATION_READ_FORBIDDEN),
+            errorLine(NOTIFICATION_NOT_FOUND),
+            errorLine(USER_NOT_FOUND));
+
+    private static final String LEGACY_STATUS_DESCRIPTION = String.join("\n",
+            "Deprecated API입니다. 신규 구현에서는 GET /notifications/status를 사용합니다.",
+            "사용자에게 읽지 않은 알림이 하나라도 있는지 조회합니다.",
+            "",
+            "이 API가 정의하는 응답은 다음과 같습니다.",
+            "",
+            "- 200 OK — 성공.",
+            errorLine(INVALID_TOKEN));
+
+    private static final String LEGACY_READ_DESCRIPTION = String.join("\n",
+            "Deprecated API입니다. 신규 구현에서는 PATCH /notifications/{notificationId}/read-status를 사용합니다.",
+            "사용자에게 발송된 알림을 읽음 상태로 변경합니다.",
+            "신규 API와 달리 성공 시 201 Created를 반환합니다.",
+            "",
+            "이 API가 정의하는 응답은 다음과 같습니다.",
+            "",
+            "- 201 Created — 성공. (응답 본문이 없습니다.)",
+            errorLine(INVALID_TOKEN));
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private NotificationApplication notificationApplication;
+
+    @BeforeEach
+    void setUp() {
+        given(userService.getUserOrException(USER_ID)).willReturn(mock(User.class));
+    }
+
+    @DisplayName("피드와 작품 알림을 포함한 알림 목록 200 응답을 문서화한다")
+    @Test
+    void documentGetNotificationsSuccess() throws Exception {
+        given(notificationApplication.getNotifications(any(User.class), eq(0L), eq(10)))
+                .willReturn(notificationPageResponse());
+
+        mockMvc.perform(notificationsRequest().with(accessToken(USER_ID)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.isLoadable").value(true))
+                .andExpect(jsonPath("$.notifications[0].feedId").value(31L))
+                .andExpect(jsonPath("$.notifications[0].novelId").isEmpty())
+                .andExpect(jsonPath("$.notifications[1].feedId").isEmpty())
+                .andExpect(jsonPath("$.notifications[1].novelId").value(7L))
+                .andDo(document("notifications-get",
+                        resource(notificationList()
+                                .responseSchema(PAGE_RESPONSE_SCHEMA)
+                                .responseFields(notificationPageFields())
+                                .build())));
+    }
+
+    @DisplayName("목록 파라미터를 생략하면 첫 커서와 기본 조회 개수를 사용한다")
+    @Test
+    void getNotificationsWithDefaultParameters() throws Exception {
+        given(notificationApplication.getNotifications(any(User.class), isNull(), eq(10)))
+                .willReturn(new NotificationPageResponse(false, List.of()));
+
+        mockMvc.perform(get("/notifications").with(accessToken(USER_ID)))
+                .andExpect(status().isOk());
+
+        then(notificationApplication).should().getNotifications(any(User.class), isNull(), eq(10));
+    }
+
+    @DisplayName("음수 커서의 400 응답을 문서화한다")
+    @Test
+    void documentGetNotificationsWithNegativeCursor() throws Exception {
+        mockMvc.perform(get("/notifications")
+                        .queryParam("lastNotificationId", "-1")
+                        .queryParam("size", "10")
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andDo(document("notifications-get-cursor-negative",
+                        resource(notificationListError().build())));
+    }
+
+    @DisplayName("1 미만 조회 개수의 400 응답을 문서화한다")
+    @Test
+    void documentGetNotificationsWithTooSmallSize() throws Exception {
+        documentListValidationError("0", "notifications-get-size-too-small");
+    }
+
+    @DisplayName("50 초과 조회 개수의 400 응답을 문서화한다")
+    @Test
+    void documentGetNotificationsWithTooLargeSize() throws Exception {
+        documentListValidationError("51", "notifications-get-size-too-large");
+    }
+
+    @DisplayName("알림 목록 요청의 만료 토큰 401 응답을 문서화한다")
+    @Test
+    void documentGetNotificationsWithExpiredToken() throws Exception {
+        mockMvc.perform(notificationsRequest().with(expiredAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ACCESS_TOKEN_EXPIRED.getCode()))
+                .andDo(document("notifications-get-access-token-expired",
+                        resource(notificationListError().build())));
+    }
+
+    @DisplayName("알림 목록 요청의 변조 토큰 401 응답을 문서화한다")
+    @Test
+    void documentGetNotificationsWithInvalidToken() throws Exception {
+        mockMvc.perform(notificationsRequest().with(tamperedAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andDo(document("notifications-get-invalid-token",
+                        resource(notificationListError().build())));
+    }
+
+    @DisplayName("알림 목록 요청의 Refresh Token 401 응답을 문서화한다")
+    @Test
+    void documentGetNotificationsWithWrongTokenType() throws Exception {
+        mockMvc.perform(notificationsRequest().with(refreshToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(WRONG_TOKEN_TYPE.getCode()))
+                .andDo(document("notifications-get-wrong-token-type",
+                        resource(notificationListError().build())));
+    }
+
+    @DisplayName("공지 알림 상세 조회 200 응답을 문서화한다")
+    @Test
+    void documentGetNotificationDetailSuccess() throws Exception {
+        given(notificationApplication.getNotificationDetail(any(User.class), eq(NOTIFICATION_ID)))
+                .willReturn(new NotificationDetailResponse("서비스 점검 안내", "2026.08.22", "점검 상세 내용입니다."));
+
+        mockMvc.perform(notificationDetailRequest().with(accessToken(USER_ID)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.notificationTitle").value("서비스 점검 안내"))
+                .andExpect(jsonPath("$.notificationCreatedDate").value("2026.08.22"))
+                .andExpect(jsonPath("$.notificationDetail").value("점검 상세 내용입니다."))
+                .andDo(document("notification-detail-get",
+                        resource(notificationDetail()
+                                .responseSchema(DETAIL_RESPONSE_SCHEMA)
+                                .responseFields(notificationDetailFields())
+                                .build())));
+    }
+
+    @DisplayName("양수가 아닌 상세 알림 ID의 400 응답을 문서화한다")
+    @Test
+    void documentGetNotificationDetailWithNonPositiveId() throws Exception {
+        mockMvc.perform(get("/notifications/{notificationId}", 0L).with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andDo(document("notification-detail-get-id-not-positive",
+                        resource(notificationDetailError().build())));
+    }
+
+    @DisplayName("존재하지 않는 공지 알림의 404 응답을 문서화한다")
+    @Test
+    void documentGetNotificationDetailNotFound() throws Exception {
+        given(notificationApplication.getNotificationDetail(any(User.class), eq(NOTIFICATION_ID)))
+                .willThrow(new CustomNotificationException(NOTIFICATION_NOT_FOUND, "notification not found"));
+
+        documentDetailError(NOTIFICATION_NOT_FOUND, "notification-detail-get-not-found");
+    }
+
+    @DisplayName("공지 유형이 아닌 알림 상세 요청의 400 응답을 문서화한다")
+    @Test
+    void documentGetNotificationDetailWithInvalidType() throws Exception {
+        given(notificationApplication.getNotificationDetail(any(User.class), eq(NOTIFICATION_ID)))
+                .willThrow(new CustomNotificationException(NOTIFICATION_TYPE_INVALID, "invalid notification type"));
+
+        documentDetailError(NOTIFICATION_TYPE_INVALID, "notification-detail-get-type-invalid");
+    }
+
+    @DisplayName("공지 알림 상세 요청의 변조 토큰 401 응답을 문서화한다")
+    @Test
+    void documentGetNotificationDetailWithInvalidToken() throws Exception {
+        mockMvc.perform(notificationDetailRequest().with(tamperedAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andDo(document("notification-detail-get-invalid-token",
+                        resource(notificationDetailError().build())));
+    }
+
+    @DisplayName("읽지 않은 알림 상태 조회 200 응답을 문서화한다")
+    @Test
+    void documentGetNotificationStatusSuccess() throws Exception {
+        given(notificationApplication.getReadStatus(any(User.class)))
+                .willReturn(new NotificationReadStatusResponse(true));
+
+        mockMvc.perform(get("/notifications/status").with(accessToken(USER_ID)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.hasUnreadNotifications").value(true))
+                .andDo(document("notification-status-get",
+                        resource(notificationStatus()
+                                .responseSchema(STATUS_RESPONSE_SCHEMA)
+                                .responseFields(notificationStatusFields())
+                                .build())));
+    }
+
+    @DisplayName("알림 상태 요청의 변조 토큰 401 응답을 문서화한다")
+    @Test
+    void documentGetNotificationStatusWithInvalidToken() throws Exception {
+        mockMvc.perform(get("/notifications/status").with(tamperedAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andDo(document("notification-status-get-invalid-token",
+                        resource(notificationStatusError().build())));
+    }
+
+    @DisplayName("알림 상태 요청의 사용자가 없으면 404 응답을 문서화한다")
+    @Test
+    void documentGetNotificationStatusWithUnknownUser() throws Exception {
+        given(userService.getUserOrException(USER_ID))
+                .willThrow(new CustomUserException(USER_NOT_FOUND, "user not found"));
+
+        mockMvc.perform(get("/notifications/status").with(accessToken(USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(USER_NOT_FOUND.getCode()))
+                .andDo(document("notification-status-get-user-not-found",
+                        resource(notificationStatusError().build())));
+    }
+
+    @DisplayName("알림 읽음 처리 204 응답을 문서화한다")
+    @Test
+    void documentUpdateNotificationReadStatusSuccess() throws Exception {
+        mockMvc.perform(notificationReadRequest().with(accessToken(USER_ID)))
+                .andExpect(status().isNoContent())
+                .andExpect(content().string(""))
+                .andDo(document("notification-read-status-patch",
+                        resource(notificationRead().build())));
+    }
+
+    @DisplayName("양수가 아닌 읽음 처리 알림 ID의 400 응답을 문서화한다")
+    @Test
+    void documentUpdateNotificationReadStatusWithNonPositiveId() throws Exception {
+        mockMvc.perform(patch("/notifications/{notificationId}/read-status", 0L)
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andDo(document("notification-read-status-patch-id-not-positive",
+                        resource(notificationReadError().build())));
+    }
+
+    @DisplayName("존재하지 않는 알림 읽음 요청의 404 응답을 문서화한다")
+    @Test
+    void documentUpdateNotificationReadStatusNotFound() throws Exception {
+        willThrow(new CustomNotificationException(NOTIFICATION_NOT_FOUND, "notification not found"))
+                .given(notificationApplication)
+                .updateNotificationReadStatus(any(User.class), eq(NOTIFICATION_ID));
+
+        documentReadError(NOTIFICATION_NOT_FOUND, "notification-read-status-patch-not-found");
+    }
+
+    @DisplayName("다른 사용자의 알림 읽음 요청의 403 응답을 문서화한다")
+    @Test
+    void documentUpdateNotificationReadStatusForbidden() throws Exception {
+        willThrow(new CustomNotificationException(NOTIFICATION_READ_FORBIDDEN, "notification read forbidden"))
+                .given(notificationApplication)
+                .updateNotificationReadStatus(any(User.class), eq(NOTIFICATION_ID));
+
+        documentReadError(NOTIFICATION_READ_FORBIDDEN, "notification-read-status-patch-forbidden");
+    }
+
+    @DisplayName("알림 읽음 요청의 변조 토큰 401 응답을 문서화한다")
+    @Test
+    void documentUpdateNotificationReadStatusWithInvalidToken() throws Exception {
+        mockMvc.perform(notificationReadRequest().with(tamperedAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andDo(document("notification-read-status-patch-invalid-token",
+                        resource(notificationReadError().build())));
+    }
+
+    @DisplayName("기존 읽지 않은 알림 상태 조회 200 응답을 Deprecated API로 문서화한다")
+    @Test
+    void documentGetNotificationStatusDeprecatedSuccess() throws Exception {
+        given(notificationApplication.getReadStatus(any(User.class)))
+                .willReturn(new NotificationReadStatusResponse(true));
+
+        mockMvc.perform(get("/notifications/unread").with(accessToken(USER_ID)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("$.hasUnreadNotifications").value(true))
+                .andDo(document("notification-unread-get-deprecated",
+                        resource(notificationLegacyStatus()
+                                .responseSchema(STATUS_RESPONSE_SCHEMA)
+                                .responseFields(notificationStatusFields())
+                                .build())));
+    }
+
+    @DisplayName("기존 알림 상태 조회의 변조 토큰 401 응답을 문서화한다")
+    @Test
+    void documentGetNotificationStatusDeprecatedWithInvalidToken() throws Exception {
+        mockMvc.perform(get("/notifications/unread").with(tamperedAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andDo(document("notification-unread-get-deprecated-invalid-token",
+                        resource(notificationLegacyStatus()
+                                .responseSchema(ERROR_RESULT_SCHEMA)
+                                .responseFields(errorResultFields())
+                                .build())));
+    }
+
+    @DisplayName("기존 알림 읽음 처리 201 응답을 Deprecated API로 문서화한다")
+    @Test
+    void documentCreateNotificationAsReadDeprecatedSuccess() throws Exception {
+        mockMvc.perform(notificationLegacyReadRequest().with(accessToken(USER_ID)))
+                .andExpect(status().isCreated())
+                .andExpect(content().string(""))
+                .andDo(document("notification-read-post-deprecated",
+                        resource(notificationLegacyRead().build())));
+    }
+
+    @DisplayName("기존 알림 읽음 처리의 변조 토큰 401 응답을 문서화한다")
+    @Test
+    void documentCreateNotificationAsReadDeprecatedWithInvalidToken() throws Exception {
+        mockMvc.perform(notificationLegacyReadRequest().with(tamperedAccessToken(USER_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(INVALID_TOKEN.getCode()))
+                .andDo(document("notification-read-post-deprecated-invalid-token",
+                        resource(notificationLegacyRead()
+                                .responseSchema(ERROR_RESULT_SCHEMA)
+                                .responseFields(errorResultFields())
+                                .build())));
+    }
+
+    @DisplayName("유효한 토큰의 사용자가 없으면 404 응답을 문서화한다")
+    @Test
+    void documentUnknownUser() throws Exception {
+        given(userService.getUserOrException(USER_ID))
+                .willThrow(new CustomUserException(USER_NOT_FOUND, "user not found"));
+
+        mockMvc.perform(notificationsRequest().with(accessToken(USER_ID)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(USER_NOT_FOUND.getCode()))
+                .andDo(document("notifications-get-user-not-found",
+                        resource(notificationListError().build())));
+    }
+
+    private void documentListValidationError(String size, String identifier) throws Exception {
+        mockMvc.perform(get("/notifications")
+                        .queryParam("lastNotificationId", "0")
+                        .queryParam("size", size)
+                        .with(accessToken(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST.name()))
+                .andDo(document(identifier, resource(notificationListError().build())));
+    }
+
+    private void documentDetailError(ICustomError error, String identifier) throws Exception {
+        mockMvc.perform(notificationDetailRequest().with(accessToken(USER_ID)))
+                .andExpect(status().is(error.getStatusCode().value()))
+                .andExpect(jsonPath("$.code").value(error.getCode()))
+                .andExpect(jsonPath("$.message").value(error.getDescription()))
+                .andDo(document(identifier, resource(notificationDetailError().build())));
+    }
+
+    private void documentReadError(ICustomError error, String identifier) throws Exception {
+        mockMvc.perform(notificationReadRequest().with(accessToken(USER_ID)))
+                .andExpect(status().is(error.getStatusCode().value()))
+                .andExpect(jsonPath("$.code").value(error.getCode()))
+                .andExpect(jsonPath("$.message").value(error.getDescription()))
+                .andDo(document(identifier, resource(notificationReadError().build())));
+    }
+
+    private ResourceSnippetParametersBuilder notificationListError() {
+        return notificationList()
+                .responseSchema(ERROR_RESULT_SCHEMA)
+                .responseFields(errorResultFields());
+    }
+
+    private ResourceSnippetParametersBuilder notificationList() {
+        return ResourceSnippetParameters.builder()
+                .tag(TAG)
+                .summary("알림 목록 조회")
+                .description(LIST_DESCRIPTION)
+                .queryParameters(notificationQueryParameters());
+    }
+
+    private ResourceSnippetParametersBuilder notificationDetailError() {
+        return notificationDetail()
+                .responseSchema(ERROR_RESULT_SCHEMA)
+                .responseFields(errorResultFields());
+    }
+
+    private ResourceSnippetParametersBuilder notificationDetail() {
+        return ResourceSnippetParameters.builder()
+                .tag(TAG)
+                .summary("공지 알림 상세 조회")
+                .description(DETAIL_DESCRIPTION)
+                .pathParameters(notificationIdParameter("조회할 공지 알림 ID"));
+    }
+
+    private ResourceSnippetParametersBuilder notificationStatusError() {
+        return notificationStatus()
+                .responseSchema(ERROR_RESULT_SCHEMA)
+                .responseFields(errorResultFields());
+    }
+
+    private ResourceSnippetParametersBuilder notificationStatus() {
+        return ResourceSnippetParameters.builder()
+                .tag(TAG)
+                .summary("읽지 않은 알림 상태 조회")
+                .description(STATUS_DESCRIPTION);
+    }
+
+    private ResourceSnippetParametersBuilder notificationReadError() {
+        return notificationRead()
+                .responseSchema(ERROR_RESULT_SCHEMA)
+                .responseFields(errorResultFields());
+    }
+
+    private ResourceSnippetParametersBuilder notificationRead() {
+        return ResourceSnippetParameters.builder()
+                .tag(TAG)
+                .summary("알림 읽음 처리")
+                .description(READ_DESCRIPTION)
+                .pathParameters(notificationIdParameter("읽음 처리할 알림 ID"));
+    }
+
+    private ResourceSnippetParametersBuilder notificationLegacyStatus() {
+        return ResourceSnippetParameters.builder()
+                .tag(TAG)
+                .summary("[Deprecated] 읽지 않은 알림 상태 조회")
+                .description(LEGACY_STATUS_DESCRIPTION)
+                .deprecated(true);
+    }
+
+    private ResourceSnippetParametersBuilder notificationLegacyRead() {
+        return ResourceSnippetParameters.builder()
+                .tag(TAG)
+                .summary("[Deprecated] 알림 읽음 처리")
+                .description(LEGACY_READ_DESCRIPTION)
+                .pathParameters(notificationIdParameter("읽음 처리할 알림 ID"))
+                .deprecated(true);
+    }
+
+    private List<ParameterDescriptorWithType> notificationQueryParameters() {
+        return List.of(
+                parameterWithName("lastNotificationId").optional()
+                        .type(SimpleType.INTEGER)
+                        .defaultValue(0)
+                        .description("이전 페이지의 마지막 알림 ID. 첫 페이지는 생략하거나 0을 보낸다."),
+                parameterWithName("size").optional()
+                        .type(SimpleType.INTEGER)
+                        .defaultValue(10)
+                        .description("조회 개수. 1 이상 50 이하."));
+    }
+
+    private ParameterDescriptorWithType notificationIdParameter(String description) {
+        return parameterWithName("notificationId")
+                .type(SimpleType.INTEGER)
+                .description(description + ". 양수여야 한다.");
+    }
+
+    private List<FieldDescriptor> notificationPageFields() {
+        return List.of(
+                fieldWithPath("isLoadable").type(BOOLEAN).description("다음 페이지가 있는지 여부"),
+                fieldWithPath("notifications").type(ARRAY).description("최신순 알림 목록"),
+                fieldWithPath("notifications[].notificationId").type(NUMBER).description("알림 ID"),
+                fieldWithPath("notifications[].notificationImage").type(STRING).description("알림 유형 이미지 URL"),
+                fieldWithPath("notifications[].notificationTitle").type(STRING).description("알림 제목"),
+                fieldWithPath("notifications[].notificationBody").type(STRING).description("알림 본문"),
+                fieldWithPath("notifications[].createdDate").type(STRING)
+                        .description("알림 생성 시각. 24시간 이내는 상대 시간, 이후는 yyyy.MM.dd 형식."),
+                fieldWithPath("notifications[].isRead").type(BOOLEAN).description("읽음 여부"),
+                fieldWithPath("notifications[].isNotice").type(BOOLEAN).description("공지·이벤트 알림 여부"),
+                fieldWithPath("notifications[].feedId").type(NUMBER).optional()
+                        .description("피드 이동 대상 ID. 피드 알림이 아니면 null이다."),
+                fieldWithPath("notifications[].novelId").type(NUMBER).optional()
+                        .description("작품 이동 대상 ID. 완결·휴재 복귀 알림이 아니면 null이다."));
+    }
+
+    private List<FieldDescriptor> notificationDetailFields() {
+        return List.of(
+                fieldWithPath("notificationTitle").type(STRING).description("공지 알림 제목"),
+                fieldWithPath("notificationCreatedDate").type(STRING).description("공지 생성일. yyyy.MM.dd 형식."),
+                fieldWithPath("notificationDetail").type(STRING).description("공지 상세 내용"));
+    }
+
+    private List<FieldDescriptor> notificationStatusFields() {
+        return List.of(fieldWithPath("hasUnreadNotifications").type(BOOLEAN)
+                .description("읽지 않은 알림이 하나라도 있는지 여부"));
+    }
+
+    private NotificationPageResponse notificationPageResponse() {
+        return new NotificationPageResponse(true, List.of(
+                new NotificationItem(102L, "https://image.websoso.kr/notification/feed.png",
+                        "재혼 황후", "내 글에 댓글이 달렸어요.", "3분 전", false, false, 31L, null),
+                new NotificationItem(101L, "https://image.websoso.kr/notification/novel.png",
+                        "재혼 황후", "작품 연재가 재개되었어요.", "1시간 전", false, false, null, 7L),
+                new NotificationItem(100L, "https://image.websoso.kr/notification/notice.png",
+                        "서비스 점검 안내", "공지 내용을 확인해 주세요.", "2026.08.20", true, true, null, null)));
+    }
+
+    private MockHttpServletRequestBuilder notificationsRequest() {
+        return get("/notifications")
+                .queryParam("lastNotificationId", "0")
+                .queryParam("size", "10");
+    }
+
+    private MockHttpServletRequestBuilder notificationDetailRequest() {
+        return get("/notifications/{notificationId}", NOTIFICATION_ID);
+    }
+
+    private MockHttpServletRequestBuilder notificationReadRequest() {
+        return patch("/notifications/{notificationId}/read-status", NOTIFICATION_ID);
+    }
+
+    private MockHttpServletRequestBuilder notificationLegacyReadRequest() {
+        return post("/notifications/{notificationId}/read", NOTIFICATION_ID);
+    }
+}


### PR DESCRIPTION
## Related Issue
- feat/#612 -> dev
- close #612

## Key Changes
- `NotificationController` API 6개의 애플리케이션 계층 요청 위임과 HTTP 응답을 단위 테스트로 검증했습니다.
- 알림 목록 조회, 공지 알림 상세 조회, 읽지 않은 알림 상태 조회, 알림 읽음 처리 API를 REST Docs로 문서화했습니다.
- Deprecated API인 `GET /notifications/unread`, `POST /notifications/{notificationId}/read`도 대체 API 안내와 함께 문서화하고 OpenAPI에 `deprecated: true`로 표시했습니다.
- 목록 성공 예시에 피드·완결·휴재 복귀·공지 알림을 함께 구성해 `feedId`와 `novelId`의 nullable 이동 계약을 OpenAPI 스키마에 반영했습니다.
- 커서·조회 개수·알림 ID 검증 오류와 운영·Deprecated API별 인증 3종, 사용자 없음, 알림 없음, 알림 유형·읽기 권한 오류 응답을 문서화했습니다.
- 공지 상세의 nullable 본문과 기본값이 없는 목록 커서를 실제 컨트롤러 계약에 맞게 명세에 반영했습니다.
- 로케일에 따라 달라질 수 있는 Bean Validation 메시지는 클라이언트가 `code`로 분기하도록 Swagger에 안내했습니다.

## Test
- `./gradlew test --tests org.websoso.WSSServer.notification.controller.NotificationControllerTest --tests org.websoso.WSSServer.notification.controller.notification.NotificationDocsTest`
- `./gradlew apiDocs`

두 명령 모두 로컬에서 성공했습니다. 생성된 `build/api-spec/openapi3.json`에서 6개 경로, Deprecated 표시, 작품 알림 예시, nullable 스키마, 전체 오류 응답 named example을 확인했습니다.

## To Reviewers
- 기존 읽음 처리 API는 `201 Created`, 신규 API는 `204 No Content`를 반환하는 차이를 각각 문서에 유지했습니다.
- Deprecated `POST /notifications/{notificationId}/read`에는 `@Positive` 검증이 없어 경로 파라미터에 양수 제약을 표기하지 않았습니다.
- OpenAPI 산출물은 기존 정책대로 `build/` 아래에서 생성하며 커밋하지 않습니다.

## References
- 작품 알림 도입 작업: #559
- REST Docs 기반 OpenAPI 환경 구축: #584
- API 문서 테스트 공통 기반: #585